### PR TITLE
feat: refactor BedrockAgentProvider to update agent options more effi…

### DIFF
--- a/bondable/bond/providers/bedrock/BedrockAgent.py
+++ b/bondable/bond/providers/bedrock/BedrockAgent.py
@@ -816,14 +816,12 @@ class BedrockAgentProvider(AgentProvider):
                 )
                 session.add(bedrock_options)
             else:
-                bedrock_agent_id, bedrock_agent_alias_id = update_bedrock_agent(
-                    agent_id=agent_id,
-                    agent_def=agent_def
-                )
                 bedrock_options = session.query(BedrockAgentOptions).filter_by(agent_id=agent_id).first()
                 if bedrock_options:
-                    bedrock_options.bedrock_agent_id=bedrock_agent_id
-                    bedrock_options.bedrock_agent_alias_id=bedrock_agent_alias_id
+                    bedrock_agent_id = bedrock_options.bedrock_agent_id
+                    bedrock_agent_alias_id = bedrock_options.bedrock_agent_alias_id
+
+                    # Update existing options
                     bedrock_options.temperature = agent_def.temperature or DEFAULT_TEMPERATURE
                     bedrock_options.tools = agent_def.tools or {}
                     bedrock_options.tool_resources = agent_def.tool_resources or {}
@@ -833,6 +831,12 @@ class BedrockAgentProvider(AgentProvider):
                 else: 
                     raise ValueError(f"Bedrock options for agent {agent_id} not found in database")
                 
+                bedrock_agent_id, bedrock_agent_alias_id = update_bedrock_agent(
+                    agent_def=agent_def,
+                    bedrock_agent_id=bedrock_agent_id,
+                    bedrock_agent_alias_id=bedrock_agent_alias_id
+                )
+
             session.commit()  
             
             bedrock_agent = BedrockAgent(


### PR DESCRIPTION
This pull request refactors the `create_or_update_agent_resource` method in `bondable/bond/providers/bedrock/BedrockAgent.py` to streamline how Bedrock agent resources are updated. The changes focus on improving the logic for updating agent options and ensuring consistency in handling agent IDs.

Refactoring of agent update logic:

* [`bondable/bond/providers/bedrock/BedrockAgent.py`](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bL819-R824): Removed the assignment of `bedrock_agent_id` and `bedrock_agent_alias_id` directly within the `else` block. Instead, these values are now retrieved from existing `BedrockAgentOptions` and passed to the `update_bedrock_agent` function later in the method. This ensures that updates to agent options occur after verifying their existence in the database.

* [`bondable/bond/providers/bedrock/BedrockAgent.py`](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bR834-R839): Moved the call to `update_bedrock_agent` to a later point in the method, after confirming the presence of `BedrockAgentOptions`. This improves the flow of the method and ensures that updates are applied correctly.…ciently