### PR TITLE
Bondable Log Files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ creds
 
 # iOS Firebase configuration (deployment-specific)
 flutterui/ios/Runner/GoogleService-Info.plist
+
+# Logs
+logs/

--- a/bondable/rest/logging_config.yaml
+++ b/bondable/rest/logging_config.yaml
@@ -9,45 +9,59 @@ handlers:
     default:
         class: logging.StreamHandler
         formatter: default
+    debug_file_handler:
+        class: logging.handlers.TimedRotatingFileHandler
+        filename: "logs/bondable_debug.log"
+        when: "midnight"
+        interval: 1
+        backupCount: 7
+        formatter: default
+        level: DEBUG
+        encoding: "utf-8"
 
 root:
     level: INFO
     handlers: [default]
 
 loggers:
+    bondable:
+        level: DEBUG
+        handlers: [default, debug_file_handler]
+        propagate: false
+
     uvicorn:
         level: INFO
-        handlers: [default]
+        handlers: [default, debug_file_handler]
         propagate: false
 
     uvicorn.error:
         level: INFO
-        handlers: [default]
+        handlers: [default, debug_file_handler]
         propagate: false
 
     uvicorn.access:
         level: WARNING
-        handlers: [default]
+        handlers: [default, debug_file_handler]
         propagate: false
 
     # Suppress HTTP request logs from httpx
     httpx:
         level: ERROR
-        handlers: [default]
+        handlers: [default, debug_file_handler]
         propagate: false
 
     # Suppress MCP client logs
     mcp:
         level: ERROR
-        handlers: [default]
+        handlers: [default, debug_file_handler]
         propagate: false
 
     mcp.client:
         level: ERROR
-        handlers: [default]
+        handlers: [default, debug_file_handler]
         propagate: false
 
     mcp.client.streamable_http:
         level: ERROR
-        handlers: [default]
+        handlers: [default, debug_file_handler]
         propagate: false

--- a/bondable/rest/main.py
+++ b/bondable/rest/main.py
@@ -14,8 +14,14 @@ from bondable.rest.routers import auth, agents, threads, chat, files, mcp, group
 # Configure logging from YAML file
 def setup_logging():
     """Load logging configuration from YAML file"""
+
+    project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    logs_dir = os.path.join(project_root, "logs")
+
+    if not os.path.exists(logs_dir):
+        os.makedirs(logs_dir)
+
     config_path = os.path.join(os.path.dirname(__file__), "logging_config.yaml")
-    
     if os.path.exists(config_path):
         with open(config_path, 'r') as f:
             config = yaml.safe_load(f)


### PR DESCRIPTION
Add a new file handler for our bondable logging. Logs sent to the default handler (console) will be unchanged only report INFO and higher logs. Logs sent to the log file will contain debug information for debugging purposes.