### PR TITLE
feat: add Terraform IAM policy scripts for user permissions management

### DIFF
--- a/deployment/policies/add-terraform-policy.sh
+++ b/deployment/policies/add-terraform-policy.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Script to add Terraform permissions to bond-bedrock-user
+# Run this with an account that has IAM permissions
+
+USER_NAME="bond-bedrock-user"
+POLICY_NAME="TerraformInfrastructurePolicy"
+
+echo "Adding Terraform infrastructure policy to user: $USER_NAME"
+
+aws iam put-user-policy \
+  --user-name $USER_NAME \
+  --policy-name $POLICY_NAME \
+  --policy-document file://iam-policy-for-terraform.json
+
+if [ $? -eq 0 ]; then
+  echo "✅ Policy added successfully!"
+  echo "You can now run: terraform apply -var-file=environments/minimal.tfvars"
+else
+  echo "❌ Failed to add policy. You may need to:"
+  echo "1. Log into AWS Console with root/admin account"
+  echo "2. Manually add the policy from iam-policy-for-terraform.json"
+fi

--- a/deployment/policies/terraform-admin-policy.json
+++ b/deployment/policies/terraform-admin-policy.json
@@ -1,0 +1,44 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:*",
+        "ec2:*",
+        "vpc:*",
+        "rds:*",
+        "s3:*",
+        "secretsmanager:*",
+        "ecr:*",
+        "apprunner:*",
+        "logs:*",
+        "sts:AssumeRole",
+        "sts:GetCallerIdentity",
+        "elasticloadbalancing:*",
+        "autoscaling:*",
+        "cloudwatch:*",
+        "kms:*",
+        "tag:*",
+        "resource-groups:*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "iam:CreateServiceLinkedRole"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "iam:AWSServiceName": [
+            "apprunner.amazonaws.com",
+            "rds.amazonaws.com",
+            "elasticloadbalancing.amazonaws.com"
+          ]
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This pull request introduces new scripts and IAM policy files to streamline the process of granting Terraform permissions to the `bond-bedrock-user` in AWS. The changes make it easier to automate the assignment of necessary permissions for infrastructure management via Terraform.

**Terraform user policy automation:**

* Added `add-terraform-policy.sh` script to automate attaching a Terraform permissions policy to the `bond-bedrock-user`, including instructions for manual remediation if the script fails. (`deployment/policies/add-terraform-policy.sh`)

**Terraform permissions policy definition:**

* Added `terraform-admin-policy.json`, defining an AWS IAM policy that grants broad permissions needed for Terraform operations, including access to IAM, EC2, VPC, RDS, S3, Secrets Manager, ECR, App Runner, CloudWatch, KMS, and more. It also includes permissions for creating service-linked roles for specific AWS services. (`deployment/policies/terraform-admin-policy.json`)