### PR TITLE
Vpc deploy fixes

### DIFF
--- a/deployment/Dockerfile.backend
+++ b/deployment/Dockerfile.backend
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM public.ecr.aws/docker/library/python:3.12-slim
 
 WORKDIR /app
 

--- a/deployment/Dockerfile.frontend
+++ b/deployment/Dockerfile.frontend
@@ -1,7 +1,7 @@
 # Dockerfile for pre-built Flutter web application
 # This expects the Flutter web app to be built locally and provided in the build context
 
-FROM nginx:alpine
+FROM public.ecr.aws/nginx/nginx:alpine
 
 # Copy pre-built Flutter web app
 # The build context should contain the built web files

--- a/deployment/terraform-existing-vpc/backend.tf
+++ b/deployment/terraform-existing-vpc/backend.tf
@@ -77,8 +77,8 @@ resource "aws_apprunner_service" "backend" {
   }
 
   instance_configuration {
-    cpu               = "0.25 vCPU"
-    memory            = "0.5 GB"
+    cpu               = "0.5 vCPU"
+    memory            = "1 GB"
     instance_role_arn = aws_iam_role.app_runner_instance.arn
   }
 

--- a/deployment/terraform-existing-vpc/security.tf
+++ b/deployment/terraform-existing-vpc/security.tf
@@ -67,3 +67,36 @@ resource "aws_security_group_rule" "app_runner_to_rds" {
   security_group_id        = aws_security_group.app_runner.id
   description              = "Allow App Runner to access RDS"
 }
+
+# Security Group for VPC Interface Endpoints
+resource "aws_security_group" "vpc_endpoints" {
+  name_prefix = "${var.project_name}-${var.environment}-vpc-endpoints-"
+  description = "Security group for VPC interface endpoints"
+  vpc_id      = data.aws_vpc.existing.id
+
+  # Allow HTTPS traffic from App Runner security group
+  ingress {
+    from_port       = 443
+    to_port         = 443
+    protocol        = "tcp"
+    security_groups = [aws_security_group.app_runner.id]
+    description     = "HTTPS from App Runner"
+  }
+
+  # Allow all outbound
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+    description = "Allow all outbound"
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-vpc-endpoints-sg"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/deployment/terraform-existing-vpc/vpc-endpoints.tf
+++ b/deployment/terraform-existing-vpc/vpc-endpoints.tf
@@ -1,0 +1,55 @@
+# VPC Endpoints for AWS services
+
+# VPC Endpoint for S3 (Gateway type - FREE, no security groups needed)
+resource "aws_vpc_endpoint" "s3" {
+  vpc_id            = data.aws_vpc.existing.id
+  service_name      = "com.amazonaws.${var.aws_region}.s3"
+  vpc_endpoint_type = "Gateway"
+  route_table_ids   = concat(data.aws_route_tables.private.ids, [data.aws_route_table.main.id])
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-s3-endpoint"
+  }
+}
+
+# VPC Endpoint for Secrets Manager (Interface type)
+resource "aws_vpc_endpoint" "secretsmanager" {
+  vpc_id              = data.aws_vpc.existing.id
+  service_name        = "com.amazonaws.${var.aws_region}.secretsmanager"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = local.vpc_endpoint_subnet_ids  # Use subnets in different AZs
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-secretsmanager-endpoint"
+  }
+}
+
+# VPC Endpoint for Bedrock (Interface type)
+resource "aws_vpc_endpoint" "bedrock" {
+  vpc_id              = data.aws_vpc.existing.id
+  service_name        = "com.amazonaws.${var.aws_region}.bedrock-runtime"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = local.vpc_endpoint_subnet_ids  # Use subnets in different AZs
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = true
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-bedrock-endpoint"
+  }
+}
+
+# VPC Endpoint for CloudWatch Logs (Interface type)
+resource "aws_vpc_endpoint" "logs" {
+  vpc_id              = data.aws_vpc.existing.id
+  service_name        = "com.amazonaws.${var.aws_region}.logs"
+  vpc_endpoint_type   = "Interface"
+  subnet_ids          = local.vpc_endpoint_subnet_ids  # Use subnets in different AZs
+  security_group_ids  = [aws_security_group.vpc_endpoints.id]
+  private_dns_enabled = false  # Disabled due to existing conflicting DNS domain
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-logs-endpoint"
+  }
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the deployment infrastructure, focusing on enhanced security, reliability, and AWS best practices for networking and resource management. The main changes include switching Docker base images to public ECR sources, optimizing resource allocation for the backend, and implementing VPC endpoints for secure and efficient access to AWS services. Additionally, subnet selection logic is refined for better control, and new security groups are introduced for VPC interface endpoints.

**Docker image sources updated:**

* Switched Docker base images for both `backend` and `frontend` from official Docker Hub sources to public ECR repositories (`public.ecr.aws`). This improves reliability and aligns with AWS best practices for image sourcing. (`deployment/Dockerfile.backend` [[1]](diffhunk://#diff-bfd175fda010ab00ec69cf8c1b41bfd040a2cd3d1e041083eea77ce72e4d657bL1-R1) `deployment/Dockerfile.frontend` [[2]](diffhunk://#diff-edb1e591802abb25a26754899076e0bb8d2ba2d1a6c8f99b29b998bbfe663e6bL4-R4)

**Backend resource allocation:**

* Increased App Runner backend instance resources, doubling CPU to `0.5 vCPU` and memory to `1 GB` for better performance and scalability. (`deployment/terraform-existing-vpc/backend.tf` [deployment/terraform-existing-vpc/backend.tfL80-R81](diffhunk://#diff-2578149b4fb87c353487d0a39749cd437ae7715094bfc3c8a79a7c6fbd8fb160L80-R81))

**VPC endpoints and networking enhancements:**

* Added new Terraform resources to create VPC endpoints for S3 (gateway), Secrets Manager, Bedrock, and CloudWatch Logs (interface endpoints). This allows secure, private connectivity to AWS services without traversing the public internet. (`deployment/terraform-existing-vpc/vpc-endpoints.tf` [deployment/terraform-existing-vpc/vpc-endpoints.tfR1-R55](diffhunk://#diff-57def32164eafa3792ac32f326afba6e8fe075b8bb04cf95ab5736539429e3ccR1-R55))
* Implemented logic to select specific subnets for App Runner and VPC endpoints, limiting the number for control and ensuring endpoints are distributed across different availability zones. (`deployment/terraform-existing-vpc/data-sources.tf` [deployment/terraform-existing-vpc/data-sources.tfL36-R63](diffhunk://#diff-2e80d19c01df0ba18fa6e07a48fe08ba75be4ccfe1b4105198901ab56f7bbf4eL36-R63))
* Added data sources for route tables to support VPC endpoint configuration, including selection of private and main route tables. (`deployment/terraform-existing-vpc/data-sources.tf` [deployment/terraform-existing-vpc/data-sources.tfR26-R45](diffhunk://#diff-2e80d19c01df0ba18fa6e07a48fe08ba75be4ccfe1b4105198901ab56f7bbf4eR26-R45))

**Security group improvements:**

* Created a dedicated security group for VPC interface endpoints, allowing HTTPS ingress from the App Runner security group and all outbound traffic, with lifecycle management for safe updates. (`deployment/terraform-existing-vpc/security.tf` [deployment/terraform-existing-vpc/security.tfR70-R102](diffhunk://#diff-2bf4287c7a954d73fb408bf019a0eb59ef1de4fd1b4058cb02e90a9a28c9f770R70-R102))