### PR TITLE
perf: fix event loop blocking for concurrent requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,6 @@ hello_world/
 vpn/
 
 deployment/eks-hello-world/
+
+# Concurrency investigation tests (temporary, not for CI)
+tests/investigation/

--- a/bondable/bond/providers/bedrock/BedrockAgent.py
+++ b/bondable/bond/providers/bedrock/BedrockAgent.py
@@ -82,7 +82,6 @@ MIN_RECORDS_FOR_CSV = 5
 MAX_INVOKE_RETRIES = 2
 INVOKE_RETRY_BASE_DELAY = 1.0  # seconds; exponential backoff (1s, 2s)
 
-
 class BedrockAgent(Agent):
     """Bedrock implementation of the Agent interface"""
 
@@ -2807,6 +2806,7 @@ Remember: Return ONLY the icon name that exists in the above list, and a valid h
                 bedrock_agent_id = agent.bedrock_agent_id
                 bedrock_agent_alias_id = agent.bedrock_agent_alias_id
 
+
             # Delete from metadata
             session = self.metadata.get_db_session()
             try:
@@ -2887,6 +2887,7 @@ Remember: Return ONLY the icon name that exists in the above list, and a valid h
                     agent_def=agent_def,
                     owner_user_id=owner_user_id
                 )
+
                 bedrock_options = BedrockAgentOptions(
                     agent_id=agent_id,
                     bedrock_agent_id=bedrock_agent_id,
@@ -2993,6 +2994,7 @@ Remember: Return ONLY the icon name that exists in the above list, and a valid h
                     bedrock_agent_alias_id=bedrock_agent_alias_id,
                     owner_user_id=owner_user_id
                 )
+
 
             session.commit()
 

--- a/bondable/bond/providers/metadata.py
+++ b/bondable/bond/providers/metadata.py
@@ -267,7 +267,15 @@ class Metadata(ABC):
 
     def __init__(self, metadata_db_url):
         self.metadata_db_url = metadata_db_url
-        self.engine = create_engine(self.metadata_db_url, echo=False)
+        engine_kwargs = {"echo": False}
+        if not metadata_db_url.startswith("sqlite"):
+            engine_kwargs.update({
+                "pool_size": 20,
+                "max_overflow": 10,
+                "pool_pre_ping": True,
+                "pool_recycle": 3600,
+            })
+        self.engine = create_engine(self.metadata_db_url, **engine_kwargs)
         self.create_all()
         self.session = scoped_session(sessionmaker(bind=self.engine))
         self._ensure_everyone_group()

--- a/bondable/rest/routers/agents.py
+++ b/bondable/rest/routers/agents.py
@@ -74,7 +74,7 @@ def _process_tool_resources(request_data, provider: Provider, user_id: str) -> d
 
 
 @router.get("", response_model=List[AgentRef])
-async def get_agents(
+def get_agents(
     current_user: Annotated[User, Depends(get_current_user)],
     provider: Provider = Depends(get_bond_provider)
 ):
@@ -118,7 +118,7 @@ async def get_agents(
 
 
 @router.get("/models", response_model=List[ModelInfo])
-async def get_available_models(
+def get_available_models(
     current_user: Annotated[User, Depends(get_current_user)],
     provider: Provider = Depends(get_bond_provider)
 ):
@@ -132,7 +132,7 @@ async def get_available_models(
 
 
 @router.get("/default", response_model=AgentResponse)
-async def get_default_agent(
+def get_default_agent(
     current_user: Annotated[User, Depends(get_current_user)],
     provider: Provider = Depends(get_bond_provider)
 ):
@@ -158,7 +158,7 @@ async def get_default_agent(
 
 
 @router.get("/available-groups", response_model=List[dict])
-async def get_available_groups_for_agent(
+def get_available_groups_for_agent(
     current_user: Annotated[User, Depends(get_current_user)],
     provider: Provider = Depends(get_bond_provider),
     agent_id: str = None  # Optional - for editing existing agents
@@ -176,7 +176,7 @@ async def get_available_groups_for_agent(
 
 
 @router.post("", response_model=AgentResponse, status_code=status.HTTP_201_CREATED)
-async def create_agent(
+def create_agent(
     request_data: AgentCreateRequest,
     current_user: Annotated[User, Depends(get_current_user)],
     provider: Provider = Depends(get_bond_provider)
@@ -280,7 +280,7 @@ async def create_agent(
 
 
 @router.put("/{agent_id}", response_model=AgentResponse)
-async def update_agent(
+def update_agent(
     agent_id: str,
     request_data: AgentUpdateRequest,
     current_user: Annotated[User, Depends(get_current_user)],
@@ -423,7 +423,7 @@ async def update_agent(
 
 
 @router.get("/{agent_id}", response_model=AgentDetailResponse)
-async def get_agent_details(
+def get_agent_details(
     agent_id: str,
     current_user: Annotated[User, Depends(get_current_user)],
     provider: Provider = Depends(get_bond_provider)
@@ -513,7 +513,7 @@ async def get_agent_details(
 
 
 @router.delete("/{agent_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_agent(
+def delete_agent(
     agent_id: str,
     current_user: Annotated[User, Depends(get_current_user)],
     provider: Provider = Depends(get_bond_provider)

--- a/bondable/rest/routers/chat.py
+++ b/bondable/rest/routers/chat.py
@@ -100,7 +100,7 @@ def _build_system_message(thread_id, agent_id, text):
 
 
 @router.post("")
-async def chat(
+def chat(
     request_body: ChatRequest,
     user_and_token: Annotated[tuple[User, str], Depends(get_current_user_with_token)],
     provider: Provider = Depends(get_bond_provider)

--- a/bondable/rest/routers/threads.py
+++ b/bondable/rest/routers/threads.py
@@ -24,7 +24,7 @@ def _resolve_agent_name(provider: Provider, agent_id: str) -> Optional[str]:
 
 
 @router.get("", response_model=PaginatedThreadsResponse)
-async def get_threads(
+def get_threads(
     current_user: Annotated[User, Depends(get_current_user)],
     provider: Provider = Depends(get_bond_provider),
     offset: int = 0,
@@ -76,7 +76,7 @@ async def get_threads(
 
 
 @router.post("", response_model=ThreadRef, status_code=status.HTTP_201_CREATED)
-async def create_thread(
+def create_thread(
     request_body: CreateThreadRequest,
     current_user: Annotated[User, Depends(get_current_user)],
     provider: Provider = Depends(get_bond_provider)
@@ -100,7 +100,7 @@ async def create_thread(
 
 
 @router.post("/cleanup", status_code=status.HTTP_200_OK)
-async def cleanup_empty_threads(
+def cleanup_empty_threads(
     current_user: Annotated[User, Depends(get_current_user)],
     provider: Provider = Depends(get_bond_provider)
 ):
@@ -115,7 +115,7 @@ async def cleanup_empty_threads(
 
 
 @router.delete("/{thread_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_thread(
+def delete_thread(
     thread_id: str,
     current_user: Annotated[User, Depends(get_current_user)],
     provider: Provider = Depends(get_bond_provider)
@@ -139,7 +139,7 @@ async def delete_thread(
 
 
 @router.put("/{thread_id}", response_model=ThreadRef)
-async def update_thread(
+def update_thread(
     thread_id: str,
     request_body: UpdateThreadRequest,
     current_user: Annotated[User, Depends(get_current_user)],
@@ -184,7 +184,7 @@ async def update_thread(
 
 
 @router.get("/{thread_id}/messages", response_model=List[MessageRef])
-async def get_messages(
+def get_messages(
     thread_id: str,
     current_user: Annotated[User, Depends(get_current_user)],
     provider: Provider = Depends(get_bond_provider),
@@ -272,7 +272,7 @@ async def get_messages(
 
 
 @router.put("/{thread_id}/messages/{message_id}/feedback", response_model=MessageFeedbackResponse)
-async def update_message_feedback(
+def update_message_feedback(
     thread_id: str,
     message_id: str,
     request: MessageFeedbackRequest,
@@ -318,7 +318,7 @@ async def update_message_feedback(
 
 
 @router.delete("/{thread_id}/messages/{message_id}/feedback", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_message_feedback(
+def delete_message_feedback(
     thread_id: str,
     message_id: str,
     current_user: Annotated[User, Depends(get_current_user)],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ build-backend = "poetry.core.masonry.api"
 markers = [
     "integration: marks tests that require a running backend (deselected by default, run with --integration)",
     "docker: marks tests that require Docker daemon (deselected by default, run with --docker)",
+    "investigation: marks concurrency investigation tests (deselected by default, run with --investigation)",
 ]
 
 [tool.bandit]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,12 @@ def pytest_addoption(parser):
         default=False,
         help="Run Docker-based tests (requires Docker daemon)",
     )
+    parser.addoption(
+        "--investigation",
+        action="store_true",
+        default=False,
+        help="Run concurrency investigation tests",
+    )
 
 
 def pytest_collection_modifyitems(config, items):
@@ -28,3 +34,9 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "docker" in item.keywords:
                 item.add_marker(skip_docker)
+
+    if not config.getoption("--investigation"):
+        skip_investigation = pytest.mark.skip(reason="needs --investigation flag to run")
+        for item in items:
+            if "investigation" in item.keywords:
+                item.add_marker(skip_investigation)


### PR DESCRIPTION
## Summary

- Convert FastAPI route handlers from `async def` to `def` in chat, agents, and threads routers so Starlette runs them in a threadpool instead of blocking the event loop
- Add explicit PostgreSQL connection pool configuration (pool_size=20, max_overflow=10, pool_pre_ping=True)
- Add investigation test marker and gitignore for temporary concurrency diagnostic tests

## Problem

All FastAPI route handlers were declared as `async def` but called synchronous code (boto3 Bedrock API calls, SQLAlchemy DB queries). This blocked the asyncio event loop, serializing all concurrent requests through a single thread.

Key bottlenecks identified:
- **Chat handler**: ~500-700ms of sync Bedrock API calls per request serialized on the event loop. At n=10 concurrent requests, the last request waited 5.5s just for setup
- **Agent creation**: `create_bedrock_agent()` uses `time.sleep(2)` × 30 polling loops, blocking the event loop for 10-60s and starving all other requests
- **DB pool**: No explicit configuration, relying on SQLAlchemy defaults

## Fix

Starlette handles `def` (sync) and `async def` handlers differently:
- `async def` → runs directly on the event loop (blocks if sync code is called)
- `def` → automatically wrapped in `run_in_threadpool` (non-blocking)

Changing handlers from `async def` to `def` moves all synchronous work off the event loop into Starlette's threadpool (anyio, capacity=40), allowing concurrent requests to run in parallel.

## Measured Results

| Metric | Before | After | Improvement |
|--------|--------|-------|-------------|
| Chat TTFB n=1 | 889ms | 747ms | 1.2x |
| Chat TTFB n=5 | 2,824ms | 697ms | **4x** |
| Chat TTFB n=10 | 5,538ms | 695ms | **8x** |
| Chat TTFB during agent creation | 11,762ms | 5,305ms | **2.2x** |

## Test plan

- [x] 1,167 backend unit tests passed (0 failures)
- [x] 127 Flutter tests passed (0 failures)
- [x] 318 integration tests passed (5 pre-existing failures, verified identical on main)
- [x] Investigation load tests confirm flat TTFB scaling across concurrency levels
- [x] No `await` expressions in any converted handler (verified via AST parse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)