### PR TITLE
feat: add Everyone group for global agent sharing

### DIFF
--- a/bondable/bond/providers/agent.py
+++ b/bondable/bond/providers/agent.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from bondable.bond.definition import AgentDefinition
 from bondable.bond.broker import Broker
-from bondable.bond.providers.metadata import Metadata, AgentRecord, AgentGroup, GroupUser, VectorStore
+from bondable.bond.providers.metadata import Metadata, AgentRecord, AgentGroup, GroupUser, VectorStore, EVERYONE_GROUP_ID
 from sqlalchemy import case, func
 from typing import List, Dict, Optional, Generator
 import logging
@@ -460,19 +460,22 @@ class AgentProvider(ABC):
                     ).label('max_permission_rank')
                 )
                 .join(AgentGroup, AgentRecord.agent_id == AgentGroup.agent_id)
-                .join(GroupUser, AgentGroup.group_id == GroupUser.group_id)
-                .filter(GroupUser.user_id == user_id)
+                .outerjoin(GroupUser, AgentGroup.group_id == GroupUser.group_id)
+                .filter(
+                    (GroupUser.user_id == user_id) | (AgentGroup.group_id == EVERYONE_GROUP_ID)
+                )
             )
             if exclude_ids:
                 shared_query = shared_query.filter(~AgentRecord.agent_id.in_(exclude_ids))
             shared_query = shared_query.group_by(AgentRecord.agent_id).all()
 
+            rank_to_permission = {2: "can_edit", 1: "can_use", 0: "can_use_read_only"}
             shared_agent_records = [
                 {
                     "name": agent.name,
                     "agent_id": agent.agent_id,
                     "owned": False,
-                    "permission": "can_edit" if max_rank == 2 else "can_use"
+                    "permission": rank_to_permission.get(max_rank, "can_use")
                 }
                 for agent, max_rank in shared_query
             ]
@@ -502,8 +505,8 @@ class AgentProvider(ABC):
 
     def can_user_access_agent(self, user_id: str, agent_id: str) -> bool:
         """
-        Validates if a user can access a given agent. The user can either be the owner of the agent
-        or the agent could have been shared with the user via a group.
+        Validates if a user can access a given agent. The user can either be the owner of the agent,
+        the agent could have been shared with the user via a group, or the agent is in the Everyone group.
         """
         with self.metadata.get_db_session() as session:
             access_query = (
@@ -512,7 +515,8 @@ class AgentProvider(ABC):
                 .outerjoin(GroupUser, AgentGroup.group_id == GroupUser.group_id)
                 .filter(
                     (AgentRecord.owner_user_id == user_id) |
-                    (GroupUser.user_id == user_id),
+                    (GroupUser.user_id == user_id) |
+                    (AgentGroup.group_id == EVERYONE_GROUP_ID),
                     AgentRecord.agent_id == agent_id
                 )
                 .exists()
@@ -535,13 +539,13 @@ class AgentProvider(ABC):
             if agent_record.owner_user_id == user_id:
                 return 'owner'
 
-            # Check shared access via groups
+            # Check shared access via groups (including the Everyone group)
             shared_permissions = (
                 session.query(AgentGroup.permission)
-                .join(GroupUser, AgentGroup.group_id == GroupUser.group_id)
+                .outerjoin(GroupUser, AgentGroup.group_id == GroupUser.group_id)
                 .filter(
                     AgentGroup.agent_id == agent_id,
-                    GroupUser.user_id == user_id
+                    (GroupUser.user_id == user_id) | (AgentGroup.group_id == EVERYONE_GROUP_ID)
                 )
                 .all()
             )

--- a/bondable/bond/providers/metadata.py
+++ b/bondable/bond/providers/metadata.py
@@ -11,6 +11,11 @@ from typing import List, Dict, Any, Optional, Tuple
 
 LOGGER = logging.getLogger(__name__)
 
+# Well-known group ID for the "Everyone" group.
+# Agents associated with this group are accessible to all authenticated users
+# without requiring explicit group_users membership rows.
+EVERYONE_GROUP_ID = "grp_everyone"
+
 
 # These are the default ORM classes
 # All instances of Metadata should use these classes and augment them as needed
@@ -264,6 +269,7 @@ class Metadata(ABC):
         self.engine = create_engine(self.metadata_db_url, echo=False)
         self.create_all()
         self.session = scoped_session(sessionmaker(bind=self.engine))
+        self._ensure_everyone_group()
         LOGGER.info(f"Created Metadata instance using database engine: {self.metadata_db_url}")
 
     def get_engine(self):
@@ -339,11 +345,45 @@ class Metadata(ABC):
                 conn.commit()
             LOGGER.info("Migration: Added last_agent_id column to threads table")
 
+    def _ensure_everyone_group(self):
+        """Create the well-known 'Everyone' group if it doesn't already exist."""
+        session = scoped_session(sessionmaker(bind=self.engine))()
+        try:
+            existing = session.query(Group).filter(Group.id == EVERYONE_GROUP_ID).first()
+            if not existing:
+                system_user = session.query(User).filter(User.email == "system@bondableai.com").first()
+                if not system_user:
+                    import uuid
+                    system_user = User(
+                        id=str(uuid.uuid4()),
+                        email="system@bondableai.com",
+                        name="System",
+                        sign_in_method="system"
+                    )
+                    session.add(system_user)
+                    session.flush()
+
+                everyone_group = Group(
+                    id=EVERYONE_GROUP_ID,
+                    name="Everyone",
+                    description="Agents in this group are accessible to all users",
+                    owner_user_id=system_user.id
+                )
+                session.add(everyone_group)
+                session.commit()
+                LOGGER.info(f"Created 'Everyone' group with id: {EVERYONE_GROUP_ID}")
+        except Exception as e:
+            session.rollback()
+            LOGGER.warning(f"Everyone group could not be created; agents assigned to it will not be globally visible until this is resolved: {e}")
+        finally:
+            session.close()
+
     def drop_and_recreate_all(self):
         """Drop all tables and recreate them. Use with caution - this deletes all data!"""
         LOGGER.warning("Dropping all tables and recreating schema. All data will be lost!")
         Base.metadata.drop_all(self.engine)
         Base.metadata.create_all(self.engine)
+        self._ensure_everyone_group()
         LOGGER.info("Schema recreated successfully")
 
     def get_db_session(self) -> scoped_session:

--- a/bondable/rest/routers/agents.py
+++ b/bondable/rest/routers/agents.py
@@ -14,6 +14,7 @@ from bondable.rest.models.agents import (
 from bondable.rest.dependencies.auth import get_current_user
 from bondable.rest.dependencies.providers import get_bond_provider
 from bondable.rest.routers.files import _to_opaque_id, _resolve_file_id
+from bondable.bond.providers.metadata import EVERYONE_GROUP_ID
 
 router = APIRouter(prefix="/agents", tags=["Agent"])
 LOGGER = logging.getLogger(__name__)
@@ -382,6 +383,7 @@ async def update_agent(
                 # Look up default_group_id from agent record to preserve it
                 updated_agent_record = provider.agents.get_agent_record(agent_instance.get_agent_id())
                 preserve_ids = [updated_agent_record.default_group_id] if updated_agent_record and updated_agent_record.default_group_id else []
+                preserve_ids.append(EVERYONE_GROUP_ID)
 
                 provider.groups.sync_agent_groups(
                     agent_id=agent_instance.get_agent_id(),

--- a/tests/test_agent_sharing.py
+++ b/tests/test_agent_sharing.py
@@ -29,6 +29,7 @@ from bondable.bond.providers.files import FilesProvider, FileDetails
 from bondable.bond.providers.vectorstores import VectorStoresProvider
 from bondable.bond.groups import Groups
 from bondable.bond.definition import AgentDefinition
+from bondable.bond.providers.metadata import EVERYONE_GROUP_ID
 
 # Test configuration
 jwt_config = Config.config().get_jwt_config()
@@ -357,11 +358,11 @@ class TestUpdateAgentPreservesDefaultGroup:
         )
 
         assert response.status_code == 200
-        # Verify sync_agent_groups was called with the default group in preserve_group_ids
+        # Verify sync_agent_groups was called with the default group + Everyone group in preserve_group_ids
         provider.groups.sync_agent_groups.assert_called_once_with(
             agent_id=agent_id,
             desired_group_ids=[additional_group_id],
-            preserve_group_ids=[default_group_id],
+            preserve_group_ids=[default_group_id, EVERYONE_GROUP_ID],
             group_permissions=None
         )
 
@@ -409,7 +410,7 @@ class TestUpdateAgentPreservesDefaultGroup:
         provider.groups.sync_agent_groups.assert_called_once_with(
             agent_id=agent_id,
             desired_group_ids=[additional_group_id],
-            preserve_group_ids=[default_group_id],
+            preserve_group_ids=[default_group_id, EVERYONE_GROUP_ID],
             group_permissions=None
         )
 
@@ -442,11 +443,11 @@ class TestUpdateAgentPreservesDefaultGroup:
         )
 
         assert response.status_code == 200
-        # preserve_group_ids should be empty when default_group_id is None
+        # preserve_group_ids should only contain Everyone group when default_group_id is None
         provider.groups.sync_agent_groups.assert_called_once_with(
             agent_id=agent_id,
             desired_group_ids=["grp_some_group"],
-            preserve_group_ids=[],
+            preserve_group_ids=[EVERYONE_GROUP_ID],
             group_permissions=None
         )
 

--- a/tests/test_everyone_group.py
+++ b/tests/test_everyone_group.py
@@ -1,0 +1,278 @@
+"""
+Integration tests for the 'Everyone' group feature.
+
+Verifies that agents associated with the well-known Everyone group (grp_everyone)
+are accessible to all authenticated users without explicit group_users membership.
+"""
+import pytest
+import os
+import tempfile
+
+# --- Test Database Setup ---
+_test_db_file = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+TEST_DB_URL = f"sqlite:///{_test_db_file.name}"
+os.environ['METADATA_DB_URL'] = TEST_DB_URL
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, scoped_session
+from bondable.bond.providers.metadata import (
+    Base, User, Group, AgentRecord, AgentGroup, GroupUser,
+    EVERYONE_GROUP_ID,
+)
+
+USER_A = "everyone-test-user-a"
+USER_B = "everyone-test-user-b"
+SYSTEM_USER = "everyone-test-system"
+AGENT_PUBLIC = "agent_public_001"
+AGENT_PRIVATE = "agent_private_002"
+AGENT_BOTH = "agent_both_003"
+
+
+class FakeMetadata:
+    """Minimal Metadata-like object with a real SQLite DB."""
+    def __init__(self, db_url):
+        self.engine = create_engine(db_url, echo=False)
+        Base.metadata.create_all(self.engine)
+        self._session_factory = scoped_session(sessionmaker(bind=self.engine))
+
+    def get_db_session(self):
+        return self._session_factory()
+
+
+class FakeAgentProvider:
+    """
+    Minimal AgentProvider that exposes only the three access-control methods
+    under test, using real SQL queries against a test database.
+    """
+    def __init__(self, metadata):
+        self.metadata = metadata
+
+    # Import the real implementations by delegation
+    from bondable.bond.providers.agent import AgentProvider as _AP
+    can_user_access_agent = _AP.can_user_access_agent
+    get_agent_records = _AP.get_agent_records
+    get_user_agent_permission = _AP.get_user_agent_permission
+
+
+@pytest.fixture(scope="module")
+def db():
+    metadata = FakeMetadata(TEST_DB_URL)
+    session = metadata.get_db_session()
+
+    # Seed users (unique emails to avoid conflicts when running with other test files)
+    for uid, email in [
+        (SYSTEM_USER, "everyone-test-system@test.com"),
+        (USER_A, "everyone-test-a@test.com"),
+        (USER_B, "everyone-test-b@test.com"),
+    ]:
+        if not session.query(User).filter(User.id == uid).first():
+            session.add(User(id=uid, email=email, sign_in_method="test"))
+
+    # Seed Everyone group
+    if not session.query(Group).filter(Group.id == EVERYONE_GROUP_ID).first():
+        session.add(Group(
+            id=EVERYONE_GROUP_ID,
+            name="Everyone",
+            description="Agents in this group are accessible to all users",
+            owner_user_id=SYSTEM_USER,
+        ))
+
+    # Seed a private group for USER_A only
+    private_group_id = "grp_private_test"
+    if not session.query(Group).filter(Group.id == private_group_id).first():
+        session.add(Group(id=private_group_id, name="Private Group", owner_user_id=USER_A))
+        session.flush()
+        session.add(GroupUser(group_id=private_group_id, user_id=USER_A))
+
+    session.commit()
+    session.close()
+    return metadata
+
+
+@pytest.fixture(scope="module")
+def provider(db):
+    return FakeAgentProvider(db)
+
+
+@pytest.fixture(autouse=True)
+def clear_agents(db):
+    """Clear agent-related tables before each test."""
+    session = db.get_db_session()
+    session.query(AgentGroup).delete()
+    session.query(AgentRecord).delete()
+    session.commit()
+    session.close()
+
+
+@pytest.fixture(scope="module", autouse=True)
+def cleanup_db():
+    yield
+    db_path = TEST_DB_URL.replace("sqlite:///", "")
+    if os.path.exists(db_path):
+        try:
+            os.remove(db_path)
+        except Exception:
+            pass
+
+
+def _create_agent(db, agent_id, name, owner_user_id):
+    session = db.get_db_session()
+    session.add(AgentRecord(
+        agent_id=agent_id, name=name, owner_user_id=owner_user_id
+    ))
+    session.commit()
+    session.close()
+
+
+def _add_agent_to_group(db, agent_id, group_id, permission="can_use"):
+    session = db.get_db_session()
+    session.add(AgentGroup(agent_id=agent_id, group_id=group_id, permission=permission))
+    session.commit()
+    session.close()
+
+
+class TestCanUserAccessAgent:
+    """Test can_user_access_agent with Everyone group."""
+
+    def test_everyone_group_grants_access(self, db, provider):
+        """User NOT in any group can access agent in Everyone group."""
+        _create_agent(db, AGENT_PUBLIC, "Public Agent", SYSTEM_USER)
+        _add_agent_to_group(db, AGENT_PUBLIC, EVERYONE_GROUP_ID)
+
+        # USER_B has no group membership at all
+        assert provider.can_user_access_agent(USER_B, AGENT_PUBLIC) is True
+
+    def test_private_agent_not_accessible_without_group(self, db, provider):
+        """Agent NOT in Everyone group is inaccessible to non-members."""
+        _create_agent(db, AGENT_PRIVATE, "Private Agent", SYSTEM_USER)
+        _add_agent_to_group(db, AGENT_PRIVATE, "grp_private_test")
+
+        # USER_B is not in the private group
+        assert provider.can_user_access_agent(USER_B, AGENT_PRIVATE) is False
+
+    def test_owner_still_has_access(self, db, provider):
+        """Agent owner can access agent regardless of Everyone group."""
+        _create_agent(db, AGENT_PRIVATE, "My Agent", USER_A)
+        assert provider.can_user_access_agent(USER_A, AGENT_PRIVATE) is True
+
+
+class TestGetAgentRecords:
+    """Test get_agent_records includes Everyone group agents."""
+
+    def test_everyone_agent_appears_in_list(self, db, provider):
+        """Agent in Everyone group appears in any user's agent list."""
+        _create_agent(db, AGENT_PUBLIC, "Public Agent", SYSTEM_USER)
+        _add_agent_to_group(db, AGENT_PUBLIC, EVERYONE_GROUP_ID)
+
+        records = provider.get_agent_records(USER_B)
+        agent_ids = [r["agent_id"] for r in records]
+        assert AGENT_PUBLIC in agent_ids
+
+    def test_everyone_agent_has_correct_permission(self, db, provider):
+        """Everyone group agent shows with the permission from agent_groups."""
+        _create_agent(db, AGENT_PUBLIC, "Public Agent", SYSTEM_USER)
+        _add_agent_to_group(db, AGENT_PUBLIC, EVERYONE_GROUP_ID, permission="can_use")
+
+        records = provider.get_agent_records(USER_B)
+        public_record = next(r for r in records if r["agent_id"] == AGENT_PUBLIC)
+        assert public_record["permission"] == "can_use"
+        assert public_record["owned"] is False
+
+    def test_private_agent_not_in_list_for_non_member(self, db, provider):
+        """Agent NOT in Everyone group does not appear for non-members."""
+        _create_agent(db, AGENT_PRIVATE, "Private Agent", SYSTEM_USER)
+        _add_agent_to_group(db, AGENT_PRIVATE, "grp_private_test")
+
+        records = provider.get_agent_records(USER_B)
+        agent_ids = [r["agent_id"] for r in records]
+        assert AGENT_PRIVATE not in agent_ids
+
+
+class TestGetUserAgentPermission:
+    """Test get_user_agent_permission with Everyone group."""
+
+    def test_everyone_group_permission(self, db, provider):
+        """User gets permission from Everyone group's agent_groups row."""
+        _create_agent(db, AGENT_PUBLIC, "Public Agent", SYSTEM_USER)
+        _add_agent_to_group(db, AGENT_PUBLIC, EVERYONE_GROUP_ID, permission="can_use")
+
+        perm = provider.get_user_agent_permission(USER_B, AGENT_PUBLIC)
+        assert perm == "can_use"
+
+    def test_no_permission_without_everyone_or_group(self, db, provider):
+        """User gets None for agent they have no access to."""
+        _create_agent(db, AGENT_PRIVATE, "Private Agent", SYSTEM_USER)
+        # No group association at all
+
+        perm = provider.get_user_agent_permission(USER_B, AGENT_PRIVATE)
+        assert perm is None
+
+    def test_permission_stacking_highest_wins(self, db, provider):
+        """User in can_edit group + Everyone (can_use) gets can_edit."""
+        _create_agent(db, AGENT_BOTH, "Both Agent", SYSTEM_USER)
+        _add_agent_to_group(db, AGENT_BOTH, EVERYONE_GROUP_ID, permission="can_use")
+        _add_agent_to_group(db, AGENT_BOTH, "grp_private_test", permission="can_edit")
+
+        # USER_A is in grp_private_test with can_edit, plus Everyone with can_use
+        perm = provider.get_user_agent_permission(USER_A, AGENT_BOTH)
+        assert perm == "can_edit"
+
+    def test_owner_permission_takes_precedence(self, db, provider):
+        """Owner gets 'owner' even if agent is in Everyone group."""
+        _create_agent(db, AGENT_PUBLIC, "Public Agent", USER_A)
+        _add_agent_to_group(db, AGENT_PUBLIC, EVERYONE_GROUP_ID)
+
+        perm = provider.get_user_agent_permission(USER_A, AGENT_PUBLIC)
+        assert perm == "owner"
+
+
+class TestSyncPreservesEveryoneGroup:
+    """Test that sync_agent_groups preserves the Everyone group."""
+
+    def test_sync_does_not_remove_everyone_group(self, db):
+        """sync_agent_groups with preserve should keep Everyone group."""
+        from bondable.bond.groups import Groups
+        groups = Groups(db)
+
+        _create_agent(db, AGENT_PUBLIC, "Public Agent", SYSTEM_USER)
+        _add_agent_to_group(db, AGENT_PUBLIC, EVERYONE_GROUP_ID)
+
+        # Sync with empty desired list, but preserve Everyone group
+        groups.sync_agent_groups(
+            agent_id=AGENT_PUBLIC,
+            desired_group_ids=[],
+            preserve_group_ids=[EVERYONE_GROUP_ID],
+        )
+
+        # Verify Everyone group association still exists
+        session = db.get_db_session()
+        remaining = session.query(AgentGroup).filter(
+            AgentGroup.agent_id == AGENT_PUBLIC,
+            AgentGroup.group_id == EVERYONE_GROUP_ID,
+        ).first()
+        session.close()
+        assert remaining is not None
+
+
+class TestEnsureEveryoneGroupAutoCreation:
+    """Test that the Everyone group is auto-created on Metadata init."""
+
+    def test_everyone_group_exists_after_init(self):
+        """_ensure_everyone_group creates the group if missing."""
+        # Use a fresh temp DB
+        fresh_db_file = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+        fresh_db_url = f"sqlite:///{fresh_db_file.name}"
+
+        try:
+            from bondable.bond.providers.bedrock.BedrockMetadata import BedrockMetadata
+            metadata = BedrockMetadata(fresh_db_url)
+
+            session = metadata.get_db_session()
+            group = session.query(Group).filter(Group.id == EVERYONE_GROUP_ID).first()
+            assert group is not None
+            assert group.name == "Everyone"
+            session.close()
+            metadata.close()
+        finally:
+            if os.path.exists(fresh_db_file.name):
+                os.remove(fresh_db_file.name)


### PR DESCRIPTION
## Summary
- Introduces a well-known "Everyone" group (`grp_everyone`) that makes agents accessible to all authenticated users without requiring explicit `group_users` membership rows
- The group is auto-created on startup and preserved during UI-driven agent updates
- To make an agent globally available, just `INSERT INTO agent_groups (agent_id, group_id, permission) VALUES ('<agent_id>', 'grp_everyone', 'can_use')`

## Changes
- **`metadata.py`** — `EVERYONE_GROUP_ID` constant + `_ensure_everyone_group()` auto-creation on init and `drop_and_recreate_all`
- **`agent.py`** — Modified `can_user_access_agent`, `get_agent_records`, `get_user_agent_permission` to treat Everyone group as implicitly containing all users
- **`agents.py` router** — Everyone group preserved in `sync_agent_groups` preserve list
- **`test_everyone_group.py`** — 12 new integration tests covering access, listing, permissions, stacking, sync preservation, and auto-creation

## Test plan
- [x] 12 new integration tests pass (real SQLite DB, not mocks)
- [x] 3 existing `test_agent_sharing.py` assertions updated and passing
- [x] All 49 tests pass when run together (cross-file isolation verified)
- [ ] Manual verification: add agent to Everyone group via SQL, confirm visible to other users

🤖 Generated with [Claude Code](https://claude.com/claude-code)