### PR TITLE
fix: add pre-Alembic column fixups for existing databases

### DIFF
--- a/bondable/bond/providers/metadata.py
+++ b/bondable/bond/providers/metadata.py
@@ -313,10 +313,13 @@ class Metadata(ABC):
         has_alembic_version = 'alembic_version' in existing_tables
         has_app_tables = 'users' in existing_tables
 
-        if has_app_tables and not has_alembic_version:
-            # Existing database without Alembic — apply any missing columns
-            # from pre-Alembic manual migrations, then stamp as current
+        if has_app_tables:
+            # Existing database — ensure columns from old manual migrations
+            # are present (idempotent, safe to run every time)
             self._apply_pre_alembic_fixups(inspector)
+
+        if has_app_tables and not has_alembic_version:
+            # Existing database without Alembic — stamp as current
             LOGGER.info("Existing database detected without alembic_version. Stamping as head.")
             command.stamp(alembic_cfg, "head")
         else:

--- a/bondable/bond/providers/metadata.py
+++ b/bondable/bond/providers/metadata.py
@@ -298,9 +298,10 @@ class Metadata(ABC):
     def _run_migrations(self):
         """Run Alembic migrations programmatically.
 
-        For existing databases without alembic_version table, stamps the current
-        revision as head without executing DDL. For fresh databases, runs all
-        migrations to create the schema.
+        For existing databases without alembic_version table, brings the schema
+        up to date with any columns added by previous manual migrations, then
+        stamps as head. For fresh databases, runs all migrations to create the
+        schema.
         """
         from alembic import command
         from sqlalchemy import inspect
@@ -313,13 +314,62 @@ class Metadata(ABC):
         has_app_tables = 'users' in existing_tables
 
         if has_app_tables and not has_alembic_version:
-            # Existing database without Alembic — stamp as current
+            # Existing database without Alembic — apply any missing columns
+            # from pre-Alembic manual migrations, then stamp as current
+            self._apply_pre_alembic_fixups(inspector)
             LOGGER.info("Existing database detected without alembic_version. Stamping as head.")
             command.stamp(alembic_cfg, "head")
         else:
             # Fresh database or already Alembic-managed — run upgrade
             LOGGER.info("Running Alembic migrations...")
             command.upgrade(alembic_cfg, "head")
+
+    def _apply_pre_alembic_fixups(self, inspector):
+        """Ensure columns added by old manual _migrate_* methods exist.
+
+        These columns were added incrementally over time before Alembic was
+        adopted. If an existing database was created from an older version,
+        it may be missing some of them. This runs once before the initial
+        stamp to bring the schema up to the baseline.
+        """
+        # Check agents table columns
+        if 'agents' in [t for t in inspector.get_table_names()]:
+            agent_cols = {col['name'] for col in inspector.get_columns('agents')}
+
+            if 'default_group_id' not in agent_cols:
+                with self.engine.connect() as conn:
+                    conn.execute(text(
+                        "ALTER TABLE agents ADD COLUMN default_group_id VARCHAR REFERENCES groups(id)"
+                    ))
+                    conn.commit()
+                LOGGER.info("Pre-Alembic fixup: Added default_group_id column to agents table")
+
+            if 'slug' not in agent_cols:
+                with self.engine.connect() as conn:
+                    conn.execute(text("ALTER TABLE agents ADD COLUMN slug VARCHAR"))
+                    conn.commit()
+                LOGGER.info("Pre-Alembic fixup: Added slug column to agents table")
+                try:
+                    with self.engine.connect() as conn:
+                        conn.execute(text(
+                            "CREATE UNIQUE INDEX IF NOT EXISTS ix_agents_slug ON agents (slug)"
+                        ))
+                        conn.commit()
+                    LOGGER.info("Pre-Alembic fixup: Created unique index on agents.slug")
+                except Exception as e:
+                    LOGGER.warning(f"Could not create unique index on slug (may already exist): {e}")
+
+        # Check threads table columns
+        if 'threads' in [t for t in inspector.get_table_names()]:
+            thread_cols = {col['name'] for col in inspector.get_columns('threads')}
+
+            if 'last_agent_id' not in thread_cols:
+                with self.engine.connect() as conn:
+                    conn.execute(text(
+                        "ALTER TABLE threads ADD COLUMN last_agent_id VARCHAR"
+                    ))
+                    conn.commit()
+                LOGGER.info("Pre-Alembic fixup: Added last_agent_id column to threads table")
 
     def create_all(self):
         """Create all tables directly from SQLAlchemy models.

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -12,6 +12,7 @@ import os
 import tempfile
 
 import pytest
+import sqlalchemy as sa
 from sqlalchemy import create_engine, inspect
 from sqlalchemy.orm import sessionmaker, scoped_session
 
@@ -322,6 +323,65 @@ class TestMetadataInit:
             assert 'alembic_version' in tables
 
             # Verify it's at head
+            rev = _get_current_rev(metadata.engine)
+            assert rev is not None
+
+            metadata.close()
+        finally:
+            if os.path.exists(path):
+                os.unlink(path)
+
+    def test_init_existing_db_missing_columns(self):
+        """Metadata.__init__() should add missing columns before stamping."""
+        fd, path = tempfile.mkstemp(suffix='.db')
+        os.close(fd)
+        os.unlink(path)
+        db_url = f"sqlite:///{path}"
+
+        try:
+            # Create an older schema missing slug, default_group_id, last_agent_id
+            engine = create_engine(db_url)
+            with engine.connect() as conn:
+                conn.execute(sa.text(
+                    "CREATE TABLE users (id VARCHAR PRIMARY KEY, email VARCHAR NOT NULL, "
+                    "sign_in_method VARCHAR NOT NULL, name VARCHAR, is_admin BOOLEAN NOT NULL DEFAULT 0, "
+                    "created_at DATETIME, updated_at DATETIME)"
+                ))
+                conn.execute(sa.text(
+                    "CREATE TABLE groups (id VARCHAR PRIMARY KEY, name VARCHAR NOT NULL, "
+                    "description VARCHAR, owner_user_id VARCHAR REFERENCES users(id), "
+                    "created_at DATETIME, updated_at DATETIME)"
+                ))
+                conn.execute(sa.text(
+                    "CREATE TABLE agents (agent_id VARCHAR PRIMARY KEY, name VARCHAR NOT NULL, "
+                    "introduction VARCHAR, reminder VARCHAR, "
+                    "owner_user_id VARCHAR REFERENCES users(id) NOT NULL, "
+                    "is_default BOOLEAN NOT NULL DEFAULT 0, created_at DATETIME)"
+                ))
+                conn.execute(sa.text(
+                    "CREATE TABLE threads (thread_id VARCHAR NOT NULL, "
+                    "user_id VARCHAR NOT NULL REFERENCES users(id), "
+                    "name VARCHAR, session_id VARCHAR, "
+                    "created_at DATETIME, updated_at DATETIME, "
+                    "PRIMARY KEY (thread_id, user_id))"
+                ))
+                conn.commit()
+            engine.dispose()
+
+            # Init Metadata — should detect missing columns, add them, and stamp
+            from bondable.bond.providers.bedrock.BedrockMetadata import BedrockMetadata
+            metadata = BedrockMetadata(db_url)
+
+            # Verify missing columns were added
+            insp = inspect(metadata.engine)
+            agent_cols = {col['name'] for col in insp.get_columns('agents')}
+            assert 'slug' in agent_cols, "slug column should have been added"
+            assert 'default_group_id' in agent_cols, "default_group_id column should have been added"
+
+            thread_cols = {col['name'] for col in insp.get_columns('threads')}
+            assert 'last_agent_id' in thread_cols, "last_agent_id column should have been added"
+
+            # Verify it was stamped at head
             rev = _get_current_rev(metadata.engine)
             assert rev is not None
 


### PR DESCRIPTION
## Summary
- Fixes `UndefinedColumn: column agents.slug does not exist` on Aurora databases that were created before the slug column migration
- Before stamping an existing database as Alembic-managed, checks for and adds any columns that were previously added by the old manual `_migrate_*` methods (`slug`, `default_group_id`, `last_agent_id`)

## Root cause
The initial Alembic integration (#176) stamps existing databases at head without verifying the schema is complete. Databases created before the slug/default_group_id/last_agent_id columns were introduced are missing those columns but get stamped as current.

## Test plan
- [x] New test `test_init_existing_db_missing_columns` verifies columns are added before stamp
- [x] All 12 Alembic tests pass
- [x] Full test suite passes (1178 passed, 0 failed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)