### PR TITLE
a few more fixes to prevent errors - especially modify a provider (by…

### DIFF
--- a/flutterui/lib/main.dart
+++ b/flutterui/lib/main.dart
@@ -115,11 +115,7 @@ class MyApp extends ConsumerWidget {
             pageWidget = const AuthCallbackScreen();
             break;
           case '/threads':
-            bool isFromAgentChat = false;
-            if (settings.arguments is Map<String, dynamic>) {
-              isFromAgentChat = (settings.arguments as Map<String, dynamic>)['isFromAgentChat'] ?? false;
-            }
-            pageWidget = ThreadsScreen(isFromAgentChat: isFromAgentChat);
+            pageWidget = const ThreadsScreen();
             break;
           case CreateAgentScreen.routeName:
             pageWidget = const CreateAgentScreen();

--- a/flutterui/lib/presentation/screens/threads/logic/threads_controller.dart
+++ b/flutterui/lib/presentation/screens/threads/logic/threads_controller.dart
@@ -18,6 +18,7 @@ class ThreadsController {
 
   void initializeThreads() {
     // Always refresh threads when the screen is shown to get latest data
+    // Already using addPostFrameCallback which is safe
     WidgetsBinding.instance.addPostFrameCallback((_) {
       refreshThreads();
     });

--- a/flutterui/lib/presentation/screens/threads/threads_screen.dart
+++ b/flutterui/lib/presentation/screens/threads/threads_screen.dart
@@ -33,7 +33,8 @@ class _ThreadsScreenState extends ConsumerState<ThreadsScreen> with ErrorHandlin
   void didChangeDependencies() {
     super.didChangeDependencies();
     // Refresh threads whenever we navigate to this screen
-    _controller.refreshThreads();
+    // Use Future to avoid modifying provider during build
+    Future.microtask(() => _controller.refreshThreads());
   }
 
   void _showCreateThreadDialog() {


### PR DESCRIPTION
… calling refreshThreads()) during the widget build lifecycle