### PR TITLE
Vpc okta fix

### DIFF
--- a/deployment/terraform-existing-vpc/vpc-endpoints.tf
+++ b/deployment/terraform-existing-vpc/vpc-endpoints.tf
@@ -12,44 +12,44 @@ resource "aws_vpc_endpoint" "s3" {
   }
 }
 
-# VPC Endpoint for Secrets Manager (Interface type)
-resource "aws_vpc_endpoint" "secretsmanager" {
-  vpc_id              = data.aws_vpc.existing.id
-  service_name        = "com.amazonaws.${var.aws_region}.secretsmanager"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = local.vpc_endpoint_subnet_ids  # Use subnets in different AZs
-  security_group_ids  = [aws_security_group.vpc_endpoints.id]
-  private_dns_enabled = true
+# # VPC Endpoint for Secrets Manager (Interface type)
+# resource "aws_vpc_endpoint" "secretsmanager" {
+#   vpc_id              = data.aws_vpc.existing.id
+#   service_name        = "com.amazonaws.${var.aws_region}.secretsmanager"
+#   vpc_endpoint_type   = "Interface"
+#   subnet_ids          = local.vpc_endpoint_subnet_ids  # Use subnets in different AZs
+#   security_group_ids  = [aws_security_group.vpc_endpoints.id]
+#   private_dns_enabled = true
 
-  tags = {
-    Name = "${var.project_name}-${var.environment}-secretsmanager-endpoint"
-  }
-}
+#   tags = {
+#     Name = "${var.project_name}-${var.environment}-secretsmanager-endpoint"
+#   }
+# }
 
-# VPC Endpoint for Bedrock (Interface type)
-resource "aws_vpc_endpoint" "bedrock" {
-  vpc_id              = data.aws_vpc.existing.id
-  service_name        = "com.amazonaws.${var.aws_region}.bedrock-runtime"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = local.vpc_endpoint_subnet_ids  # Use subnets in different AZs
-  security_group_ids  = [aws_security_group.vpc_endpoints.id]
-  private_dns_enabled = true
+# # VPC Endpoint for Bedrock (Interface type)
+# resource "aws_vpc_endpoint" "bedrock" {
+#   vpc_id              = data.aws_vpc.existing.id
+#   service_name        = "com.amazonaws.${var.aws_region}.bedrock-runtime"
+#   vpc_endpoint_type   = "Interface"
+#   subnet_ids          = local.vpc_endpoint_subnet_ids  # Use subnets in different AZs
+#   security_group_ids  = [aws_security_group.vpc_endpoints.id]
+#   private_dns_enabled = true
 
-  tags = {
-    Name = "${var.project_name}-${var.environment}-bedrock-endpoint"
-  }
-}
+#   tags = {
+#     Name = "${var.project_name}-${var.environment}-bedrock-endpoint"
+#   }
+# }
 
-# VPC Endpoint for CloudWatch Logs (Interface type)
-resource "aws_vpc_endpoint" "logs" {
-  vpc_id              = data.aws_vpc.existing.id
-  service_name        = "com.amazonaws.${var.aws_region}.logs"
-  vpc_endpoint_type   = "Interface"
-  subnet_ids          = local.vpc_endpoint_subnet_ids  # Use subnets in different AZs
-  security_group_ids  = [aws_security_group.vpc_endpoints.id]
-  private_dns_enabled = false  # Disabled due to existing conflicting DNS domain
+# # VPC Endpoint for CloudWatch Logs (Interface type)
+# resource "aws_vpc_endpoint" "logs" {
+#   vpc_id              = data.aws_vpc.existing.id
+#   service_name        = "com.amazonaws.${var.aws_region}.logs"
+#   vpc_endpoint_type   = "Interface"
+#   subnet_ids          = local.vpc_endpoint_subnet_ids  # Use subnets in different AZs
+#   security_group_ids  = [aws_security_group.vpc_endpoints.id]
+#   private_dns_enabled = false  # Disabled due to existing conflicting DNS domain
 
-  tags = {
-    Name = "${var.project_name}-${var.environment}-logs-endpoint"
-  }
-}
+#   tags = {
+#     Name = "${var.project_name}-${var.environment}-logs-endpoint"
+#   }
+# }


### PR DESCRIPTION
This pull request introduces two main changes: it comments out the Terraform resources for several AWS VPC interface endpoints (Secrets Manager, Bedrock, and CloudWatch Logs), and it adds a new section to the VPC test script to check permissions and capabilities for custom domains and Route 53 integration. These changes help clarify which VPC endpoints are currently being provisioned and improve diagnostics for custom domain support in your AWS environment.

Key changes:

**Terraform Infrastructure Updates:**
* Commented out the creation of the `aws_vpc_endpoint` resources for Secrets Manager, Bedrock, and CloudWatch Logs in `vpc-endpoints.tf`, so these endpoints will no longer be provisioned by default.

**Testing and Diagnostics Enhancements:**
* Added a new "Custom Domain Permission Tests" section to `test-vpc-availability.sh` that:
  * Checks App Runner custom domain permissions and provides warnings if IAM permissions are missing.
  * Verifies Route 53 access, lists hosted zones, and checks the ability to read record sets, with clear warnings if permissions are insufficient.
  * Tests ACM (certificate manager) permissions, noting that App Runner can still provision certificates automatically if listing is not allowed.
  * Summarizes overall custom domain capability, indicating whether automatic or manual DNS configuration is needed and which IAM permissions may be missing.