### PR TITLE
feat: user-defined MCP server configuration

### DIFF
--- a/bondable/bond/alembic/versions/a3f1c8d92b4e_add_user_mcp_servers.py
+++ b/bondable/bond/alembic/versions/a3f1c8d92b4e_add_user_mcp_servers.py
@@ -1,0 +1,45 @@
+"""add_user_mcp_servers
+
+Revision ID: a3f1c8d92b4e
+Revises: 2731cf82e217
+Create Date: 2026-04-08 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'a3f1c8d92b4e'
+down_revision: Union[str, None] = '2731cf82e217'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table('user_mcp_servers',
+        sa.Column('id', sa.String(), nullable=False),
+        sa.Column('owner_user_id', sa.String(), nullable=False),
+        sa.Column('server_name', sa.String(), nullable=False),
+        sa.Column('display_name', sa.String(), nullable=False),
+        sa.Column('description', sa.String(), nullable=True),
+        sa.Column('url', sa.String(), nullable=False),
+        sa.Column('transport', sa.String(), nullable=False, server_default='streamable-http'),
+        sa.Column('auth_type', sa.String(), nullable=False, server_default='none'),
+        sa.Column('headers_encrypted', sa.String(), nullable=True),
+        sa.Column('oauth_config_encrypted', sa.String(), nullable=True),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('1')),
+        sa.Column('created_at', sa.DateTime(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(['owner_user_id'], ['users.id'], ),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('owner_user_id', 'server_name', name='_user_mcp_server_name_uc'),
+    )
+    op.create_index(op.f('ix_user_mcp_servers_owner_user_id'), 'user_mcp_servers', ['owner_user_id'], unique=False)
+
+
+def downgrade() -> None:
+    op.drop_index(op.f('ix_user_mcp_servers_owner_user_id'), table_name='user_mcp_servers')
+    op.drop_table('user_mcp_servers')

--- a/bondable/bond/alembic/versions/b7e2d4f1a093_add_extra_config_to_user_mcp_servers.py
+++ b/bondable/bond/alembic/versions/b7e2d4f1a093_add_extra_config_to_user_mcp_servers.py
@@ -1,0 +1,28 @@
+"""add_extra_config_to_user_mcp_servers
+
+Revision ID: b7e2d4f1a093
+Revises: a3f1c8d92b4e
+Create Date: 2026-04-08 17:10:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = 'b7e2d4f1a093'
+down_revision: Union[str, None] = 'a3f1c8d92b4e'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table('user_mcp_servers') as batch_op:
+        batch_op.add_column(sa.Column('extra_config', sa.JSON(), nullable=True))
+
+
+def downgrade() -> None:
+    with op.batch_alter_table('user_mcp_servers') as batch_op:
+        batch_op.drop_column('extra_config')

--- a/bondable/bond/providers/bedrock/BedrockAgent.py
+++ b/bondable/bond/providers/bedrock/BedrockAgent.py
@@ -1313,7 +1313,7 @@ Please integrate any relevant insights from the documents with your analysis of 
                     # =============================================================
                     # Get MCP config to resolve server from hash
                     mcp_config = Config.config().get_mcp_config()
-                    target_server = _resolve_server_from_hash(server_hash, mcp_config) if mcp_config else None
+                    target_server = _resolve_server_from_hash(server_hash, mcp_config, owner_user_id=getattr(self, 'owner_user_id', None)) if mcp_config else None
 
                     # T9/T21: Structured audit log for MCP tool invocations
                     user_email = getattr(self._current_user, 'email', 'unknown') if self._current_user else 'unknown'

--- a/bondable/bond/providers/bedrock/BedrockMCP.py
+++ b/bondable/bond/providers/bedrock/BedrockMCP.py
@@ -161,22 +161,137 @@ def _build_common_tool_path(tool_name: str) -> str:
     return f"/b.{COMMON_SERVER_HASH}.{tool_name}"
 
 
-def _resolve_server_from_hash(server_hash: str, mcp_config: Dict[str, Any]) -> Optional[str]:
+def _resolve_server_from_hash(server_hash: str, mcp_config: Dict[str, Any], owner_user_id: Optional[str] = None) -> Optional[str]:
     """
     Resolve server hash to server name.
+
+    Checks global servers first, then user-defined servers if owner_user_id is provided.
 
     Args:
         server_hash: 6-character hash from tool path
         mcp_config: MCP configuration dict with mcpServers
+        owner_user_id: Agent owner's user_id for resolving user-defined servers
 
     Returns:
-        Server name if found, None otherwise
+        Server name if found (or "__user_server__{id}" for user servers), None otherwise
     """
     servers = mcp_config.get('mcpServers', {})
     for server_name in servers:
         if _hash_server_name(server_name) == server_hash:
             return server_name
+
+    # Check user-defined servers
+    if owner_user_id:
+        user_server = _resolve_user_server_by_hash(server_hash, owner_user_id)
+        if user_server:
+            return f"__user_server__{user_server.id}"
+
     return None
+
+
+def _resolve_user_server_by_hash(server_hash: str, owner_user_id: str):
+    """
+    Resolve a server hash to a UserMcpServer record.
+
+    Args:
+        server_hash: 6-character hash from tool path
+        owner_user_id: Owner user ID to scope the lookup
+
+    Returns:
+        UserMcpServer record if found, None otherwise
+    """
+    try:
+        from bondable.bond.providers.metadata import UserMcpServer
+        from bondable.rest.routers.user_mcp_servers import get_user_server_internal_name
+        from bondable.bond.config import Config
+
+        config = Config.config()
+        provider = config.get_provider()
+        if not provider or not hasattr(provider, 'metadata'):
+            return None
+
+        db_session = provider.metadata.get_db_session()
+        if not db_session:
+            return None
+
+        user_servers = db_session.query(UserMcpServer).filter(
+            UserMcpServer.owner_user_id == owner_user_id,
+            UserMcpServer.is_active == True  # noqa: E712
+        ).all()
+
+        for server in user_servers:
+            internal_name = get_user_server_internal_name(owner_user_id, server.server_name)
+            if _hash_server_name(internal_name) == server_hash:
+                return server
+
+    except Exception as e:
+        LOGGER.warning("[MCP] Error resolving user server from hash: %s", e)
+
+    return None
+
+
+def _get_user_server_config(server_id: str) -> Optional[Tuple[str, Dict[str, Any]]]:
+    """
+    Load a user-defined MCP server config from the database and build a server_config dict.
+
+    Returns:
+        Tuple of (connection_name, server_config_dict) or None
+    """
+    try:
+        import json as _json
+        from bondable.bond.providers.metadata import UserMcpServer
+        from bondable.bond.auth.token_encryption import decrypt_token
+        from bondable.bond.config import Config
+
+        config = Config.config()
+        provider = config.get_provider()
+        if not provider or not hasattr(provider, 'metadata'):
+            return None
+
+        db_session = provider.metadata.get_db_session()
+        if not db_session:
+            return None
+
+        server = db_session.query(UserMcpServer).filter(
+            UserMcpServer.id == server_id,
+            UserMcpServer.is_active == True  # noqa: E712
+        ).first()
+        if not server:
+            return None
+
+        connection_name = f"user_{server.id}"
+        server_config = {
+            "url": server.url,
+            "transport": server.transport,
+            "auth_type": server.auth_type,
+        }
+
+        # Decrypt headers for 'header' auth
+        if server.auth_type == 'header' and server.headers_encrypted:
+            try:
+                server_config["headers"] = _json.loads(decrypt_token(server.headers_encrypted))
+            except Exception as e:
+                LOGGER.warning("[MCP] Failed to decrypt headers for user server %s: %s", server_id, e)
+
+        # Decrypt OAuth config for 'oauth2' auth
+        if server.auth_type == 'oauth2' and server.oauth_config_encrypted:
+            try:
+                oauth_data = _json.loads(decrypt_token(server.oauth_config_encrypted))
+                server_config["oauth_config"] = oauth_data
+            except Exception as e:
+                LOGGER.warning("[MCP] Failed to decrypt oauth_config for user server %s: %s", server_id, e)
+
+        # Merge extra_config fields (cloud_id, site_url, etc.)
+        if server.extra_config:
+            for key, value in server.extra_config.items():
+                if key not in server_config:
+                    server_config[key] = value
+
+        return connection_name, server_config
+
+    except Exception as e:
+        LOGGER.warning("[MCP] Error loading user server config: %s", e)
+        return None
 
 
 # =============================================================================
@@ -1196,11 +1311,20 @@ async def execute_mcp_tool(
         this will return an error with authorization_required flag.
     """
     servers = mcp_config.get('mcpServers', {})
-    if not servers:
-        return {"success": False, "error": "No MCP servers configured"}
 
-    # If target_server is specified, only check that server (direct routing)
-    if target_server:
+    # Handle user-defined server (sentinel prefix from _resolve_server_from_hash)
+    if target_server and target_server.startswith("__user_server__"):
+        server_id = target_server[len("__user_server__"):]
+        user_config = _get_user_server_config(server_id)
+        if user_config is None:
+            return {"success": False, "error": f"User-defined server '{server_id}' not found or inactive"}
+        connection_name, user_server_config = user_config
+        # Execute against this user-defined server using a synthetic config
+        servers_to_check = {connection_name: user_server_config}
+        LOGGER.debug("[MCP Execute] Direct routing to user server '%s' for tool '%s'", safe_id(server_id), safe_id(tool_name))
+    elif target_server:
+        if not servers:
+            return {"success": False, "error": "No MCP servers configured"}
         if target_server in servers:
             servers_to_check = {target_server: servers[target_server]}
             LOGGER.debug("[MCP Execute] Direct routing to server '%s' for tool '%s'", safe_id(target_server), safe_id(tool_name))
@@ -1208,6 +1332,8 @@ async def execute_mcp_tool(
             LOGGER.error("[MCP Execute] Target server '%s' not found in config", safe_id(target_server))
             return {"success": False, "error": f"Target server '{target_server}' not found in MCP configuration"}
     else:
+        if not servers:
+            return {"success": False, "error": "No MCP servers configured"}
         servers_to_check = servers
         LOGGER.debug("[MCP Execute] Searching %d servers for tool '%s'", len(servers), safe_id(tool_name))
 

--- a/bondable/bond/providers/metadata.py
+++ b/bondable/bond/providers/metadata.py
@@ -263,6 +263,39 @@ class UserAgentSortOrder(Base):
     __table_args__ = (PrimaryKeyConstraint('user_id', 'agent_id'),)
 
 
+# ============================================================================
+# User-Defined MCP Server Configuration
+# ============================================================================
+
+class UserMcpServer(Base):
+    """
+    User-defined MCP server configurations.
+
+    Allows users to add their own MCP servers (with none, header, or oauth2 auth).
+    Secrets (headers, oauth_config) are encrypted at rest using token_encryption.
+    """
+    __tablename__ = "user_mcp_servers"
+
+    id = Column(String, primary_key=True, nullable=False)  # UUID
+    owner_user_id = Column(String, ForeignKey('users.id'), nullable=False, index=True)
+    server_name = Column(String, nullable=False)  # Unique per user, [a-z][a-z0-9_]{0,63}
+    display_name = Column(String, nullable=False)
+    description = Column(String, nullable=True)
+    url = Column(String, nullable=False)  # MCP server endpoint URL
+    transport = Column(String, nullable=False, default='streamable-http')  # streamable-http | sse
+    auth_type = Column(String, nullable=False, default='none')  # none | header | oauth2
+    headers_encrypted = Column(String, nullable=True)  # Encrypted JSON for static headers (API keys)
+    oauth_config_encrypted = Column(String, nullable=True)  # Encrypted JSON for OAuth2 config
+    extra_config = Column(JSON, default=dict)  # Arbitrary extra fields (cloud_id, site_url, etc.)
+    is_active = Column(Boolean, default=True, nullable=False)
+    created_at = Column(DateTime, default=datetime.datetime.now)
+    updated_at = Column(DateTime, default=datetime.datetime.now, onupdate=datetime.datetime.now)
+
+    __table_args__ = (
+        UniqueConstraint('owner_user_id', 'server_name', name='_user_mcp_server_name_uc'),
+    )
+
+
 class Metadata(ABC):
 
     def __init__(self, metadata_db_url):

--- a/bondable/rest/main.py
+++ b/bondable/rest/main.py
@@ -10,7 +10,7 @@ from dotenv import load_dotenv
 load_dotenv()
 
 # Import routers
-from bondable.rest.routers import auth, agents, threads, chat, files, mcp, groups, connections, scheduled_jobs, agent_folders
+from bondable.rest.routers import auth, agents, threads, chat, files, mcp, groups, connections, scheduled_jobs, agent_folders, user_mcp_servers
 
 # Configure logging from YAML file
 def setup_logging():
@@ -115,6 +115,7 @@ app.include_router(groups.router)
 app.include_router(connections.router)
 app.include_router(scheduled_jobs.router)
 app.include_router(agent_folders.router)
+app.include_router(user_mcp_servers.router)
 
 # Health check endpoint
 @app.get("/health")

--- a/bondable/rest/routers/connections.py
+++ b/bondable/rest/routers/connections.py
@@ -55,6 +55,8 @@ class ConnectionStatusResponse(BaseModel):
     expires_at: Optional[str] = None
     requires_authorization: bool = False
     has_refresh_token: bool = False
+    is_user_defined: bool = False
+    user_server_id: Optional[str] = None
 
 
 class ConnectionsListResponse(BaseModel):
@@ -88,12 +90,12 @@ def _get_db_session():
 # Connection Config Helpers
 # =============================================================================
 
-def _get_connection_configs() -> List[Dict[str, Any]]:
+def _get_connection_configs(user_id: Optional[str] = None) -> List[Dict[str, Any]]:
     """
-    Get all OAuth2 connection configurations from BOND_MCP_CONFIG environment variable.
+    Get all OAuth2 connection configurations.
 
-    Connection configs are now stored exclusively in the BOND_MCP_CONFIG environment
-    variable (JSON format). The ConnectionConfig database table has been removed.
+    Combines global configs from BOND_MCP_CONFIG with user-defined OAuth servers
+    from the database when user_id is provided.
     """
     configs = []
 
@@ -130,7 +132,8 @@ def _get_connection_configs() -> List[Dict[str, Any]]:
                     "oauth_scopes": oauth_config.get('scopes'),
                     "oauth_redirect_uri": oauth_config.get('redirect_uri'),
                     "icon_url": server_config.get('icon_url'),
-                    "extra_config": extra_config
+                    "extra_config": extra_config,
+                    "is_user_defined": False
                 })
 
         LOGGER.debug(f"Loaded {len(configs)} OAuth2 connection configs from BOND_MCP_CONFIG")
@@ -138,12 +141,75 @@ def _get_connection_configs() -> List[Dict[str, Any]]:
     except Exception as e:
         LOGGER.error(f"Error loading connection configs: {e}")
 
+    # Load user-defined OAuth servers from database
+    if user_id:
+        try:
+            user_oauth_configs = _get_user_oauth_connection_configs(user_id)
+            configs.extend(user_oauth_configs)
+            if user_oauth_configs:
+                LOGGER.debug(f"Loaded {len(user_oauth_configs)} user-defined OAuth2 connections for user")
+        except Exception as e:
+            LOGGER.error(f"Error loading user OAuth connection configs: {e}")
+
     return configs
 
 
-def _get_connection_config(connection_name: str) -> Optional[Dict[str, Any]]:
+def _get_user_oauth_connection_configs(user_id: str) -> List[Dict[str, Any]]:
+    """
+    Get OAuth2 connection configurations from user-defined MCP servers.
+    Returns configs in the same format as global configs.
+    """
+    import json
+    from bondable.bond.providers.metadata import UserMcpServer
+    from bondable.bond.auth.token_encryption import decrypt_token
+
+    session = _get_db_session()
+    if not session:
+        return []
+
+    try:
+        user_servers = session.query(UserMcpServer).filter(
+            UserMcpServer.owner_user_id == user_id,
+            UserMcpServer.auth_type == 'oauth2',
+            UserMcpServer.is_active == True,  # noqa: E712
+            UserMcpServer.oauth_config_encrypted.isnot(None)
+        ).all()
+
+        configs = []
+        for server in user_servers:
+            try:
+                oauth_data = json.loads(decrypt_token(server.oauth_config_encrypted))
+                internal_name = f"user_{server.id}"
+
+                configs.append({
+                    "name": internal_name,
+                    "display_name": server.display_name,
+                    "description": server.description or f"Connect to {server.display_name}",
+                    "url": server.url,
+                    "transport": server.transport,
+                    "auth_type": "oauth2",
+                    "oauth_client_id": oauth_data.get("client_id"),
+                    "oauth_authorize_url": oauth_data.get("authorize_url"),
+                    "oauth_token_url": oauth_data.get("token_url"),
+                    "oauth_scopes": oauth_data.get("scopes"),
+                    "oauth_redirect_uri": oauth_data.get("redirect_uri"),
+                    "icon_url": None,
+                    "extra_config": {"client_secret": oauth_data.get("client_secret")},
+                    "is_user_defined": True,
+                    "user_server_id": server.id,
+                })
+            except Exception as e:
+                LOGGER.warning(f"Error decrypting OAuth config for user server {safe_id(server.id)}: {e}")
+
+        return configs
+    except Exception as e:
+        LOGGER.error(f"Error querying user OAuth servers: {e}")
+        return []
+
+
+def _get_connection_config(connection_name: str, user_id: Optional[str] = None) -> Optional[Dict[str, Any]]:
     """Get a specific connection configuration by name."""
-    configs = _get_connection_configs()
+    configs = _get_connection_configs(user_id=user_id)
     for config in configs:
         if config["name"] == connection_name:
             return config
@@ -253,8 +319,8 @@ async def list_connections(
     LOGGER.debug(f"[Connections] Listing connections for user {current_user.email}")
 
 
-    # Get all connection configs
-    configs = _get_connection_configs()
+    # Get all connection configs (including user-defined OAuth servers)
+    configs = _get_connection_configs(user_id=current_user.user_id)
 
     # Get user's connection tokens
     token_cache = get_mcp_token_cache()
@@ -286,7 +352,9 @@ async def list_connections(
             scopes=user_conn.get("scopes"),
             expires_at=user_conn.get("expires_at"),
             requires_authorization=not connected,
-            has_refresh_token=has_refresh_token
+            has_refresh_token=has_refresh_token,
+            is_user_defined=config.get("is_user_defined", False),
+            user_server_id=config.get("user_server_id")
         )
         connections.append(connection_status)
 
@@ -317,7 +385,7 @@ async def authorize_connection(
     Returns:
         Authorization URL to redirect user to
     """
-    config = _get_connection_config(connection_name)
+    config = _get_connection_config(connection_name, user_id=current_user.user_id)
     if config is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -411,8 +479,8 @@ async def oauth_callback(
     code_verifier = state_data["code_verifier"]
     redirect_uri = state_data["redirect_uri"]
 
-    # Get connection configuration
-    config = _get_connection_config(connection_name)
+    # Get connection configuration (include user-defined servers via user_id from state)
+    config = _get_connection_config(connection_name, user_id=user_id)
     if config is None:
         LOGGER.error("Connection config not found during OAuth callback")
         raise HTTPException(
@@ -526,7 +594,7 @@ async def get_connection_status(
     LOGGER.debug(f"[Connections] Checking status of {connection_name} for user {current_user.email}")
 
 
-    config = _get_connection_config(connection_name)
+    config = _get_connection_config(connection_name, user_id=current_user.user_id)
     if config is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/bondable/rest/routers/connections.py
+++ b/bondable/rest/routers/connections.py
@@ -500,6 +500,18 @@ async def oauth_callback(
             detail="No token URL configured for this connection"
         )
 
+    # Defense-in-depth SSRF check on token_url before making server-side request
+    if config.get("is_user_defined"):
+        from bondable.rest.routers.user_mcp_servers import _validate_url_ssrf
+        try:
+            _validate_url_ssrf(token_url)
+        except HTTPException:
+            LOGGER.warning("SSRF check failed for user-defined token_url")
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Token URL is blocked for security reasons"
+            )
+
     # Exchange code for token
     token_data = {
         "grant_type": "authorization_code",

--- a/bondable/rest/routers/mcp.py
+++ b/bondable/rest/routers/mcp.py
@@ -53,6 +53,8 @@ class MCPServerWithTools(BaseModel):
     connection_status: ConnectionStatusInfo
     tools: List[MCPToolResponse]
     tool_count: int
+    is_user_defined: bool = False
+    user_server_id: Optional[str] = None
 
 
 class MCPToolsGroupedResponse(BaseModel):
@@ -227,6 +229,20 @@ async def list_mcp_tools(
             ))
 
         # =================================================================
+        # Inject User-Defined MCP Servers
+        # =================================================================
+        # User-defined servers from the database appear alongside global servers
+        # =================================================================
+        try:
+            user_servers_result = await _discover_user_mcp_server_tools(
+                current_user, token_cache
+            )
+            server_tools_list.extend(user_servers_result["servers"])
+            all_tools.extend(user_servers_result["tools"])
+        except Exception as e:
+            LOGGER.warning(f"[MCP Tools] Error loading user-defined servers: {e}")
+
+        # =================================================================
         # Inject Admin Tools for Admin Users
         # =================================================================
         # Admin tools are internal tools that appear like a regular MCP server
@@ -327,6 +343,138 @@ async def list_mcp_tools(
         if grouped:
             return MCPToolsGroupedResponse(servers=[], total_servers=0, total_tools=0)
         return []
+
+
+async def _discover_user_mcp_server_tools(
+    current_user: Any,
+    token_cache
+) -> Dict[str, Any]:
+    """
+    Discover tools from user-defined MCP servers.
+
+    Returns dict with 'servers' (list of MCPServerWithTools) and 'tools' (flat list).
+    """
+    from fastmcp.client.transports import SSETransport, StreamableHttpTransport
+    from bondable.bond.providers.metadata import UserMcpServer
+    from bondable.rest.routers.user_mcp_servers import get_user_server_internal_name, _decrypt_headers, _decrypt_oauth_config
+
+    result = {"servers": [], "tools": []}
+
+    db_session = None
+    try:
+        config = Config.config()
+        provider = config.get_provider()
+        if provider and hasattr(provider, 'metadata'):
+            db_session = provider.metadata.get_db_session()
+    except Exception:
+        return result
+
+    if not db_session:
+        return result
+
+    try:
+        user_servers = db_session.query(UserMcpServer).filter(
+            UserMcpServer.owner_user_id == current_user.user_id,
+            UserMcpServer.is_active == True  # noqa: E712
+        ).all()
+    except Exception as e:
+        LOGGER.warning(f"[MCP Tools] Error querying user servers: {e}")
+        return result
+
+    for user_server in user_servers:
+        internal_name = get_user_server_internal_name(current_user.user_id, user_server.server_name)
+        display_name = user_server.display_name
+        description = user_server.description
+        auth_type = user_server.auth_type
+
+        # Determine connection status
+        if auth_type == 'oauth2':
+            connection_name = f"user_{user_server.id}"
+            connection_status = _get_connection_status_for_server(
+                connection_name, {"auth_type": "oauth2"}, current_user.user_id, token_cache
+            )
+        else:
+            # 'none' and 'header' auth don't require OAuth connection
+            connection_status = ConnectionStatusInfo(
+                connected=True, valid=True, requires_authorization=False
+            )
+
+        server_tools: List[MCPToolResponse] = []
+
+        try:
+            # Build auth headers
+            headers = {'User-Agent': 'Bond-AI-MCP-Client/1.0'}
+
+            if auth_type == 'header' and user_server.headers_encrypted:
+                decrypted = _decrypt_headers(user_server.headers_encrypted)
+                if decrypted:
+                    headers.update(decrypted)
+            elif auth_type == 'oauth2':
+                # Use the connection-name-based OAuth flow
+                connection_name = f"user_{user_server.id}"
+                try:
+                    oauth_headers = get_mcp_auth_headers(
+                        connection_name, {"auth_type": "oauth2"}, current_user
+                    )
+                    headers.update(oauth_headers)
+                except (AuthorizationRequiredError, TokenExpiredError):
+                    pass  # Will show as not connected
+
+            server_url = user_server.url
+            transport_type = user_server.transport
+
+            if server_url and connection_status.connected and connection_status.valid:
+                if transport_type == 'sse':
+                    transport = SSETransport(server_url, headers=headers)
+                else:
+                    transport = StreamableHttpTransport(server_url, headers=headers)
+
+                try:
+                    import asyncio
+                    async with Client(transport) as client:
+                        tools = await asyncio.wait_for(client.list_tools(), timeout=15)
+                        server_tools = [
+                            MCPToolResponse(
+                                name=getattr(tool, "name", ""),
+                                description=getattr(tool, "description", ""),
+                                input_schema=getattr(tool, "inputSchema", {})
+                            )
+                            for tool in tools
+                        ]
+                        result["tools"].extend(server_tools)
+                except asyncio.TimeoutError:
+                    LOGGER.warning(f"[MCP Tools] Timeout listing tools from user server '{internal_name}'")
+                except Exception as e:
+                    LOGGER.warning(f"[MCP Tools] Error listing tools from user server '{internal_name}': {e}")
+
+        except AuthorizationRequiredError:
+            connection_status = ConnectionStatusInfo(
+                connected=False, valid=False, requires_authorization=True
+            )
+        except TokenExpiredError:
+            connection_status = ConnectionStatusInfo(
+                connected=True, valid=False, requires_authorization=True
+            )
+        except Exception as e:
+            LOGGER.warning(f"[MCP Tools] Error processing user server '{internal_name}': {e}")
+
+        result["servers"].append(MCPServerWithTools(
+            server_name=internal_name,
+            display_name=display_name,
+            description=description,
+            icon_url=None,
+            auth_type=auth_type,
+            connection_status=connection_status,
+            tools=server_tools,
+            tool_count=len(server_tools),
+            is_user_defined=True,
+            user_server_id=user_server.id
+        ))
+
+    if result["servers"]:
+        LOGGER.info(f"[MCP Tools] Discovered {len(result['servers'])} user-defined servers with {len(result['tools'])} tools")
+
+    return result
 
 
 def _get_connection_status_for_server(

--- a/bondable/rest/routers/user_mcp_servers.py
+++ b/bondable/rest/routers/user_mcp_servers.py
@@ -56,11 +56,23 @@ class OAuthConfigInput(BaseModel):
     @field_validator('authorize_url', 'token_url')
     @classmethod
     def validate_https_urls(cls, v, info):
+        import ipaddress as _ipaddress
         parsed = urlparse(v)
         if parsed.scheme not in ('http', 'https'):
             raise ValueError(f"{info.field_name} must use http or https scheme")
-        if not parsed.hostname:
+        hostname = (parsed.hostname or '').lower()
+        if not hostname:
             raise ValueError(f"{info.field_name} must have a valid hostname")
+        # SSRF protection: block cloud metadata endpoints in OAuth URLs
+        if hostname in _MCP_SSRF_BLOCKED:
+            raise ValueError(f"{info.field_name} hostname is blocked for security reasons")
+        try:
+            addr = _ipaddress.ip_address(hostname)
+            if addr.is_link_local:
+                raise ValueError(f"{info.field_name} hostname is blocked for security reasons")
+        except ValueError as ve:
+            if "blocked" in str(ve):
+                raise
         return v
 
 

--- a/bondable/rest/routers/user_mcp_servers.py
+++ b/bondable/rest/routers/user_mcp_servers.py
@@ -1,0 +1,867 @@
+"""
+User MCP Servers Router - API endpoints for managing user-defined MCP server configurations.
+
+Users can add their own MCP server configs (with none, header, or oauth2 auth).
+These servers appear alongside global servers in tool discovery and agent creation.
+"""
+
+import json
+import logging
+import re
+import uuid
+from typing import Annotated, Any, List, Dict, Optional
+from urllib.parse import urlparse
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel, field_validator
+
+from bondable.bond.config import Config
+from bondable.bond.auth.token_encryption import encrypt_token, decrypt_token
+from bondable.bond.providers.metadata import UserMcpServer
+from bondable.rest.models.auth import User
+from bondable.rest.dependencies.auth import get_current_user
+from bondable.utils.logging_utils import safe_id
+
+router = APIRouter(prefix="/user-mcp-servers", tags=["User MCP Servers"])
+LOGGER = logging.getLogger(__name__)
+
+# Server name pattern: lowercase letters, digits, underscores; must start with letter
+SERVER_NAME_PATTERN = re.compile(r'^[a-z][a-z0-9_]{0,63}$')
+
+# SSRF blocked hostnames for user-defined MCP servers.
+# Unlike the web browsing SSRF list, we do NOT block localhost here because
+# users legitimately run MCP servers locally. We only block cloud metadata endpoints.
+_MCP_SSRF_BLOCKED = frozenset({
+    "metadata.google.internal",
+    "169.254.169.254",
+    "169.254.170.2",  # AWS ECS task metadata
+    "fd00:ec2::254",  # AWS IMDSv2 IPv6
+})
+
+
+# =============================================================================
+# Request/Response Models
+# =============================================================================
+
+class OAuthConfigInput(BaseModel):
+    """OAuth2 configuration provided by the user."""
+    client_id: str
+    client_secret: str
+    authorize_url: str
+    token_url: str
+    scopes: Optional[str] = None
+    redirect_uri: str
+    provider: Optional[str] = None  # e.g., "atlassian", "microsoft"
+
+    @field_validator('authorize_url', 'token_url')
+    @classmethod
+    def validate_https_urls(cls, v, info):
+        parsed = urlparse(v)
+        if parsed.scheme not in ('http', 'https'):
+            raise ValueError(f"{info.field_name} must use http or https scheme")
+        if not parsed.hostname:
+            raise ValueError(f"{info.field_name} must have a valid hostname")
+        return v
+
+
+class UserMcpServerCreate(BaseModel):
+    """Request model for creating a user MCP server."""
+    server_name: str
+    display_name: str
+    description: Optional[str] = None
+    url: str
+    transport: str = "streamable-http"
+    auth_type: str = "none"  # none | header | oauth2
+    headers: Optional[Dict[str, str]] = None
+    oauth_config: Optional[OAuthConfigInput] = None
+    extra_config: Optional[Dict[str, Any]] = None  # cloud_id, site_url, etc.
+
+    @field_validator('server_name')
+    @classmethod
+    def validate_server_name(cls, v):
+        if not SERVER_NAME_PATTERN.match(v):
+            raise ValueError(
+                "server_name must start with a lowercase letter and contain only "
+                "lowercase letters, digits, and underscores (max 64 chars)"
+            )
+        return v
+
+    @field_validator('transport')
+    @classmethod
+    def validate_transport(cls, v):
+        if v not in ('streamable-http', 'sse'):
+            raise ValueError("transport must be 'streamable-http' or 'sse'")
+        return v
+
+    @field_validator('auth_type')
+    @classmethod
+    def validate_auth_type(cls, v):
+        if v not in ('none', 'header', 'oauth2'):
+            raise ValueError("auth_type must be 'none', 'header', or 'oauth2'")
+        return v
+
+    @field_validator('url')
+    @classmethod
+    def validate_url(cls, v):
+        parsed = urlparse(v)
+        if parsed.scheme not in ('http', 'https'):
+            raise ValueError("url must use http or https scheme")
+        if not parsed.hostname:
+            raise ValueError("url must have a valid hostname")
+        return v
+
+
+class UserMcpServerUpdate(BaseModel):
+    """Request model for updating a user MCP server."""
+    display_name: Optional[str] = None
+    description: Optional[str] = None
+    url: Optional[str] = None
+    transport: Optional[str] = None
+    auth_type: Optional[str] = None
+    headers: Optional[Dict[str, str]] = None
+    oauth_config: Optional[OAuthConfigInput] = None
+    extra_config: Optional[Dict[str, Any]] = None
+    is_active: Optional[bool] = None
+
+    @field_validator('transport')
+    @classmethod
+    def validate_transport(cls, v):
+        if v is not None and v not in ('streamable-http', 'sse'):
+            raise ValueError("transport must be 'streamable-http' or 'sse'")
+        return v
+
+    @field_validator('auth_type')
+    @classmethod
+    def validate_auth_type(cls, v):
+        if v is not None and v not in ('none', 'header', 'oauth2'):
+            raise ValueError("auth_type must be 'none', 'header', or 'oauth2'")
+        return v
+
+    @field_validator('url')
+    @classmethod
+    def validate_url(cls, v):
+        if v is not None:
+            parsed = urlparse(v)
+            if parsed.scheme not in ('http', 'https'):
+                raise ValueError("url must use http or https scheme")
+            if not parsed.hostname:
+                raise ValueError("url must have a valid hostname")
+        return v
+
+
+class OAuthConfigDisplay(BaseModel):
+    """OAuth config with client_secret redacted."""
+    client_id: str
+    authorize_url: str
+    token_url: str
+    scopes: Optional[str] = None
+    redirect_uri: str
+    provider: Optional[str] = None
+
+
+class UserMcpServerResponse(BaseModel):
+    """Response model for a user MCP server."""
+    id: str
+    server_name: str
+    display_name: str
+    description: Optional[str] = None
+    url: str
+    transport: str
+    auth_type: str
+    has_headers: bool = False
+    has_oauth_config: bool = False
+    oauth_config: Optional[OAuthConfigDisplay] = None
+    extra_config: Optional[Dict[str, Any]] = None
+    is_active: bool = True
+    created_at: Optional[str] = None
+    updated_at: Optional[str] = None
+
+
+class UserMcpServerListResponse(BaseModel):
+    """Response model for listing user MCP servers."""
+    servers: List[UserMcpServerResponse]
+    total: int
+
+
+class TestConnectionResponse(BaseModel):
+    """Response model for testing connectivity."""
+    success: bool
+    tool_count: int = 0
+    tools: List[str] = []
+    error: Optional[str] = None
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _get_db_session():
+    """Get database session from the provider."""
+    config = Config.config()
+    provider = config.get_provider()
+    if provider and hasattr(provider, 'metadata'):
+        return provider.metadata.get_db_session()
+    return None
+
+
+def _validate_url_ssrf(url: str):
+    """Validate URL is not targeting cloud metadata endpoints (SSRF protection)."""
+    import ipaddress
+    parsed = urlparse(url)
+    hostname = (parsed.hostname or '').lower()
+
+    # Check exact hostname blocklist
+    if hostname in _MCP_SSRF_BLOCKED:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"URL hostname '{hostname}' is blocked for security reasons"
+        )
+
+    # Check if the hostname resolves to a link-local IP (169.254.0.0/16)
+    # This catches alternate representations like hex, octal, or mapped IPv6
+    try:
+        addr = ipaddress.ip_address(hostname)
+        if addr.is_link_local:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail=f"URL hostname '{hostname}' is blocked for security reasons"
+            )
+    except ValueError:
+        pass  # Not an IP literal — hostname check above is sufficient
+
+
+def _validate_no_global_collision(server_name: str):
+    """Ensure server_name doesn't collide with a global MCP server name."""
+    try:
+        mcp_config = Config.config().get_mcp_config()
+        global_servers = mcp_config.get('mcpServers', {})
+        if server_name in global_servers:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Server name '{server_name}' conflicts with a global MCP server"
+            )
+    except HTTPException:
+        raise
+    except Exception as e:
+        LOGGER.debug("Could not check global MCP config for collision: %s", e)
+
+
+def _validate_auth_fields(auth_type: str, headers: Optional[Dict], oauth_config: Optional[OAuthConfigInput]):
+    """Validate that auth-related fields match the auth_type."""
+    if auth_type == 'header' and not headers:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="headers are required when auth_type is 'header'"
+        )
+    if auth_type == 'oauth2' and not oauth_config:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="oauth_config is required when auth_type is 'oauth2'"
+        )
+    if auth_type == 'none':
+        if headers:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="headers should not be provided when auth_type is 'none'"
+            )
+        if oauth_config:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="oauth_config should not be provided when auth_type is 'none'"
+            )
+    if auth_type == 'header' and oauth_config:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="oauth_config should not be provided when auth_type is 'header'"
+        )
+    if auth_type == 'oauth2' and headers:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="headers should not be provided when auth_type is 'oauth2'"
+        )
+
+
+def _encrypt_headers(headers: Optional[Dict[str, str]]) -> Optional[str]:
+    """Encrypt headers dict as JSON string."""
+    if not headers:
+        return None
+    return encrypt_token(json.dumps(headers))
+
+
+def _decrypt_headers(encrypted: Optional[str]) -> Optional[Dict[str, str]]:
+    """Decrypt encrypted headers JSON string."""
+    if not encrypted:
+        return None
+    return json.loads(decrypt_token(encrypted))
+
+
+def _encrypt_oauth_config(oauth_config: Optional[OAuthConfigInput]) -> Optional[str]:
+    """Encrypt OAuth config as JSON string."""
+    if not oauth_config:
+        return None
+    return encrypt_token(json.dumps(oauth_config.model_dump()))
+
+
+def _decrypt_oauth_config(encrypted: Optional[str]) -> Optional[Dict]:
+    """Decrypt encrypted OAuth config JSON string."""
+    if not encrypted:
+        return None
+    return json.loads(decrypt_token(encrypted))
+
+
+def _server_to_response(server: UserMcpServer) -> UserMcpServerResponse:
+    """Convert a UserMcpServer DB record to a response model (secrets redacted)."""
+    oauth_display = None
+    if server.oauth_config_encrypted:
+        try:
+            oauth_data = _decrypt_oauth_config(server.oauth_config_encrypted)
+            if oauth_data:
+                oauth_display = OAuthConfigDisplay(
+                    client_id=oauth_data.get('client_id', ''),
+                    authorize_url=oauth_data.get('authorize_url', ''),
+                    token_url=oauth_data.get('token_url', ''),
+                    scopes=oauth_data.get('scopes'),
+                    redirect_uri=oauth_data.get('redirect_uri', ''),
+                    provider=oauth_data.get('provider'),
+                )
+        except Exception as e:
+            LOGGER.warning("Failed to decrypt oauth_config for server %s: %s", safe_id(server.id), e)
+
+    return UserMcpServerResponse(
+        id=server.id,
+        server_name=server.server_name,
+        display_name=server.display_name,
+        description=server.description,
+        url=server.url,
+        transport=server.transport,
+        auth_type=server.auth_type,
+        has_headers=server.headers_encrypted is not None,
+        has_oauth_config=server.oauth_config_encrypted is not None,
+        oauth_config=oauth_display,
+        extra_config=server.extra_config if server.extra_config else None,
+        is_active=server.is_active,
+        created_at=server.created_at.isoformat() if server.created_at else None,
+        updated_at=server.updated_at.isoformat() if server.updated_at else None,
+    )
+
+
+def _check_agent_references(server: UserMcpServer, db_session) -> List[str]:
+    """Check if any agents reference tools from this server. Returns list of agent names."""
+    from bondable.bond.providers.bedrock.BedrockMCP import _hash_server_name
+    from bondable.bond.providers.metadata import AgentRecord
+    from bondable.bond.providers.bedrock.BedrockMetadata import BedrockAgentOptions
+
+    internal_name = get_user_server_internal_name(server.owner_user_id, server.server_name)
+    server_hash = _hash_server_name(internal_name)
+    tool_prefix = f"{internal_name}:"
+
+    referencing_agents = []
+    try:
+        options_list = db_session.query(BedrockAgentOptions).filter(
+            BedrockAgentOptions.mcp_tools.isnot(None)
+        ).all()
+
+        for opts in options_list:
+            mcp_tools = opts.mcp_tools or []
+            if isinstance(mcp_tools, str):
+                mcp_tools = json.loads(mcp_tools)
+            for tool in mcp_tools:
+                if tool.startswith(tool_prefix) or f".{server_hash}." in tool:
+                    agent = db_session.query(AgentRecord).filter(
+                        AgentRecord.agent_id == opts.agent_id
+                    ).first()
+                    if agent:
+                        referencing_agents.append(agent.name)
+                    break
+    except Exception as e:
+        LOGGER.warning("Error checking agent references: %s", e)
+
+    return referencing_agents
+
+
+def get_user_server_internal_name(owner_user_id: str, server_name: str) -> str:
+    """Get the internal name used for hashing. Exported for use by other modules."""
+    return f"user_{owner_user_id[:8]}_{server_name}"
+
+
+# =============================================================================
+# Endpoints
+# =============================================================================
+
+@router.post("", response_model=UserMcpServerResponse, status_code=status.HTTP_201_CREATED)
+async def create_user_mcp_server(
+    request: UserMcpServerCreate,
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> UserMcpServerResponse:
+    """Create a new user-defined MCP server configuration."""
+    LOGGER.info("[UserMCP] Create request from user %s: server_name=%s",
+                safe_id(current_user.user_id), safe_id(request.server_name))
+
+    # Validate
+    _validate_url_ssrf(request.url)
+    _validate_no_global_collision(request.server_name)
+    _validate_auth_fields(request.auth_type, request.headers, request.oauth_config)
+
+    db_session = _get_db_session()
+    if not db_session:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database not available")
+
+    try:
+        # Check uniqueness within user's servers
+        existing = db_session.query(UserMcpServer).filter(
+            UserMcpServer.owner_user_id == current_user.user_id,
+            UserMcpServer.server_name == request.server_name
+        ).first()
+        if existing:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"You already have a server named '{request.server_name}'"
+            )
+
+        server = UserMcpServer(
+            id=str(uuid.uuid4()),
+            owner_user_id=current_user.user_id,
+            server_name=request.server_name,
+            display_name=request.display_name,
+            description=request.description,
+            url=request.url,
+            transport=request.transport,
+            auth_type=request.auth_type,
+            headers_encrypted=_encrypt_headers(request.headers),
+            oauth_config_encrypted=_encrypt_oauth_config(request.oauth_config),
+            extra_config=request.extra_config or {},
+            is_active=True,
+        )
+        db_session.add(server)
+        db_session.commit()
+        db_session.refresh(server)
+
+        LOGGER.info("[UserMCP] Created server %s for user %s", safe_id(server.id), safe_id(current_user.user_id))
+        return _server_to_response(server)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        db_session.rollback()
+        LOGGER.error("[UserMCP] Error creating server: %s", e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create server")
+
+
+@router.get("", response_model=UserMcpServerListResponse)
+async def list_user_mcp_servers(
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> UserMcpServerListResponse:
+    """List the current user's MCP server configurations."""
+    db_session = _get_db_session()
+    if not db_session:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database not available")
+
+    try:
+        servers = db_session.query(UserMcpServer).filter(
+            UserMcpServer.owner_user_id == current_user.user_id
+        ).order_by(UserMcpServer.created_at).all()
+
+        return UserMcpServerListResponse(
+            servers=[_server_to_response(s) for s in servers],
+            total=len(servers)
+        )
+    except Exception as e:
+        LOGGER.error("[UserMCP] Error listing servers: %s", e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to list servers")
+
+
+# =============================================================================
+# Import endpoint — MUST be before /{server_id} routes to avoid path collision
+# =============================================================================
+
+class ImportJsonRequest(BaseModel):
+    """Import a server config from JSON (same format as BOND_MCP_CONFIG entries)."""
+    server_name: str
+    config: Dict[str, Any]  # Raw JSON config matching BOND_MCP_CONFIG format
+
+
+@router.post("/import", response_model=UserMcpServerResponse, status_code=status.HTTP_201_CREATED)
+async def import_user_mcp_server(
+    request: ImportJsonRequest,
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> UserMcpServerResponse:
+    """Import a server config from JSON (same format as BOND_MCP_CONFIG entries).
+
+    Example JSON config:
+    {
+        "server_name": "microsoft",
+        "config": {
+            "url": "http://localhost:5557/mcp",
+            "auth_type": "oauth2",
+            "transport": "streamable-http",
+            "display_name": "Microsoft",
+            "description": "Connect to Microsoft email",
+            "oauth_config": { ... },
+            "cloud_id": "...",
+            "site_url": "..."
+        }
+    }
+    """
+    config = request.config
+    server_name = request.server_name
+
+    # Validate server_name
+    if not SERVER_NAME_PATTERN.match(server_name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="server_name must start with a lowercase letter and contain only lowercase letters, digits, and underscores"
+        )
+
+    # Extract known fields from config
+    url = config.get('url', '')
+    if not url:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Config must include 'url'")
+
+    transport = config.get('transport', 'streamable-http')
+    auth_type = config.get('auth_type', 'none')
+    display_name = config.get('display_name', server_name.replace('_', ' ').title())
+    description = config.get('description')
+    headers = config.get('headers')
+    oauth_config_data = config.get('oauth_config')
+
+    # Validate
+    _validate_url_ssrf(url)
+    _validate_no_global_collision(server_name)
+
+    if auth_type not in ('none', 'header', 'oauth2', 'bond_jwt'):
+        auth_type = 'none'
+    # Treat bond_jwt as none for user-defined servers
+    if auth_type == 'bond_jwt':
+        auth_type = 'none'
+
+    # Build encrypted fields
+    headers_encrypted = None
+    if headers and auth_type == 'header':
+        headers_encrypted = _encrypt_headers(headers)
+
+    oauth_config_encrypted = None
+    if oauth_config_data and auth_type == 'oauth2':
+        # Validate required OAuth fields
+        for field in ('client_id', 'authorize_url', 'token_url', 'redirect_uri'):
+            if not oauth_config_data.get(field):
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"oauth_config must include '{field}'"
+                )
+        # client_secret may be missing (for PKCE-only flows) — allow it
+        oauth_config_encrypted = encrypt_token(json.dumps(oauth_config_data))
+
+    # Collect extra config (everything not in the known fields)
+    known_keys = {'url', 'transport', 'auth_type', 'display_name', 'description',
+                  'headers', 'oauth_config', 'icon_url'}
+    extra_config = {k: v for k, v in config.items() if k not in known_keys and v is not None}
+
+    db_session = _get_db_session()
+    if not db_session:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database not available")
+
+    try:
+        existing = db_session.query(UserMcpServer).filter(
+            UserMcpServer.owner_user_id == current_user.user_id,
+            UserMcpServer.server_name == server_name
+        ).first()
+        if existing:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"You already have a server named '{server_name}'"
+            )
+
+        server = UserMcpServer(
+            id=str(uuid.uuid4()),
+            owner_user_id=current_user.user_id,
+            server_name=server_name,
+            display_name=display_name,
+            description=description,
+            url=url,
+            transport=transport,
+            auth_type=auth_type,
+            headers_encrypted=headers_encrypted,
+            oauth_config_encrypted=oauth_config_encrypted,
+            extra_config=extra_config,
+            is_active=True,
+        )
+        db_session.add(server)
+        db_session.commit()
+        db_session.refresh(server)
+
+        LOGGER.info("[UserMCP] Imported server %s for user %s", safe_id(server.id), safe_id(current_user.user_id))
+        return _server_to_response(server)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        db_session.rollback()
+        LOGGER.error("[UserMCP] Error importing server: %s", e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to import server")
+
+
+# =============================================================================
+# Per-server endpoints (/{server_id}/...)
+# =============================================================================
+
+@router.get("/{server_id}", response_model=UserMcpServerResponse)
+async def get_user_mcp_server(
+    server_id: str,
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> UserMcpServerResponse:
+    """Get a specific user MCP server configuration (secrets redacted)."""
+    db_session = _get_db_session()
+    if not db_session:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database not available")
+
+    server = db_session.query(UserMcpServer).filter(
+        UserMcpServer.id == server_id,
+        UserMcpServer.owner_user_id == current_user.user_id
+    ).first()
+    if not server:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Server not found")
+
+    return _server_to_response(server)
+
+
+@router.put("/{server_id}", response_model=UserMcpServerResponse)
+async def update_user_mcp_server(
+    server_id: str,
+    request: UserMcpServerUpdate,
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> UserMcpServerResponse:
+    """Update a user MCP server configuration."""
+    db_session = _get_db_session()
+    if not db_session:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database not available")
+
+    try:
+        server = db_session.query(UserMcpServer).filter(
+            UserMcpServer.id == server_id,
+            UserMcpServer.owner_user_id == current_user.user_id
+        ).first()
+        if not server:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Server not found")
+
+        # Determine effective auth_type for validation
+        effective_auth_type = request.auth_type if request.auth_type is not None else server.auth_type
+
+        # If auth_type is changing, validate the new combination
+        if request.auth_type is not None:
+            effective_headers = request.headers
+            effective_oauth = request.oauth_config
+            # When changing auth_type, require the matching fields
+            _validate_auth_fields(effective_auth_type, effective_headers, effective_oauth)
+
+        if request.url is not None:
+            _validate_url_ssrf(request.url)
+            server.url = request.url
+        if request.display_name is not None:
+            server.display_name = request.display_name
+        if request.description is not None:
+            server.description = request.description
+        if request.transport is not None:
+            server.transport = request.transport
+        if request.auth_type is not None:
+            server.auth_type = request.auth_type
+            # Clear the old auth data when switching types
+            if request.auth_type == 'none':
+                server.headers_encrypted = None
+                server.oauth_config_encrypted = None
+            elif request.auth_type == 'header':
+                server.oauth_config_encrypted = None
+                if request.headers is not None:
+                    server.headers_encrypted = _encrypt_headers(request.headers)
+            elif request.auth_type == 'oauth2':
+                server.headers_encrypted = None
+                if request.oauth_config is not None:
+                    server.oauth_config_encrypted = _encrypt_oauth_config(request.oauth_config)
+        else:
+            # Auth type not changing, just update the provided fields
+            if request.headers is not None:
+                if effective_auth_type != 'header':
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="headers can only be set when auth_type is 'header'"
+                    )
+                server.headers_encrypted = _encrypt_headers(request.headers)
+            if request.oauth_config is not None:
+                if effective_auth_type != 'oauth2':
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail="oauth_config can only be set when auth_type is 'oauth2'"
+                    )
+                server.oauth_config_encrypted = _encrypt_oauth_config(request.oauth_config)
+
+        if request.extra_config is not None:
+            server.extra_config = request.extra_config
+        if request.is_active is not None:
+            server.is_active = request.is_active
+
+        db_session.commit()
+        db_session.refresh(server)
+
+        LOGGER.info("[UserMCP] Updated server %s", safe_id(server.id))
+        return _server_to_response(server)
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        db_session.rollback()
+        LOGGER.error("[UserMCP] Error updating server: %s", e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to update server")
+
+
+@router.delete("/{server_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_user_mcp_server(
+    server_id: str,
+    current_user: Annotated[User, Depends(get_current_user)]
+):
+    """Delete a user MCP server configuration. Blocked if any agents reference its tools."""
+    db_session = _get_db_session()
+    if not db_session:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database not available")
+
+    try:
+        server = db_session.query(UserMcpServer).filter(
+            UserMcpServer.id == server_id,
+            UserMcpServer.owner_user_id == current_user.user_id
+        ).first()
+        if not server:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Server not found")
+
+        # Check for agent references
+        referencing_agents = _check_agent_references(server, db_session)
+        if referencing_agents:
+            agent_names = ", ".join(referencing_agents[:5])
+            detail = f"Cannot delete: server is referenced by agent(s): {agent_names}"
+            if len(referencing_agents) > 5:
+                detail += f" and {len(referencing_agents) - 5} more"
+            raise HTTPException(status_code=status.HTTP_409_CONFLICT, detail=detail)
+
+        db_session.delete(server)
+        db_session.commit()
+        LOGGER.info("[UserMCP] Deleted server %s", safe_id(server.id))
+
+    except HTTPException:
+        raise
+    except Exception as e:
+        db_session.rollback()
+        LOGGER.error("[UserMCP] Error deleting server: %s", e)
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to delete server")
+
+
+@router.post("/{server_id}/test", response_model=TestConnectionResponse)
+async def test_user_mcp_server(
+    server_id: str,
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> TestConnectionResponse:
+    """Test connectivity to a user MCP server by listing its tools."""
+    db_session = _get_db_session()
+    if not db_session:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database not available")
+
+    server = db_session.query(UserMcpServer).filter(
+        UserMcpServer.id == server_id,
+        UserMcpServer.owner_user_id == current_user.user_id
+    ).first()
+    if not server:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Server not found")
+
+    try:
+        from fastmcp import Client
+        from fastmcp.client.transports import StreamableHttpTransport, SSETransport
+
+        # Build headers
+        headers = {'User-Agent': 'Bond-AI-MCP-Client/1.0'}
+        if server.auth_type == 'header' and server.headers_encrypted:
+            decrypted = _decrypt_headers(server.headers_encrypted)
+            if decrypted:
+                headers.update(decrypted)
+
+        # Create transport
+        if server.transport == 'sse':
+            transport = SSETransport(server.url, headers=headers)
+        else:
+            transport = StreamableHttpTransport(server.url, headers=headers)
+
+        import asyncio
+        async with Client(transport) as client:
+            tools = await asyncio.wait_for(client.list_tools(), timeout=30)
+            tool_names = [getattr(t, 'name', str(t)) for t in tools]
+
+        return TestConnectionResponse(
+            success=True,
+            tool_count=len(tool_names),
+            tools=tool_names[:50]  # Limit response size
+        )
+
+    except Exception as e:
+        LOGGER.warning("[UserMCP] Test connection failed for server %s: %s", safe_id(server.id), e)
+        return TestConnectionResponse(
+            success=False,
+            error=str(e)[:500]
+        )
+
+
+# =============================================================================
+# Export endpoint
+# =============================================================================
+
+class ExportJsonResponse(BaseModel):
+    """Export a server config as JSON."""
+    server_name: str
+    config: Dict[str, Any]
+
+
+@router.get("/{server_id}/export", response_model=ExportJsonResponse)
+async def export_user_mcp_server(
+    server_id: str,
+    current_user: Annotated[User, Depends(get_current_user)]
+) -> ExportJsonResponse:
+    """Export a user MCP server config as JSON (matching BOND_MCP_CONFIG format).
+
+    Note: client_secret is included in the export so users can back up their config.
+    """
+    db_session = _get_db_session()
+    if not db_session:
+        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Database not available")
+
+    server = db_session.query(UserMcpServer).filter(
+        UserMcpServer.id == server_id,
+        UserMcpServer.owner_user_id == current_user.user_id
+    ).first()
+    if not server:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Server not found")
+
+    config: Dict[str, Any] = {
+        "url": server.url,
+        "transport": server.transport,
+        "display_name": server.display_name,
+    }
+    if server.description:
+        config["description"] = server.description
+    if server.auth_type and server.auth_type != 'none':
+        config["auth_type"] = server.auth_type
+
+    # Include decrypted headers
+    if server.headers_encrypted:
+        try:
+            config["headers"] = _decrypt_headers(server.headers_encrypted)
+        except Exception as e:
+            LOGGER.warning("Failed to decrypt headers for export of server %s: %s", safe_id(server.id), e)
+
+    # Include decrypted OAuth config (with client_secret for backup)
+    if server.oauth_config_encrypted:
+        try:
+            config["oauth_config"] = _decrypt_oauth_config(server.oauth_config_encrypted)
+        except Exception as e:
+            LOGGER.warning("Failed to decrypt oauth_config for export of server %s: %s", safe_id(server.id), e)
+
+    # Include extra config fields at the top level
+    if server.extra_config:
+        for key, value in server.extra_config.items():
+            if key not in config:
+                config[key] = value
+
+    return ExportJsonResponse(server_name=server.server_name, config=config)

--- a/flutterui/lib/data/models/mcp_model.dart
+++ b/flutterui/lib/data/models/mcp_model.dart
@@ -285,6 +285,8 @@ class McpServerWithTools {
   final McpConnectionStatusInfo connectionStatus;
   final List<McpToolModel> tools;
   final int toolCount;
+  final bool isUserDefined;
+  final String? userServerId;
 
   const McpServerWithTools({
     required this.serverName,
@@ -295,6 +297,8 @@ class McpServerWithTools {
     required this.connectionStatus,
     required this.tools,
     required this.toolCount,
+    this.isUserDefined = false,
+    this.userServerId,
   });
 
   factory McpServerWithTools.fromJson(Map<String, dynamic> json) {
@@ -311,6 +315,8 @@ class McpServerWithTools {
           .map((item) => McpToolModel.fromJson(item as Map<String, dynamic>))
           .toList(),
       toolCount: json['tool_count'] as int,
+      isUserDefined: json['is_user_defined'] as bool? ?? false,
+      userServerId: json['user_server_id'] as String?,
     );
   }
 
@@ -324,6 +330,8 @@ class McpServerWithTools {
       'connection_status': connectionStatus.toJson(),
       'tools': tools.map((t) => t.toJson()).toList(),
       'tool_count': toolCount,
+      'is_user_defined': isUserDefined,
+      'user_server_id': userServerId,
     };
   }
 

--- a/flutterui/lib/data/models/user_mcp_server_model.dart
+++ b/flutterui/lib/data/models/user_mcp_server_model.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/foundation.dart' show immutable;
+
+/// OAuth config display (client_secret redacted)
+@immutable
+class OAuthConfigDisplay {
+  final String clientId;
+  final String authorizeUrl;
+  final String tokenUrl;
+  final String? scopes;
+  final String redirectUri;
+  final String? provider;
+
+  const OAuthConfigDisplay({
+    required this.clientId,
+    required this.authorizeUrl,
+    required this.tokenUrl,
+    this.scopes,
+    required this.redirectUri,
+    this.provider,
+  });
+
+  factory OAuthConfigDisplay.fromJson(Map<String, dynamic> json) {
+    return OAuthConfigDisplay(
+      clientId: json['client_id'] as String,
+      authorizeUrl: json['authorize_url'] as String,
+      tokenUrl: json['token_url'] as String,
+      scopes: json['scopes'] as String?,
+      redirectUri: json['redirect_uri'] as String,
+      provider: json['provider'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'client_id': clientId,
+      'authorize_url': authorizeUrl,
+      'token_url': tokenUrl,
+      'scopes': scopes,
+      'redirect_uri': redirectUri,
+      'provider': provider,
+    };
+  }
+}
+
+/// User-defined MCP server configuration
+@immutable
+class UserMcpServerModel {
+  final String id;
+  final String serverName;
+  final String displayName;
+  final String? description;
+  final String url;
+  final String transport;
+  final String authType;
+  final bool hasHeaders;
+  final bool hasOauthConfig;
+  final OAuthConfigDisplay? oauthConfig;
+  final Map<String, dynamic>? extraConfig;
+  final bool isActive;
+  final String? createdAt;
+  final String? updatedAt;
+
+  const UserMcpServerModel({
+    required this.id,
+    required this.serverName,
+    required this.displayName,
+    this.description,
+    required this.url,
+    this.transport = 'streamable-http',
+    this.authType = 'none',
+    this.hasHeaders = false,
+    this.hasOauthConfig = false,
+    this.oauthConfig,
+    this.extraConfig,
+    this.isActive = true,
+    this.createdAt,
+    this.updatedAt,
+  });
+
+  factory UserMcpServerModel.fromJson(Map<String, dynamic> json) {
+    return UserMcpServerModel(
+      id: json['id'] as String,
+      serverName: json['server_name'] as String,
+      displayName: json['display_name'] as String,
+      description: json['description'] as String?,
+      url: json['url'] as String,
+      transport: json['transport'] as String? ?? 'streamable-http',
+      authType: json['auth_type'] as String? ?? 'none',
+      hasHeaders: json['has_headers'] as bool? ?? false,
+      hasOauthConfig: json['has_oauth_config'] as bool? ?? false,
+      oauthConfig: json['oauth_config'] != null
+          ? OAuthConfigDisplay.fromJson(json['oauth_config'] as Map<String, dynamic>)
+          : null,
+      extraConfig: json['extra_config'] as Map<String, dynamic>?,
+      isActive: json['is_active'] as bool? ?? true,
+      createdAt: json['created_at'] as String?,
+      updatedAt: json['updated_at'] as String?,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'server_name': serverName,
+      'display_name': displayName,
+      'description': description,
+      'url': url,
+      'transport': transport,
+      'auth_type': authType,
+      'has_headers': hasHeaders,
+      'has_oauth_config': hasOauthConfig,
+      'oauth_config': oauthConfig?.toJson(),
+      'extra_config': extraConfig,
+      'is_active': isActive,
+      'created_at': createdAt,
+      'updated_at': updatedAt,
+    };
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is UserMcpServerModel && other.id == id;
+  }
+
+  @override
+  int get hashCode => id.hashCode;
+}
+
+/// Response for listing user MCP servers
+@immutable
+class UserMcpServerListResponse {
+  final List<UserMcpServerModel> servers;
+  final int total;
+
+  const UserMcpServerListResponse({
+    required this.servers,
+    required this.total,
+  });
+
+  factory UserMcpServerListResponse.fromJson(Map<String, dynamic> json) {
+    return UserMcpServerListResponse(
+      servers: (json['servers'] as List<dynamic>)
+          .map((item) => UserMcpServerModel.fromJson(item as Map<String, dynamic>))
+          .toList(),
+      total: json['total'] as int,
+    );
+  }
+}
+
+/// Response for testing connectivity
+@immutable
+class TestConnectionResponse {
+  final bool success;
+  final int toolCount;
+  final List<String> tools;
+  final String? error;
+
+  const TestConnectionResponse({
+    required this.success,
+    this.toolCount = 0,
+    this.tools = const [],
+    this.error,
+  });
+
+  factory TestConnectionResponse.fromJson(Map<String, dynamic> json) {
+    return TestConnectionResponse(
+      success: json['success'] as bool,
+      toolCount: json['tool_count'] as int? ?? 0,
+      tools: (json['tools'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          [],
+      error: json['error'] as String?,
+    );
+  }
+}

--- a/flutterui/lib/data/services/user_mcp_server_service.dart
+++ b/flutterui/lib/data/services/user_mcp_server_service.dart
@@ -1,0 +1,305 @@
+import 'dart:convert';
+import 'package:flutter/foundation.dart' show immutable;
+import 'package:http/http.dart' as http;
+
+import 'package:flutterui/core/constants/api_constants.dart';
+import 'package:flutterui/data/models/user_mcp_server_model.dart';
+import 'package:flutterui/data/services/auth_service.dart';
+import 'package:flutterui/data/services/web_http_client.dart' as web_client;
+import '../../core/utils/logger.dart';
+
+/// Service for managing user-defined MCP server configurations.
+@immutable
+class UserMcpServerService {
+  final http.Client _httpClient;
+  final AuthService _authService;
+
+  UserMcpServerService({
+    http.Client? httpClient,
+    required AuthService authService,
+  })  : _httpClient = httpClient ?? web_client.createHttpClient(),
+        _authService = authService;
+
+  /// List the current user's MCP server configurations
+  Future<UserMcpServerListResponse> listServers() async {
+    logger.i("[UserMcpServerService] listServers called.");
+    try {
+      final headers = await _authService.authenticatedHeaders;
+      final url = '${ApiConstants.baseUrl}/user-mcp-servers';
+
+      final response = await _httpClient.get(
+        Uri.parse(url),
+        headers: headers,
+      );
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+        final result = UserMcpServerListResponse.fromJson(data);
+        logger.i("[UserMcpServerService] Fetched ${result.total} servers.");
+        return result;
+      } else {
+        logger.e("[UserMcpServerService] Failed to list servers. Status: ${response.statusCode}");
+        throw Exception('Failed to list servers: ${response.statusCode}');
+      }
+    } catch (e, stackTrace) {
+      logger.e("[UserMcpServerService] Error in listServers: ${e.toString()}");
+      logger.e("[UserMcpServerService] Stack trace: $stackTrace");
+      throw Exception('Failed to list servers: ${e.toString()}');
+    }
+  }
+
+  /// Create a new user MCP server configuration
+  Future<UserMcpServerModel> createServer({
+    required String serverName,
+    required String displayName,
+    String? description,
+    required String url,
+    String transport = 'streamable-http',
+    String authType = 'none',
+    Map<String, String>? headers,
+    Map<String, dynamic>? oauthConfig,
+    Map<String, dynamic>? extraConfig,
+  }) async {
+    logger.i("[UserMcpServerService] createServer called: $serverName");
+    try {
+      final authHeaders = await _authService.authenticatedHeaders;
+      final apiUrl = '${ApiConstants.baseUrl}/user-mcp-servers';
+
+      final body = <String, dynamic>{
+        'server_name': serverName,
+        'display_name': displayName,
+        'url': url,
+        'transport': transport,
+        'auth_type': authType,
+      };
+      if (description != null) body['description'] = description;
+      if (headers != null) body['headers'] = headers;
+      if (oauthConfig != null) body['oauth_config'] = oauthConfig;
+      if (extraConfig != null) body['extra_config'] = extraConfig;
+
+      final response = await _httpClient.post(
+        Uri.parse(apiUrl),
+        headers: {...authHeaders, 'Content-Type': 'application/json'},
+        body: json.encode(body),
+      );
+
+      if (response.statusCode == 201) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+        final result = UserMcpServerModel.fromJson(data);
+        logger.i("[UserMcpServerService] Created server: ${result.id}");
+        return result;
+      } else {
+        final errorBody = json.decode(response.body);
+        final detail = errorBody['detail'] ?? 'Unknown error';
+        logger.e("[UserMcpServerService] Failed to create. Status: ${response.statusCode}, Detail: $detail");
+        throw Exception(detail);
+      }
+    } catch (e, stackTrace) {
+      logger.e("[UserMcpServerService] Error in createServer: ${e.toString()}");
+      logger.e("[UserMcpServerService] Stack trace: $stackTrace");
+      rethrow;
+    }
+  }
+
+  /// Get a specific user MCP server configuration
+  Future<UserMcpServerModel> getServer(String serverId) async {
+    logger.i("[UserMcpServerService] getServer called: $serverId");
+    try {
+      final headers = await _authService.authenticatedHeaders;
+      final url = '${ApiConstants.baseUrl}/user-mcp-servers/$serverId';
+
+      final response = await _httpClient.get(
+        Uri.parse(url),
+        headers: headers,
+      );
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+        return UserMcpServerModel.fromJson(data);
+      } else {
+        logger.e("[UserMcpServerService] Failed to get server. Status: ${response.statusCode}");
+        throw Exception('Failed to get server: ${response.statusCode}');
+      }
+    } catch (e, stackTrace) {
+      logger.e("[UserMcpServerService] Error in getServer: ${e.toString()}");
+      logger.e("[UserMcpServerService] Stack trace: $stackTrace");
+      throw Exception('Failed to get server: ${e.toString()}');
+    }
+  }
+
+  /// Update a user MCP server configuration
+  Future<UserMcpServerModel> updateServer(
+    String serverId, {
+    String? displayName,
+    String? description,
+    String? url,
+    String? transport,
+    String? authType,
+    Map<String, String>? headers,
+    Map<String, dynamic>? oauthConfig,
+    Map<String, dynamic>? extraConfig,
+    bool? isActive,
+  }) async {
+    logger.i("[UserMcpServerService] updateServer called: $serverId");
+    try {
+      final authHeaders = await _authService.authenticatedHeaders;
+      final apiUrl = '${ApiConstants.baseUrl}/user-mcp-servers/$serverId';
+
+      final body = <String, dynamic>{};
+      if (displayName != null) body['display_name'] = displayName;
+      if (description != null) body['description'] = description;
+      if (url != null) body['url'] = url;
+      if (transport != null) body['transport'] = transport;
+      if (authType != null) body['auth_type'] = authType;
+      if (headers != null) body['headers'] = headers;
+      if (oauthConfig != null) body['oauth_config'] = oauthConfig;
+      if (extraConfig != null) body['extra_config'] = extraConfig;
+      if (isActive != null) body['is_active'] = isActive;
+
+      final response = await _httpClient.put(
+        Uri.parse(apiUrl),
+        headers: {...authHeaders, 'Content-Type': 'application/json'},
+        body: json.encode(body),
+      );
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+        final result = UserMcpServerModel.fromJson(data);
+        logger.i("[UserMcpServerService] Updated server: ${result.id}");
+        return result;
+      } else {
+        final errorBody = json.decode(response.body);
+        final detail = errorBody['detail'] ?? 'Unknown error';
+        logger.e("[UserMcpServerService] Failed to update. Status: ${response.statusCode}, Detail: $detail");
+        throw Exception(detail);
+      }
+    } catch (e, stackTrace) {
+      logger.e("[UserMcpServerService] Error in updateServer: ${e.toString()}");
+      logger.e("[UserMcpServerService] Stack trace: $stackTrace");
+      rethrow;
+    }
+  }
+
+  /// Delete a user MCP server configuration
+  Future<void> deleteServer(String serverId) async {
+    logger.i("[UserMcpServerService] deleteServer called: $serverId");
+    try {
+      final headers = await _authService.authenticatedHeaders;
+      final url = '${ApiConstants.baseUrl}/user-mcp-servers/$serverId';
+
+      final response = await _httpClient.delete(
+        Uri.parse(url),
+        headers: headers,
+      );
+
+      if (response.statusCode == 204) {
+        logger.i("[UserMcpServerService] Deleted server: $serverId");
+      } else if (response.statusCode == 409) {
+        final errorBody = json.decode(response.body);
+        final detail = errorBody['detail'] ?? 'Server is referenced by agents';
+        throw Exception(detail);
+      } else {
+        logger.e("[UserMcpServerService] Failed to delete. Status: ${response.statusCode}");
+        throw Exception('Failed to delete server: ${response.statusCode}');
+      }
+    } catch (e, stackTrace) {
+      logger.e("[UserMcpServerService] Error in deleteServer: ${e.toString()}");
+      logger.e("[UserMcpServerService] Stack trace: $stackTrace");
+      rethrow;
+    }
+  }
+
+  /// Test connectivity to a user MCP server
+  Future<TestConnectionResponse> testServer(String serverId) async {
+    logger.i("[UserMcpServerService] testServer called: $serverId");
+    try {
+      final headers = await _authService.authenticatedHeaders;
+      final url = '${ApiConstants.baseUrl}/user-mcp-servers/$serverId/test';
+
+      final response = await _httpClient.post(
+        Uri.parse(url),
+        headers: headers,
+      );
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+        final result = TestConnectionResponse.fromJson(data);
+        logger.i("[UserMcpServerService] Test result: success=${result.success}, tools=${result.toolCount}");
+        return result;
+      } else {
+        logger.e("[UserMcpServerService] Failed to test. Status: ${response.statusCode}");
+        throw Exception('Failed to test server: ${response.statusCode}');
+      }
+    } catch (e, stackTrace) {
+      logger.e("[UserMcpServerService] Error in testServer: ${e.toString()}");
+      logger.e("[UserMcpServerService] Stack trace: $stackTrace");
+      throw Exception('Failed to test server: ${e.toString()}');
+    }
+  }
+
+  /// Import a server from JSON config (same format as BOND_MCP_CONFIG)
+  Future<UserMcpServerModel> importServer({
+    required String serverName,
+    required Map<String, dynamic> config,
+  }) async {
+    logger.i("[UserMcpServerService] importServer called: $serverName");
+    try {
+      final authHeaders = await _authService.authenticatedHeaders;
+      final url = '${ApiConstants.baseUrl}/user-mcp-servers/import';
+
+      final body = {
+        'server_name': serverName,
+        'config': config,
+      };
+
+      final response = await _httpClient.post(
+        Uri.parse(url),
+        headers: {...authHeaders, 'Content-Type': 'application/json'},
+        body: json.encode(body),
+      );
+
+      if (response.statusCode == 201) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+        final result = UserMcpServerModel.fromJson(data);
+        logger.i("[UserMcpServerService] Imported server: ${result.id}");
+        return result;
+      } else {
+        final errorBody = json.decode(response.body);
+        final detail = errorBody['detail'] ?? 'Unknown error';
+        logger.e("[UserMcpServerService] Failed to import. Status: ${response.statusCode}, Detail: $detail");
+        throw Exception(detail);
+      }
+    } catch (e, stackTrace) {
+      logger.e("[UserMcpServerService] Error in importServer: ${e.toString()}");
+      logger.e("[UserMcpServerService] Stack trace: $stackTrace");
+      rethrow;
+    }
+  }
+
+  /// Export a server config as JSON
+  Future<Map<String, dynamic>> exportServer(String serverId) async {
+    logger.i("[UserMcpServerService] exportServer called: $serverId");
+    try {
+      final headers = await _authService.authenticatedHeaders;
+      final url = '${ApiConstants.baseUrl}/user-mcp-servers/$serverId/export';
+
+      final response = await _httpClient.get(
+        Uri.parse(url),
+        headers: headers,
+      );
+
+      if (response.statusCode == 200) {
+        final data = json.decode(response.body) as Map<String, dynamic>;
+        logger.i("[UserMcpServerService] Exported server: $serverId");
+        return data;
+      } else {
+        logger.e("[UserMcpServerService] Failed to export. Status: ${response.statusCode}");
+        throw Exception('Failed to export server: ${response.statusCode}');
+      }
+    } catch (e, stackTrace) {
+      logger.e("[UserMcpServerService] Error in exportServer: ${e.toString()}");
+      logger.e("[UserMcpServerService] Stack trace: $stackTrace");
+      throw Exception('Failed to export server: ${e.toString()}');
+    }
+  }
+}

--- a/flutterui/lib/presentation/screens/agents/widgets/mcp_selection_section.dart
+++ b/flutterui/lib/presentation/screens/agents/widgets/mcp_selection_section.dart
@@ -382,6 +382,23 @@ class _McpSelectionSectionState extends ConsumerState<McpSelectionSection> {
                                 fontWeight: FontWeight.w600,
                               ),
                             ),
+                            if (server.isUserDefined) ...[
+                              const SizedBox(width: 6),
+                              Container(
+                                padding: const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                                decoration: BoxDecoration(
+                                  color: theme.colorScheme.tertiary.withValues(alpha: 0.15),
+                                  borderRadius: BorderRadius.circular(4),
+                                ),
+                                child: Text(
+                                  'Personal',
+                                  style: theme.textTheme.labelSmall?.copyWith(
+                                    color: theme.colorScheme.tertiary,
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                              ),
+                            ],
                             if (selectedCount > 0) ...[
                               const SizedBox(width: AppSpacing.sm),
                               Container(

--- a/flutterui/lib/presentation/screens/connections/add_mcp_server_dialog.dart
+++ b/flutterui/lib/presentation/screens/connections/add_mcp_server_dialog.dart
@@ -1,0 +1,699 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import '../../../data/models/user_mcp_server_model.dart';
+
+/// Full-screen page for adding or editing a user-defined MCP server configuration.
+/// Supports both a structured form and raw JSON import.
+class AddMcpServerPage extends StatefulWidget {
+  final UserMcpServerModel? existingServer;
+
+  const AddMcpServerPage({super.key, this.existingServer});
+
+  @override
+  State<AddMcpServerPage> createState() => _AddMcpServerPageState();
+}
+
+class _AddMcpServerPageState extends State<AddMcpServerPage> with SingleTickerProviderStateMixin {
+  late final TabController _tabController;
+  final _formKey = GlobalKey<FormState>();
+
+  // Form fields
+  late final TextEditingController _displayNameController;
+  late final TextEditingController _serverNameController;
+  late final TextEditingController _descriptionController;
+  late final TextEditingController _urlController;
+  late String _transport;
+  late String _authType;
+
+  // Header auth
+  final List<MapEntry<TextEditingController, TextEditingController>> _headerEntries = [];
+
+  // OAuth fields
+  late final TextEditingController _clientIdController;
+  late final TextEditingController _clientSecretController;
+  late final TextEditingController _authorizeUrlController;
+  late final TextEditingController _tokenUrlController;
+  late final TextEditingController _scopesController;
+  late final TextEditingController _redirectUriController;
+  late final TextEditingController _providerController;
+
+  // Extra config
+  late final TextEditingController _cloudIdController;
+  late final TextEditingController _siteUrlController;
+
+  // JSON import
+  late final TextEditingController _jsonController;
+  String? _jsonError;
+
+  bool get _isEditing => widget.existingServer != null;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(length: 2, vsync: this);
+    final s = widget.existingServer;
+
+    _displayNameController = TextEditingController(text: s?.displayName ?? '');
+    _serverNameController = TextEditingController(text: s?.serverName ?? '');
+    _descriptionController = TextEditingController(text: s?.description ?? '');
+    _urlController = TextEditingController(text: s?.url ?? '');
+    _transport = s?.transport ?? 'streamable-http';
+    _authType = s?.authType ?? 'none';
+
+    _clientIdController = TextEditingController(text: s?.oauthConfig?.clientId ?? '');
+    _clientSecretController = TextEditingController();
+    _authorizeUrlController = TextEditingController(text: s?.oauthConfig?.authorizeUrl ?? '');
+    _tokenUrlController = TextEditingController(text: s?.oauthConfig?.tokenUrl ?? '');
+    _scopesController = TextEditingController(text: s?.oauthConfig?.scopes ?? '');
+    _redirectUriController = TextEditingController(text: s?.oauthConfig?.redirectUri ?? '');
+    _providerController = TextEditingController(text: s?.oauthConfig?.provider ?? '');
+
+    _cloudIdController = TextEditingController(text: s?.extraConfig?['cloud_id']?.toString() ?? '');
+    _siteUrlController = TextEditingController(text: s?.extraConfig?['site_url']?.toString() ?? '');
+
+    _jsonController = TextEditingController();
+
+    // Pre-populate JSON tab when editing
+    if (_isEditing && s != null) {
+      final config = <String, dynamic>{
+        'url': s.url,
+        'transport': s.transport,
+        'display_name': s.displayName,
+      };
+      if (s.description != null) config['description'] = s.description;
+      if (s.authType != 'none') config['auth_type'] = s.authType;
+      if (s.oauthConfig != null) {
+        config['oauth_config'] = s.oauthConfig!.toJson();
+      }
+      if (s.extraConfig != null) {
+        for (final entry in s.extraConfig!.entries) {
+          config[entry.key] = entry.value;
+        }
+      }
+      final fullJson = {s.serverName: config};
+      _jsonController.text = const JsonEncoder.withIndent('  ').convert(fullJson);
+    }
+
+    if (!_isEditing) {
+      _displayNameController.addListener(_autoGenerateServerName);
+    }
+  }
+
+  void _autoGenerateServerName() {
+    final display = _displayNameController.text;
+    final slug = display
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^a-z0-9]+'), '_')
+        .replaceAll(RegExp(r'^_+|_+$'), '');
+    if (slug.isNotEmpty && RegExp(r'^[a-z]').hasMatch(slug)) {
+      _serverNameController.text = slug.length > 64 ? slug.substring(0, 64) : slug;
+    }
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    if (!_isEditing) _displayNameController.removeListener(_autoGenerateServerName);
+    _displayNameController.dispose();
+    _serverNameController.dispose();
+    _descriptionController.dispose();
+    _urlController.dispose();
+    _clientIdController.dispose();
+    _clientSecretController.dispose();
+    _authorizeUrlController.dispose();
+    _tokenUrlController.dispose();
+    _scopesController.dispose();
+    _redirectUriController.dispose();
+    _providerController.dispose();
+    _cloudIdController.dispose();
+    _siteUrlController.dispose();
+    _jsonController.dispose();
+    for (final entry in _headerEntries) {
+      entry.key.dispose();
+      entry.value.dispose();
+    }
+    super.dispose();
+  }
+
+  void _addHeaderEntry() {
+    setState(() {
+      _headerEntries.add(MapEntry(TextEditingController(), TextEditingController()));
+    });
+  }
+
+  void _removeHeaderEntry(int index) {
+    setState(() {
+      _headerEntries[index].key.dispose();
+      _headerEntries[index].value.dispose();
+      _headerEntries.removeAt(index);
+    });
+  }
+
+  Map<String, dynamic>? _buildFormResult() {
+    if (!_formKey.currentState!.validate()) return null;
+
+    final result = <String, dynamic>{
+      'server_name': _serverNameController.text.trim(),
+      'display_name': _displayNameController.text.trim(),
+      'url': _urlController.text.trim(),
+      'transport': _transport,
+      'auth_type': _authType,
+    };
+
+    final desc = _descriptionController.text.trim();
+    if (desc.isNotEmpty) result['description'] = desc;
+
+    if (_authType == 'header') {
+      final headers = <String, String>{};
+      for (final entry in _headerEntries) {
+        final key = entry.key.text.trim();
+        final value = entry.value.text.trim();
+        if (key.isNotEmpty && value.isNotEmpty) {
+          headers[key] = value;
+        }
+      }
+      if (headers.isNotEmpty) result['headers'] = headers;
+    }
+
+    if (_authType == 'oauth2') {
+      result['oauth_config'] = {
+        'client_id': _clientIdController.text.trim(),
+        'client_secret': _clientSecretController.text.trim(),
+        'authorize_url': _authorizeUrlController.text.trim(),
+        'token_url': _tokenUrlController.text.trim(),
+        if (_scopesController.text.trim().isNotEmpty)
+          'scopes': _scopesController.text.trim(),
+        'redirect_uri': _redirectUriController.text.trim(),
+        if (_providerController.text.trim().isNotEmpty)
+          'provider': _providerController.text.trim(),
+      };
+    }
+
+    final extraConfig = <String, dynamic>{};
+    if (_cloudIdController.text.trim().isNotEmpty) {
+      extraConfig['cloud_id'] = _cloudIdController.text.trim();
+    }
+    if (_siteUrlController.text.trim().isNotEmpty) {
+      extraConfig['site_url'] = _siteUrlController.text.trim();
+    }
+    if (extraConfig.isNotEmpty) result['extra_config'] = extraConfig;
+
+    return result;
+  }
+
+  /// Parse JSON in any of these formats:
+  /// 1. {"server_name": "x", "config": {...}}  — full import format
+  /// 2. {"url": "...", ...}                     — raw config object
+  /// 3. "my_server": {"url": "...", ...}        — BOND_MCP_CONFIG entry (not valid JSON alone)
+  Map<String, dynamic>? _buildJsonImportResult() {
+    var text = _jsonController.text.trim();
+    if (text.isEmpty) {
+      setState(() => _jsonError = 'Please paste a JSON configuration');
+      return null;
+    }
+
+    // Format 3: "server_name": { ... } — wrap in braces to make valid JSON
+    if (text.startsWith('"') && !text.startsWith('{')) {
+      text = '{$text}';
+    }
+
+    try {
+      final parsed = json.decode(text) as Map<String, dynamic>;
+
+      // Format 1: {"server_name": "x", "config": {...}}
+      if (parsed.containsKey('config') && parsed.containsKey('server_name')) {
+        setState(() => _jsonError = null);
+        return {'_import': true, ...parsed};
+      }
+
+      // Format 2: {"url": "...", ...} — raw config, infer server name
+      if (parsed.containsKey('url')) {
+        final serverName = _inferServerName(parsed);
+        setState(() => _jsonError = null);
+        return {'_import': true, 'server_name': serverName, 'config': parsed};
+      }
+
+      // Format 3 (after wrapping): {"my_server": {"url": "...", ...}}
+      // Single key whose value is a map with "url"
+      if (parsed.length == 1) {
+        final entry = parsed.entries.first;
+        if (entry.value is Map<String, dynamic>) {
+          final config = entry.value as Map<String, dynamic>;
+          if (config.containsKey('url')) {
+            final serverName = _sanitizeServerName(entry.key);
+            setState(() => _jsonError = null);
+            return {'_import': true, 'server_name': serverName, 'config': config};
+          }
+        }
+      }
+
+      setState(() => _jsonError =
+          'Could not parse config. Supported formats:\n'
+          '  "name": { "url": "..." }  (from BOND_MCP_CONFIG)\n'
+          '  { "url": "..." }  (raw config)\n'
+          '  { "server_name": "...", "config": { "url": "..." } }');
+      return null;
+    } catch (e) {
+      setState(() => _jsonError = 'Invalid JSON: $e');
+      return null;
+    }
+  }
+
+  String _inferServerName(Map<String, dynamic> config) {
+    final displayName = config['display_name'] as String? ?? 'imported';
+    return _sanitizeServerName(displayName);
+  }
+
+  String _sanitizeServerName(String name) {
+    final slug = name
+        .toLowerCase()
+        .replaceAll(RegExp(r'[^a-z0-9]+'), '_')
+        .replaceAll(RegExp(r'^_+|_+$'), '');
+    if (slug.isNotEmpty && RegExp(r'^[a-z]').hasMatch(slug)) {
+      return slug.length > 64 ? slug.substring(0, 64) : slug;
+    }
+    return 'imported_server';
+  }
+
+  void _onSave() {
+    if (_isEditing || _tabController.index == 0) {
+      final result = _buildFormResult();
+      if (result != null) Navigator.of(context).pop(result);
+    } else {
+      final result = _buildJsonImportResult();
+      if (result != null) Navigator.of(context).pop(result);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return Scaffold(
+      backgroundColor: colorScheme.surface,
+      appBar: AppBar(
+        title: Text(_isEditing ? 'Edit MCP Server' : 'Add MCP Server',
+          style: theme.textTheme.titleLarge?.copyWith(
+            color: colorScheme.onSurface, fontWeight: FontWeight.bold)),
+        backgroundColor: colorScheme.surface,
+        foregroundColor: colorScheme.onSurface,
+        surfaceTintColor: Colors.transparent,
+        elevation: 0,
+        leading: IconButton(
+          icon: Icon(Icons.arrow_back, color: colorScheme.onSurface),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(48),
+          child: Container(
+            decoration: BoxDecoration(
+              border: Border(bottom: BorderSide(color: colorScheme.outlineVariant)),
+            ),
+            child: TabBar(
+              controller: _tabController,
+              labelColor: colorScheme.primary,
+              unselectedLabelColor: colorScheme.onSurfaceVariant,
+              indicatorColor: colorScheme.primary,
+              indicatorWeight: 3,
+              labelStyle: theme.textTheme.titleSmall?.copyWith(fontWeight: FontWeight.w600),
+              tabs: [
+                const Tab(text: 'Form'),
+                Tab(text: _isEditing ? 'JSON' : 'Import JSON'),
+              ],
+            ),
+          ),
+        ),
+      ),
+      bottomNavigationBar: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.all(16),
+          child: Row(
+            children: [
+              Expanded(
+                child: OutlinedButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Cancel'),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                flex: 2,
+                child: FilledButton(
+                  onPressed: _onSave,
+                  child: Text(_isEditing ? 'Save Changes' : 'Save'),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          _buildFormTab(),
+          _buildJsonTab(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildFormTab() {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Basic Information',
+                style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold, color: colorScheme.onSurface)),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _displayNameController,
+              decoration: const InputDecoration(
+                labelText: 'Display Name',
+                hintText: 'My Custom Server',
+                border: OutlineInputBorder(),
+              ),
+              validator: (v) => v == null || v.trim().isEmpty ? 'Required' : null,
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _serverNameController,
+              decoration: const InputDecoration(
+                labelText: 'Server Name (identifier)',
+                hintText: 'my_custom_server',
+                helperText: 'Lowercase letters, digits, underscores. Starts with letter.',
+                border: OutlineInputBorder(),
+              ),
+              enabled: !_isEditing,
+              validator: (v) {
+                if (v == null || v.trim().isEmpty) return 'Required';
+                if (!RegExp(r'^[a-z][a-z0-9_]{0,63}$').hasMatch(v.trim())) {
+                  return 'Must start with lowercase letter, only a-z, 0-9, _';
+                }
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _descriptionController,
+              decoration: const InputDecoration(
+                labelText: 'Description (optional)',
+                hintText: 'What does this server provide?',
+                border: OutlineInputBorder(),
+              ),
+              maxLines: 2,
+            ),
+
+            const SizedBox(height: 32),
+            Text('Connection',
+                style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold, color: colorScheme.onSurface)),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _urlController,
+              decoration: const InputDecoration(
+                labelText: 'Server URL',
+                hintText: 'http://localhost:5555/mcp',
+                border: OutlineInputBorder(),
+              ),
+              validator: (v) {
+                if (v == null || v.trim().isEmpty) return 'Required';
+                final uri = Uri.tryParse(v.trim());
+                if (uri == null || !uri.hasScheme || !uri.hasAuthority) return 'Must be a valid URL';
+                return null;
+              },
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              value: _transport,
+              decoration: const InputDecoration(labelText: 'Transport', border: OutlineInputBorder()),
+              items: const [
+                DropdownMenuItem(value: 'streamable-http', child: Text('Streamable HTTP')),
+                DropdownMenuItem(value: 'sse', child: Text('SSE')),
+              ],
+              onChanged: (v) => setState(() => _transport = v!),
+            ),
+            const SizedBox(height: 16),
+            DropdownButtonFormField<String>(
+              value: _authType,
+              decoration: const InputDecoration(labelText: 'Auth Type', border: OutlineInputBorder()),
+              items: const [
+                DropdownMenuItem(value: 'none', child: Text('None')),
+                DropdownMenuItem(value: 'header', child: Text('Header (API Key)')),
+                DropdownMenuItem(value: 'oauth2', child: Text('OAuth2')),
+              ],
+              onChanged: (v) => setState(() => _authType = v!),
+            ),
+
+            // Header auth
+            if (_authType == 'header') ...[
+              const SizedBox(height: 32),
+              Text('Headers',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold, color: colorScheme.onSurface)),
+              const SizedBox(height: 8),
+              ..._headerEntries.asMap().entries.map((e) {
+                final idx = e.key;
+                final entry = e.value;
+                return Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Row(
+                    children: [
+                      Expanded(
+                        child: TextFormField(
+                          controller: entry.key,
+                          decoration: const InputDecoration(labelText: 'Header Name', border: OutlineInputBorder(), isDense: true),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      Expanded(
+                        child: TextFormField(
+                          controller: entry.value,
+                          decoration: const InputDecoration(labelText: 'Value', border: OutlineInputBorder(), isDense: true),
+                          obscureText: true,
+                        ),
+                      ),
+                      const SizedBox(width: 4),
+                      IconButton(
+                        icon: Icon(Icons.remove_circle_outline, size: 20, color: colorScheme.error),
+                        onPressed: () => _removeHeaderEntry(idx),
+                      ),
+                    ],
+                  ),
+                );
+              }),
+              Align(
+                alignment: Alignment.centerLeft,
+                child: TextButton.icon(
+                  onPressed: _addHeaderEntry,
+                  icon: const Icon(Icons.add, size: 18),
+                  label: const Text('Add Header'),
+                ),
+              ),
+            ],
+
+            // OAuth2
+            if (_authType == 'oauth2') ...[
+              const SizedBox(height: 32),
+              Text('OAuth2 Configuration',
+                  style: theme.textTheme.titleMedium?.copyWith(
+                      fontWeight: FontWeight.bold, color: colorScheme.onSurface)),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _providerController,
+                decoration: const InputDecoration(
+                  labelText: 'Provider (optional)',
+                  hintText: 'e.g., atlassian, microsoft, github',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _clientIdController,
+                decoration: const InputDecoration(labelText: 'Client ID', border: OutlineInputBorder()),
+                validator: (v) => _authType == 'oauth2' && (v == null || v.trim().isEmpty) ? 'Required' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _clientSecretController,
+                decoration: InputDecoration(
+                  labelText: 'Client Secret',
+                  hintText: _isEditing ? '(leave empty to keep existing)' : null,
+                  border: const OutlineInputBorder(),
+                ),
+                obscureText: true,
+                validator: (v) {
+                  if (_authType == 'oauth2' && !_isEditing && (v == null || v.trim().isEmpty)) return 'Required';
+                  return null;
+                },
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _authorizeUrlController,
+                decoration: const InputDecoration(
+                  labelText: 'Authorize URL',
+                  hintText: 'https://auth.example.com/authorize',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (v) => _authType == 'oauth2' && (v == null || v.trim().isEmpty) ? 'Required' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _tokenUrlController,
+                decoration: const InputDecoration(
+                  labelText: 'Token URL',
+                  hintText: 'https://auth.example.com/oauth/token',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (v) => _authType == 'oauth2' && (v == null || v.trim().isEmpty) ? 'Required' : null,
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _scopesController,
+                decoration: const InputDecoration(
+                  labelText: 'Scopes (optional)',
+                  hintText: 'read write offline_access',
+                  border: OutlineInputBorder(),
+                ),
+              ),
+              const SizedBox(height: 16),
+              TextFormField(
+                controller: _redirectUriController,
+                decoration: const InputDecoration(
+                  labelText: 'Redirect URI',
+                  hintText: 'http://localhost:8000/connections/{name}/callback',
+                  border: OutlineInputBorder(),
+                ),
+                validator: (v) => _authType == 'oauth2' && (v == null || v.trim().isEmpty) ? 'Required' : null,
+              ),
+            ],
+
+            // Extra config
+            const SizedBox(height: 32),
+            Text('Extra Configuration',
+                style: theme.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.bold, color: colorScheme.onSurface)),
+            const SizedBox(height: 8),
+            Text('Optional provider-specific fields.',
+                style: theme.textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant)),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _cloudIdController,
+              decoration: const InputDecoration(
+                labelText: 'Cloud ID (optional)',
+                hintText: 'e.g., Atlassian Cloud ID',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextFormField(
+              controller: _siteUrlController,
+              decoration: const InputDecoration(
+                labelText: 'Site URL (optional)',
+                hintText: 'e.g., https://your-site.atlassian.net',
+                border: OutlineInputBorder(),
+              ),
+            ),
+            const SizedBox(height: 80), // Bottom padding for save button
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildJsonTab() {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(_isEditing ? 'JSON Configuration' : 'Import from JSON',
+              style: theme.textTheme.titleMedium?.copyWith(
+                  fontWeight: FontWeight.bold, color: colorScheme.onSurface)),
+          const SizedBox(height: 8),
+          Text(
+            _isEditing
+                ? 'View or edit the server configuration as JSON. Note: client_secret is not shown for security. Use the Export button on the server list for a full backup including secrets.'
+                : 'Paste a server entry directly from BOND_MCP_CONFIG, or a standalone JSON config object.',
+            style: theme.textTheme.bodyMedium?.copyWith(color: colorScheme.onSurfaceVariant),
+          ),
+          const SizedBox(height: 16),
+
+          // Example card (only for new servers)
+          if (!_isEditing) Card(
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(8),
+              side: BorderSide(color: colorScheme.outlineVariant),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                    children: [
+                      Text('Example', style: theme.textTheme.labelLarge?.copyWith(fontWeight: FontWeight.bold)),
+                      IconButton(
+                        icon: const Icon(Icons.copy, size: 18),
+                        tooltip: 'Copy example',
+                        onPressed: () {
+                          Clipboard.setData(const ClipboardData(text: _exampleJson));
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('Example copied to clipboard')),
+                          );
+                        },
+                      ),
+                    ],
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    _exampleJson,
+                    style: theme.textTheme.bodySmall?.copyWith(
+                      fontFamily: 'monospace',
+                      color: colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+
+          TextFormField(
+            controller: _jsonController,
+            decoration: InputDecoration(
+              labelText: 'JSON Configuration',
+              hintText: 'Paste your JSON config here...',
+              alignLabelWithHint: true,
+              errorText: _jsonError,
+              border: const OutlineInputBorder(),
+            ),
+            maxLines: 15,
+            style: theme.textTheme.bodySmall?.copyWith(fontFamily: 'monospace'),
+          ),
+          const SizedBox(height: 80), // Bottom padding for save button
+        ],
+      ),
+    );
+  }
+}
+
+const _exampleJson = '''"my_server": {
+  "url": "http://localhost:5557/mcp",
+  "transport": "streamable-http",
+  "display_name": "My Service",
+  "description": "Connect to my service"
+}''';

--- a/flutterui/lib/presentation/screens/connections/connections_screen.dart
+++ b/flutterui/lib/presentation/screens/connections/connections_screen.dart
@@ -1,10 +1,16 @@
+import 'dart:convert';
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../../providers/connections_provider.dart';
 import '../../../data/models/connection_model.dart';
+import '../../../data/models/user_mcp_server_model.dart';
+import '../../../data/services/user_mcp_server_service.dart';
+import '../../../providers/services/service_providers.dart';
 import '../../widgets/app_drawer.dart';
+import 'add_mcp_server_dialog.dart';
 
 // Conditional import for web-specific functionality
 import 'connections_web_utils_stub.dart'
@@ -109,9 +115,12 @@ class _ConnectionsScreenState extends ConsumerState<ConnectionsScreen> {
       backgroundColor: colorScheme.surface,
       drawer: const AppDrawer(),
       appBar: AppBar(
-        title: const Text('Connections'),
+        title: Text('Connections', style: textTheme.titleLarge?.copyWith(
+          color: colorScheme.onSurface, fontWeight: FontWeight.bold)),
         backgroundColor: colorScheme.surface,
+        foregroundColor: colorScheme.onSurface,
         surfaceTintColor: Colors.transparent,
+        elevation: 0,
         iconTheme: IconThemeData(color: colorScheme.onSurface),
       ),
       body: SingleChildScrollView(
@@ -228,9 +237,366 @@ class _ConnectionsScreenState extends ConsumerState<ConnectionsScreen> {
                 ref.read(connectionsNotifierProvider.notifier).loadConnections();
               },
             ),
+
+            const SizedBox(height: 32),
+
+            // My MCP Servers section
+            _MyMcpServersSection(
+              onServersChanged: () {
+                // Refresh connections list when user servers change
+                ref.read(connectionsNotifierProvider.notifier).loadConnections();
+              },
+            ),
           ],
         ),
       ),
+    );
+  }
+}
+
+/// Section for managing user-defined MCP server configurations
+class _MyMcpServersSection extends ConsumerStatefulWidget {
+  final VoidCallback onServersChanged;
+
+  const _MyMcpServersSection({required this.onServersChanged});
+
+  @override
+  ConsumerState<_MyMcpServersSection> createState() => _MyMcpServersSectionState();
+}
+
+class _MyMcpServersSectionState extends ConsumerState<_MyMcpServersSection> {
+  List<UserMcpServerModel>? _servers;
+  bool _isLoading = true;
+  String? _error;
+
+  UserMcpServerService get _service => ref.read(userMcpServerServiceProvider);
+
+  @override
+  void initState() {
+    super.initState();
+    Future.microtask(() => _loadServers());
+  }
+
+  Future<void> _loadServers() async {
+    setState(() { _isLoading = true; _error = null; });
+    try {
+      final response = await _service.listServers();
+      if (mounted) {
+        setState(() { _servers = response.servers; _isLoading = false; });
+      }
+    } catch (e) {
+      if (mounted) {
+        // Show empty state with a subtle error hint — don't block the UI
+        // (common cause: table not yet created after migration)
+        final errorStr = e.toString();
+        final isServerError = errorStr.contains('500') || errorStr.contains('502');
+        setState(() {
+          _servers = [];
+          _error = isServerError ? null : errorStr; // Only show non-server errors
+          _isLoading = false;
+        });
+      }
+    }
+  }
+
+  Future<void> _addServer() async {
+    final result = await Navigator.of(context).push<Map<String, dynamic>>(
+      MaterialPageRoute(builder: (_) => const AddMcpServerPage()),
+    );
+    if (result == null) return;
+
+    try {
+      // Check if this is a JSON import
+      if (result.containsKey('_import')) {
+        await _service.importServer(
+          serverName: result['server_name'] as String,
+          config: Map<String, dynamic>.from(result['config'] as Map),
+        );
+      } else {
+        await _service.createServer(
+          serverName: result['server_name'],
+          displayName: result['display_name'],
+          description: result['description'],
+          url: result['url'],
+          transport: result['transport'] ?? 'streamable-http',
+          authType: result['auth_type'] ?? 'none',
+          headers: result['headers'] != null
+              ? Map<String, String>.from(result['headers'])
+              : null,
+          oauthConfig: result['oauth_config'] != null
+              ? Map<String, dynamic>.from(result['oauth_config'])
+              : null,
+          extraConfig: result['extra_config'] != null
+              ? Map<String, dynamic>.from(result['extra_config'])
+              : null,
+        );
+      }
+      await _loadServers();
+      widget.onServersChanged();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('MCP server added'), backgroundColor: Colors.green),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error: $e'), backgroundColor: Colors.red),
+        );
+      }
+    }
+  }
+
+  Future<void> _editServer(UserMcpServerModel server) async {
+    final result = await Navigator.of(context).push<Map<String, dynamic>>(
+      MaterialPageRoute(builder: (_) => AddMcpServerPage(existingServer: server)),
+    );
+    if (result == null) return;
+
+    try {
+      if (result.containsKey('_import')) {
+        // JSON tab edit: delete old server and re-import with updated config
+        final config = Map<String, dynamic>.from(result['config'] as Map);
+        final serverName = result['server_name'] as String? ?? server.serverName;
+        await _service.deleteServer(server.id);
+        await _service.importServer(serverName: serverName, config: config);
+      } else {
+        // Form tab edit: update individual fields
+        await _service.updateServer(
+          server.id,
+          displayName: result['display_name'],
+          description: result['description'],
+          url: result['url'],
+          transport: result['transport'],
+          authType: result['auth_type'],
+          headers: result['headers'] != null
+              ? Map<String, String>.from(result['headers'])
+              : null,
+          oauthConfig: result['oauth_config'] != null
+              ? Map<String, dynamic>.from(result['oauth_config'])
+              : null,
+          extraConfig: result['extra_config'] != null
+              ? Map<String, dynamic>.from(result['extra_config'])
+              : null,
+        );
+      }
+      await _loadServers();
+      widget.onServersChanged();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('MCP server updated'), backgroundColor: Colors.green),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Error: $e'), backgroundColor: Colors.red),
+        );
+      }
+    }
+  }
+
+  Future<void> _deleteServer(UserMcpServerModel server) async {
+    final confirmed = await showDialog<bool>(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Delete MCP Server'),
+        content: Text('Are you sure you want to delete "${server.displayName}"?'),
+        actions: [
+          TextButton(onPressed: () => Navigator.of(ctx).pop(false), child: const Text('Cancel')),
+          TextButton(onPressed: () => Navigator.of(ctx).pop(true), child: const Text('Delete')),
+        ],
+      ),
+    );
+    if (confirmed != true) return;
+
+    try {
+      await _service.deleteServer(server.id);
+      await _loadServers();
+      widget.onServersChanged();
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('MCP server deleted'), backgroundColor: Colors.green),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('$e'), backgroundColor: Colors.red),
+        );
+      }
+    }
+  }
+
+  Future<void> _testServer(UserMcpServerModel server) async {
+    try {
+      final result = await _service.testServer(server.id);
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(result.success
+                ? 'Connected! Found ${result.toolCount} tools.'
+                : 'Connection failed: ${result.error}'),
+            backgroundColor: result.success ? Colors.green : Colors.red,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Test failed: $e'), backgroundColor: Colors.red),
+        );
+      }
+    }
+  }
+
+  Future<void> _exportServer(UserMcpServerModel server) async {
+    try {
+      final data = await _service.exportServer(server.id);
+      final jsonStr = const JsonEncoder.withIndent('  ').convert(data);
+      await Clipboard.setData(ClipboardData(text: jsonStr));
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Config copied to clipboard'), backgroundColor: Colors.green),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text('Export failed: $e'), backgroundColor: Colors.red),
+        );
+      }
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'My MCP Servers',
+              style: textTheme.headlineSmall?.copyWith(fontWeight: FontWeight.bold),
+            ),
+            FilledButton.icon(
+              onPressed: _addServer,
+              icon: const Icon(Icons.add, size: 18),
+              label: const Text('Add Server'),
+            ),
+          ],
+        ),
+        const SizedBox(height: 8),
+        Text(
+          'Add your own MCP servers to use with your agents. These servers are personal to your account.',
+          style: textTheme.bodyMedium?.copyWith(color: colorScheme.onSurfaceVariant),
+        ),
+        const SizedBox(height: 16),
+
+        if (_isLoading)
+          const Center(child: Padding(padding: EdgeInsets.all(16), child: CircularProgressIndicator())),
+
+        if (_error != null)
+          Card(
+            color: colorScheme.errorContainer,
+            child: Padding(
+              padding: const EdgeInsets.all(16),
+              child: Text('Error loading servers: $_error', style: TextStyle(color: colorScheme.onErrorContainer)),
+            ),
+          ),
+
+        if (!_isLoading && _error == null && (_servers == null || _servers!.isEmpty))
+          Card(
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+              side: BorderSide(color: colorScheme.outlineVariant),
+            ),
+            child: Padding(
+              padding: const EdgeInsets.all(32),
+              child: Center(
+                child: Column(
+                  children: [
+                    Icon(Icons.dns_outlined, size: 48, color: colorScheme.onSurfaceVariant),
+                    const SizedBox(height: 8),
+                    Text('No custom MCP servers yet',
+                        style: textTheme.bodyLarge?.copyWith(color: colorScheme.onSurfaceVariant)),
+                    const SizedBox(height: 4),
+                    Text('Add a server to get started',
+                        style: textTheme.bodySmall?.copyWith(color: colorScheme.onSurfaceVariant)),
+                  ],
+                ),
+              ),
+            ),
+          ),
+
+        if (!_isLoading && _servers != null && _servers!.isNotEmpty)
+          Card(
+            elevation: 0,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(12),
+              side: BorderSide(color: colorScheme.outlineVariant),
+            ),
+            child: Column(
+              children: _servers!.asMap().entries.map((e) {
+                final idx = e.key;
+                final server = e.value;
+                return Column(
+                  children: [
+                    if (idx > 0) Divider(height: 1, color: colorScheme.outlineVariant),
+                    ListTile(
+                      leading: Icon(
+                        server.authType == 'oauth2'
+                            ? Icons.lock_outline
+                            : server.authType == 'header'
+                                ? Icons.key
+                                : Icons.public,
+                        color: colorScheme.primary,
+                      ),
+                      title: Text(server.displayName),
+                      subtitle: Text(
+                        '${server.url}\n${server.authType} | ${server.transport}',
+                        style: textTheme.bodySmall,
+                      ),
+                      isThreeLine: true,
+                      trailing: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            icon: const Icon(Icons.play_arrow, size: 20),
+                            tooltip: 'Test connection',
+                            onPressed: () => _testServer(server),
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.download, size: 20),
+                            tooltip: 'Export JSON',
+                            onPressed: () => _exportServer(server),
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.edit, size: 20),
+                            tooltip: 'Edit',
+                            onPressed: () => _editServer(server),
+                          ),
+                          IconButton(
+                            icon: Icon(Icons.delete_outline, size: 20, color: colorScheme.error),
+                            tooltip: 'Delete',
+                            onPressed: () => _deleteServer(server),
+                          ),
+                        ],
+                      ),
+                    ),
+                  ],
+                );
+              }).toList(),
+            ),
+          ),
+      ],
     );
   }
 }

--- a/flutterui/lib/providers/services/service_providers.dart
+++ b/flutterui/lib/providers/services/service_providers.dart
@@ -9,6 +9,7 @@ import 'package:flutterui/data/services/file_service.dart';
 import 'package:flutterui/data/services/connections_service.dart';
 import 'package:flutterui/data/services/scheduled_job_service.dart';
 import 'package:flutterui/data/services/folder_service.dart';
+import 'package:flutterui/data/services/user_mcp_server_service.dart';
 import 'package:flutterui/providers/core_providers.dart' show sharedPreferencesProvider;
 
 final authServiceProvider = Provider<AuthService>((ref) {
@@ -54,4 +55,9 @@ final scheduledJobServiceProvider = Provider<ScheduledJobService>((ref) {
 final folderServiceProvider = Provider<FolderService>((ref) {
   final authService = ref.watch(authServiceProvider);
   return FolderService(authService: authService);
+});
+
+final userMcpServerServiceProvider = Provider<UserMcpServerService>((ref) {
+  final authService = ref.watch(authServiceProvider);
+  return UserMcpServerService(authService: authService);
 });

--- a/flutterui/test/data/models/mcp_model_user_defined_test.dart
+++ b/flutterui/test/data/models/mcp_model_user_defined_test.dart
@@ -1,0 +1,119 @@
+@TestOn('browser')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterui/data/models/mcp_model.dart';
+
+void main() {
+  group('McpServerWithTools - isUserDefined', () {
+    test('defaults to false', () {
+      final json = {
+        'server_name': 'global_server',
+        'display_name': 'Global Server',
+        'auth_type': 'bond_jwt',
+        'connection_status': {'connected': true, 'valid': true},
+        'tools': [],
+        'tool_count': 0,
+      };
+
+      final server = McpServerWithTools.fromJson(json);
+      expect(server.isUserDefined, false);
+      expect(server.userServerId, isNull);
+    });
+
+    test('parses isUserDefined=true', () {
+      final json = {
+        'server_name': 'user_abc12345_my_server',
+        'display_name': 'My Custom Server',
+        'auth_type': 'none',
+        'connection_status': {'connected': true, 'valid': true},
+        'tools': [
+          {'name': 'my_tool', 'description': 'A tool', 'input_schema': <String, dynamic>{}},
+        ],
+        'tool_count': 1,
+        'is_user_defined': true,
+        'user_server_id': 'uuid-123',
+      };
+
+      final server = McpServerWithTools.fromJson(json);
+      expect(server.isUserDefined, true);
+      expect(server.userServerId, 'uuid-123');
+      expect(server.toolCount, 1);
+      expect(server.tools.first.name, 'my_tool');
+    });
+
+    test('toJson includes isUserDefined fields', () {
+      final server = McpServerWithTools(
+        serverName: 'test',
+        displayName: 'Test',
+        connectionStatus: const McpConnectionStatusInfo(connected: true),
+        tools: const [],
+        toolCount: 0,
+        isUserDefined: true,
+        userServerId: 'uid-1',
+      );
+
+      final json = server.toJson();
+      expect(json['is_user_defined'], true);
+      expect(json['user_server_id'], 'uid-1');
+    });
+
+    test('global server has isUserDefined=false in toJson', () {
+      final server = McpServerWithTools(
+        serverName: 'global',
+        displayName: 'Global',
+        connectionStatus: const McpConnectionStatusInfo(connected: true),
+        tools: const [],
+        toolCount: 0,
+      );
+
+      final json = server.toJson();
+      expect(json['is_user_defined'], false);
+      expect(json['user_server_id'], isNull);
+    });
+  });
+
+  group('McpToolsGroupedResponse with user-defined servers', () {
+    test('mixed global and user-defined servers', () {
+      final json = {
+        'servers': [
+          {
+            'server_name': 'atlassian',
+            'display_name': 'Atlassian',
+            'auth_type': 'oauth2',
+            'connection_status': {'connected': true, 'valid': true},
+            'tools': [
+              {'name': 'search_issues', 'description': 'Search Jira', 'input_schema': <String, dynamic>{}},
+            ],
+            'tool_count': 1,
+            'is_user_defined': false,
+          },
+          {
+            'server_name': 'user_abc_custom',
+            'display_name': 'My Custom',
+            'auth_type': 'none',
+            'connection_status': {'connected': true, 'valid': true},
+            'tools': [
+              {'name': 'custom_tool', 'description': 'Custom', 'input_schema': <String, dynamic>{}},
+            ],
+            'tool_count': 1,
+            'is_user_defined': true,
+            'user_server_id': 'uid-abc',
+          },
+        ],
+        'total_servers': 2,
+        'total_tools': 2,
+      };
+
+      final response = McpToolsGroupedResponse.fromJson(json);
+      expect(response.totalServers, 2);
+
+      final globalServers = response.servers.where((s) => !s.isUserDefined).toList();
+      final userServers = response.servers.where((s) => s.isUserDefined).toList();
+
+      expect(globalServers.length, 1);
+      expect(userServers.length, 1);
+      expect(userServers.first.userServerId, 'uid-abc');
+    });
+  });
+}

--- a/flutterui/test/data/models/user_mcp_server_model_test.dart
+++ b/flutterui/test/data/models/user_mcp_server_model_test.dart
@@ -1,0 +1,225 @@
+@TestOn('browser')
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterui/data/models/user_mcp_server_model.dart';
+
+void main() {
+  group('UserMcpServerModel', () {
+    test('fromJson parses basic server', () {
+      final json = {
+        'id': 'abc-123',
+        'server_name': 'my_server',
+        'display_name': 'My Server',
+        'description': 'A test server',
+        'url': 'http://localhost:5555/mcp',
+        'transport': 'streamable-http',
+        'auth_type': 'none',
+        'has_headers': false,
+        'has_oauth_config': false,
+        'oauth_config': null,
+        'extra_config': null,
+        'is_active': true,
+        'created_at': '2026-04-08T12:00:00',
+        'updated_at': '2026-04-08T12:00:00',
+      };
+
+      final model = UserMcpServerModel.fromJson(json);
+      expect(model.id, 'abc-123');
+      expect(model.serverName, 'my_server');
+      expect(model.displayName, 'My Server');
+      expect(model.description, 'A test server');
+      expect(model.url, 'http://localhost:5555/mcp');
+      expect(model.transport, 'streamable-http');
+      expect(model.authType, 'none');
+      expect(model.hasHeaders, false);
+      expect(model.hasOauthConfig, false);
+      expect(model.isActive, true);
+    });
+
+    test('fromJson parses server with oauth config', () {
+      final json = {
+        'id': 'def-456',
+        'server_name': 'oauth_server',
+        'display_name': 'OAuth Server',
+        'url': 'https://oauth.example.com/mcp',
+        'transport': 'streamable-http',
+        'auth_type': 'oauth2',
+        'has_headers': false,
+        'has_oauth_config': true,
+        'oauth_config': {
+          'client_id': 'test-client',
+          'authorize_url': 'https://auth.example.com/authorize',
+          'token_url': 'https://auth.example.com/token',
+          'scopes': 'read write',
+          'redirect_uri': 'http://localhost:8000/cb',
+          'provider': 'microsoft',
+        },
+        'extra_config': {'cloud_id': 'abc123', 'site_url': 'https://example.com'},
+        'is_active': true,
+      };
+
+      final model = UserMcpServerModel.fromJson(json);
+      expect(model.authType, 'oauth2');
+      expect(model.hasOauthConfig, true);
+      expect(model.oauthConfig, isNotNull);
+      expect(model.oauthConfig!.clientId, 'test-client');
+      expect(model.oauthConfig!.provider, 'microsoft');
+      expect(model.oauthConfig!.scopes, 'read write');
+      expect(model.extraConfig, isNotNull);
+      expect(model.extraConfig!['cloud_id'], 'abc123');
+      expect(model.extraConfig!['site_url'], 'https://example.com');
+    });
+
+    test('fromJson handles missing optional fields', () {
+      final json = {
+        'id': 'min-1',
+        'server_name': 'minimal',
+        'display_name': 'Minimal',
+        'url': 'http://localhost/mcp',
+      };
+
+      final model = UserMcpServerModel.fromJson(json);
+      expect(model.transport, 'streamable-http'); // default
+      expect(model.authType, 'none'); // default
+      expect(model.hasHeaders, false);
+      expect(model.hasOauthConfig, false);
+      expect(model.oauthConfig, isNull);
+      expect(model.extraConfig, isNull);
+      expect(model.isActive, true); // default
+      expect(model.description, isNull);
+    });
+
+    test('toJson produces correct output', () {
+      final model = UserMcpServerModel(
+        id: 'test-1',
+        serverName: 'test_server',
+        displayName: 'Test Server',
+        description: 'Desc',
+        url: 'http://localhost/mcp',
+        transport: 'sse',
+        authType: 'header',
+        hasHeaders: true,
+        extraConfig: {'cloud_id': 'xyz'},
+      );
+
+      final json = model.toJson();
+      expect(json['id'], 'test-1');
+      expect(json['server_name'], 'test_server');
+      expect(json['transport'], 'sse');
+      expect(json['auth_type'], 'header');
+      expect(json['has_headers'], true);
+      expect(json['extra_config'], {'cloud_id': 'xyz'});
+    });
+
+    test('equality based on id', () {
+      final a = UserMcpServerModel(id: 'same', serverName: 'a', displayName: 'A', url: 'http://a/mcp');
+      final b = UserMcpServerModel(id: 'same', serverName: 'b', displayName: 'B', url: 'http://b/mcp');
+      final c = UserMcpServerModel(id: 'diff', serverName: 'a', displayName: 'A', url: 'http://a/mcp');
+
+      expect(a, equals(b)); // Same ID
+      expect(a, isNot(equals(c))); // Different ID
+    });
+  });
+
+  group('OAuthConfigDisplay', () {
+    test('fromJson parses correctly', () {
+      final json = {
+        'client_id': 'cid',
+        'authorize_url': 'https://auth.com/auth',
+        'token_url': 'https://auth.com/token',
+        'scopes': 'read write',
+        'redirect_uri': 'http://localhost/cb',
+        'provider': 'github',
+      };
+
+      final config = OAuthConfigDisplay.fromJson(json);
+      expect(config.clientId, 'cid');
+      expect(config.authorizeUrl, 'https://auth.com/auth');
+      expect(config.tokenUrl, 'https://auth.com/token');
+      expect(config.scopes, 'read write');
+      expect(config.redirectUri, 'http://localhost/cb');
+      expect(config.provider, 'github');
+    });
+
+    test('toJson roundtrips', () {
+      final config = OAuthConfigDisplay(
+        clientId: 'c1',
+        authorizeUrl: 'https://a/auth',
+        tokenUrl: 'https://a/token',
+        redirectUri: 'http://r/cb',
+      );
+      final json = config.toJson();
+      final roundtripped = OAuthConfigDisplay.fromJson(json);
+      expect(roundtripped.clientId, config.clientId);
+      expect(roundtripped.scopes, isNull);
+      expect(roundtripped.provider, isNull);
+    });
+  });
+
+  group('UserMcpServerListResponse', () {
+    test('fromJson parses server list', () {
+      final json = {
+        'servers': [
+          {
+            'id': '1',
+            'server_name': 'srv1',
+            'display_name': 'Server 1',
+            'url': 'http://localhost/mcp',
+            'is_active': true,
+          },
+          {
+            'id': '2',
+            'server_name': 'srv2',
+            'display_name': 'Server 2',
+            'url': 'http://localhost/mcp',
+            'is_active': false,
+          },
+        ],
+        'total': 2,
+      };
+
+      final response = UserMcpServerListResponse.fromJson(json);
+      expect(response.total, 2);
+      expect(response.servers.length, 2);
+      expect(response.servers[0].serverName, 'srv1');
+      expect(response.servers[1].isActive, false);
+    });
+
+    test('fromJson handles empty list', () {
+      final json = {'servers': [], 'total': 0};
+      final response = UserMcpServerListResponse.fromJson(json);
+      expect(response.total, 0);
+      expect(response.servers, isEmpty);
+    });
+  });
+
+  group('TestConnectionResponse', () {
+    test('fromJson parses success', () {
+      final json = {
+        'success': true,
+        'tool_count': 3,
+        'tools': ['tool_a', 'tool_b', 'tool_c'],
+      };
+
+      final response = TestConnectionResponse.fromJson(json);
+      expect(response.success, true);
+      expect(response.toolCount, 3);
+      expect(response.tools, hasLength(3));
+      expect(response.error, isNull);
+    });
+
+    test('fromJson parses failure', () {
+      final json = {
+        'success': false,
+        'tool_count': 0,
+        'tools': [],
+        'error': 'Connection refused',
+      };
+
+      final response = TestConnectionResponse.fromJson(json);
+      expect(response.success, false);
+      expect(response.error, 'Connection refused');
+    });
+  });
+}

--- a/tests/test_user_mcp_servers.py
+++ b/tests/test_user_mcp_servers.py
@@ -211,6 +211,44 @@ class TestValidation:
         assert response.status_code == 400
         assert "blocked" in response.json()["detail"].lower()
 
+    def test_ssrf_blocked_oauth_token_url(self, test_client, auth_headers):
+        """OAuth token_url must also be SSRF-checked (prevents server-side request to metadata)."""
+        data = {
+            "server_name": "ssrf_oauth_test",
+            "display_name": "X",
+            "url": "http://localhost:5555/mcp",
+            "auth_type": "oauth2",
+            "oauth_config": {
+                "client_id": "x",
+                "client_secret": "x",
+                "authorize_url": "https://auth.example.com/authorize",
+                "token_url": "http://169.254.169.254/latest/meta-data/",
+                "redirect_uri": "http://localhost:8000/cb"
+            }
+        }
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 422  # Pydantic validation error
+        assert "blocked" in response.text.lower()
+
+    def test_ssrf_blocked_oauth_authorize_url(self, test_client, auth_headers):
+        """OAuth authorize_url must also be SSRF-checked."""
+        data = {
+            "server_name": "ssrf_authz_test",
+            "display_name": "X",
+            "url": "http://localhost:5555/mcp",
+            "auth_type": "oauth2",
+            "oauth_config": {
+                "client_id": "x",
+                "client_secret": "x",
+                "authorize_url": "http://169.254.169.254/authorize",
+                "token_url": "https://auth.example.com/token",
+                "redirect_uri": "http://localhost:8000/cb"
+            }
+        }
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 422
+        assert "blocked" in response.text.lower()
+
     def test_header_auth_requires_headers(self, test_client, auth_headers):
         data = {"server_name": "header_test", "display_name": "X", "url": "http://localhost:5555/mcp", "auth_type": "header"}
         response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)

--- a/tests/test_user_mcp_servers.py
+++ b/tests/test_user_mcp_servers.py
@@ -1,0 +1,632 @@
+"""
+Tests for User MCP Servers CRUD API endpoints.
+"""
+
+import os
+import pytest
+import tempfile
+import json
+from datetime import timedelta
+from unittest.mock import patch, MagicMock
+from fastapi.testclient import TestClient
+
+# --- Test Database Setup ---
+_test_db_file = tempfile.NamedTemporaryFile(suffix='_user_mcp.db', delete=False)
+TEST_METADATA_DB_URL = f"sqlite:///{_test_db_file.name}"
+os.environ['METADATA_DB_URL'] = TEST_METADATA_DB_URL
+os.environ.setdefault('JWT_SECRET_KEY', 'test-secret-key-for-user-mcp-testing')
+
+# Import after setting environment
+from bondable.rest.main import app, create_access_token
+from bondable.bond.config import Config
+
+jwt_config = Config.config().get_jwt_config()
+TEST_USER_EMAIL = "user-mcp-test@example.com"
+TEST_USER_ID = "user-mcp-test-user-123"
+TEST_USER_EMAIL_2 = "user-mcp-test2@example.com"
+TEST_USER_ID_2 = "user-mcp-test-user-456"
+
+
+# --- Fixtures ---
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_test_db():
+    yield
+    db_path = TEST_METADATA_DB_URL.replace("sqlite:///", "")
+    if os.path.exists(db_path):
+        try:
+            os.remove(db_path)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def test_client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def auth_headers():
+    token_data = {
+        "sub": TEST_USER_EMAIL,
+        "name": "MCP Test User",
+        "provider": "okta",
+        "user_id": TEST_USER_ID
+    }
+    access_token = create_access_token(data=token_data, expires_delta=timedelta(minutes=15))
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.fixture
+def auth_headers_user2():
+    token_data = {
+        "sub": TEST_USER_EMAIL_2,
+        "name": "MCP Test User 2",
+        "provider": "okta",
+        "user_id": TEST_USER_ID_2
+    }
+    access_token = create_access_token(data=token_data, expires_delta=timedelta(minutes=15))
+    return {"Authorization": f"Bearer {access_token}"}
+
+
+@pytest.fixture
+def sample_server_data():
+    return {
+        "server_name": "my_test_server",
+        "display_name": "My Test Server",
+        "description": "A test MCP server",
+        "url": "http://localhost:5555/mcp",
+        "transport": "streamable-http",
+        "auth_type": "none"
+    }
+
+
+@pytest.fixture
+def sample_header_server_data():
+    return {
+        "server_name": "my_header_server",
+        "display_name": "My Header Server",
+        "url": "https://api.example.com/mcp",
+        "transport": "streamable-http",
+        "auth_type": "header",
+        "headers": {"Authorization": "Bearer my-api-key", "X-Custom": "value"}
+    }
+
+
+@pytest.fixture
+def sample_oauth_server_data():
+    return {
+        "server_name": "my_oauth_server",
+        "display_name": "My OAuth Server",
+        "url": "https://oauth.example.com/mcp",
+        "transport": "streamable-http",
+        "auth_type": "oauth2",
+        "oauth_config": {
+            "client_id": "test-client-id",
+            "client_secret": "test-client-secret",
+            "authorize_url": "https://auth.example.com/authorize",
+            "token_url": "https://auth.example.com/token",
+            "scopes": "read write",
+            "redirect_uri": "http://localhost:8000/connections/my_oauth_server/callback",
+            "provider": "custom"
+        }
+    }
+
+
+# --- Auth Tests ---
+
+class TestAuth:
+    def test_requires_auth(self, test_client):
+        response = test_client.get("/user-mcp-servers")
+        assert response.status_code == 401
+
+    def test_requires_auth_create(self, test_client):
+        response = test_client.post("/user-mcp-servers", json={"server_name": "x", "display_name": "X", "url": "http://x"})
+        assert response.status_code == 401
+
+
+# --- Create Tests ---
+
+class TestCreateServer:
+    def test_create_none_auth(self, test_client, auth_headers, sample_server_data):
+        response = test_client.post("/user-mcp-servers", json=sample_server_data, headers=auth_headers)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["server_name"] == "my_test_server"
+        assert data["display_name"] == "My Test Server"
+        assert data["auth_type"] == "none"
+        assert data["has_headers"] is False
+        assert data["has_oauth_config"] is False
+        assert "id" in data
+
+    def test_create_header_auth(self, test_client, auth_headers, sample_header_server_data):
+        response = test_client.post("/user-mcp-servers", json=sample_header_server_data, headers=auth_headers)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["auth_type"] == "header"
+        assert data["has_headers"] is True
+        assert data["has_oauth_config"] is False
+        # Headers should NOT be exposed in response
+        assert "headers" not in data or data.get("headers") is None
+
+    def test_create_oauth_auth(self, test_client, auth_headers, sample_oauth_server_data):
+        response = test_client.post("/user-mcp-servers", json=sample_oauth_server_data, headers=auth_headers)
+        assert response.status_code == 201
+        data = response.json()
+        assert data["auth_type"] == "oauth2"
+        assert data["has_oauth_config"] is True
+        assert data["oauth_config"]["client_id"] == "test-client-id"
+        # client_secret should NOT be in oauth_config display
+        assert "client_secret" not in data.get("oauth_config", {})
+
+    def test_create_duplicate_name(self, test_client, auth_headers, sample_server_data):
+        # First create should succeed (or already exists from previous test)
+        test_client.post("/user-mcp-servers", json=sample_server_data, headers=auth_headers)
+        # Second create with same name should fail
+        response = test_client.post("/user-mcp-servers", json=sample_server_data, headers=auth_headers)
+        assert response.status_code == 409
+
+    def test_create_same_name_different_user(self, test_client, auth_headers_user2, sample_server_data):
+        """Different users can have servers with the same name."""
+        response = test_client.post("/user-mcp-servers", json=sample_server_data, headers=auth_headers_user2)
+        assert response.status_code == 201
+
+
+# --- Validation Tests ---
+
+class TestValidation:
+    def test_invalid_server_name_uppercase(self, test_client, auth_headers):
+        data = {"server_name": "MyServer", "display_name": "X", "url": "http://localhost:5555/mcp", "auth_type": "none"}
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_invalid_server_name_starts_with_digit(self, test_client, auth_headers):
+        data = {"server_name": "1server", "display_name": "X", "url": "http://localhost:5555/mcp", "auth_type": "none"}
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_invalid_server_name_special_chars(self, test_client, auth_headers):
+        data = {"server_name": "my-server", "display_name": "X", "url": "http://localhost:5555/mcp", "auth_type": "none"}
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_invalid_transport(self, test_client, auth_headers):
+        data = {"server_name": "valid_name", "display_name": "X", "url": "http://localhost:5555/mcp", "transport": "websocket", "auth_type": "none"}
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_invalid_auth_type(self, test_client, auth_headers):
+        data = {"server_name": "valid_name", "display_name": "X", "url": "http://localhost:5555/mcp", "auth_type": "api_key"}
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_invalid_url_scheme(self, test_client, auth_headers):
+        data = {"server_name": "valid_name", "display_name": "X", "url": "ftp://example.com/mcp", "auth_type": "none"}
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 422
+
+    def test_ssrf_blocked_hostname(self, test_client, auth_headers):
+        data = {"server_name": "ssrf_test", "display_name": "X", "url": "http://169.254.169.254/mcp", "auth_type": "none"}
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 400
+        assert "blocked" in response.json()["detail"].lower()
+
+    def test_header_auth_requires_headers(self, test_client, auth_headers):
+        data = {"server_name": "header_test", "display_name": "X", "url": "http://localhost:5555/mcp", "auth_type": "header"}
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 400
+
+    def test_oauth_auth_requires_oauth_config(self, test_client, auth_headers):
+        data = {"server_name": "oauth_test", "display_name": "X", "url": "http://localhost:5555/mcp", "auth_type": "oauth2"}
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 400
+
+    def test_none_auth_rejects_headers(self, test_client, auth_headers):
+        data = {"server_name": "none_with_headers", "display_name": "X", "url": "http://localhost:5555/mcp",
+                "auth_type": "none", "headers": {"Authorization": "Bearer x"}}
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 400
+
+    def test_none_auth_rejects_oauth(self, test_client, auth_headers):
+        data = {"server_name": "none_with_oauth", "display_name": "X", "url": "http://localhost:5555/mcp",
+                "auth_type": "none", "oauth_config": {"client_id": "x", "client_secret": "x",
+                "authorize_url": "https://x.com/auth", "token_url": "https://x.com/token",
+                "redirect_uri": "http://localhost/cb"}}
+        response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert response.status_code == 400
+
+    def test_global_name_collision(self, test_client, auth_headers):
+        """Server name must not collide with a global MCP server name."""
+        # Get a global server name from config
+        try:
+            mcp_config = Config.config().get_mcp_config()
+            global_names = list(mcp_config.get('mcpServers', {}).keys())
+            if global_names:
+                data = {"server_name": global_names[0], "display_name": "X", "url": "http://localhost:5555/mcp", "auth_type": "none"}
+                response = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+                assert response.status_code == 409
+                assert "global" in response.json()["detail"].lower() or "conflict" in response.json()["detail"].lower()
+        except Exception:
+            pytest.skip("No global MCP config available")
+
+
+# --- List Tests ---
+
+class TestListServers:
+    def test_list_own_servers(self, test_client, auth_headers):
+        response = test_client.get("/user-mcp-servers", headers=auth_headers)
+        assert response.status_code == 200
+        data = response.json()
+        assert "servers" in data
+        assert "total" in data
+        assert data["total"] >= 1  # At least the one created in TestCreateServer
+
+    def test_list_only_own_servers(self, test_client, auth_headers, auth_headers_user2):
+        """User should only see their own servers, not other users'."""
+        response1 = test_client.get("/user-mcp-servers", headers=auth_headers)
+        response2 = test_client.get("/user-mcp-servers", headers=auth_headers_user2)
+        # They should have different server counts (user2 may have 1 from earlier test)
+        ids1 = {s["id"] for s in response1.json()["servers"]}
+        ids2 = {s["id"] for s in response2.json()["servers"]}
+        assert ids1.isdisjoint(ids2), "Users should not see each other's servers"
+
+
+# --- Get Tests ---
+
+class TestGetServer:
+    def test_get_server(self, test_client, auth_headers):
+        # List to get an ID
+        list_resp = test_client.get("/user-mcp-servers", headers=auth_headers)
+        servers = list_resp.json()["servers"]
+        assert len(servers) > 0
+
+        server_id = servers[0]["id"]
+        response = test_client.get(f"/user-mcp-servers/{server_id}", headers=auth_headers)
+        assert response.status_code == 200
+        assert response.json()["id"] == server_id
+
+    def test_get_nonexistent(self, test_client, auth_headers):
+        response = test_client.get("/user-mcp-servers/nonexistent-id", headers=auth_headers)
+        assert response.status_code == 404
+
+    def test_get_other_users_server(self, test_client, auth_headers, auth_headers_user2):
+        """User cannot access another user's server."""
+        list_resp = test_client.get("/user-mcp-servers", headers=auth_headers)
+        servers = list_resp.json()["servers"]
+        if servers:
+            server_id = servers[0]["id"]
+            response = test_client.get(f"/user-mcp-servers/{server_id}", headers=auth_headers_user2)
+            assert response.status_code == 404
+
+
+# --- Update Tests ---
+
+class TestUpdateServer:
+    def test_update_display_name(self, test_client, auth_headers):
+        list_resp = test_client.get("/user-mcp-servers", headers=auth_headers)
+        servers = list_resp.json()["servers"]
+        server_id = servers[0]["id"]
+
+        response = test_client.put(
+            f"/user-mcp-servers/{server_id}",
+            json={"display_name": "Updated Name"},
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+        assert response.json()["display_name"] == "Updated Name"
+
+    def test_update_url(self, test_client, auth_headers):
+        list_resp = test_client.get("/user-mcp-servers", headers=auth_headers)
+        servers = list_resp.json()["servers"]
+        server_id = servers[0]["id"]
+
+        response = test_client.put(
+            f"/user-mcp-servers/{server_id}",
+            json={"url": "http://localhost:9999/mcp"},
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+        assert response.json()["url"] == "http://localhost:9999/mcp"
+
+    def test_update_other_users_server(self, test_client, auth_headers, auth_headers_user2):
+        list_resp = test_client.get("/user-mcp-servers", headers=auth_headers)
+        servers = list_resp.json()["servers"]
+        if servers:
+            server_id = servers[0]["id"]
+            response = test_client.put(
+                f"/user-mcp-servers/{server_id}",
+                json={"display_name": "Hacked"},
+                headers=auth_headers_user2
+            )
+            assert response.status_code == 404
+
+    def test_update_switch_auth_type_none_to_header(self, test_client, auth_headers):
+        """Switching auth_type from none to header requires providing headers."""
+        list_resp = test_client.get("/user-mcp-servers", headers=auth_headers)
+        servers = list_resp.json()["servers"]
+        # Find a 'none' auth server
+        none_server = next((s for s in servers if s["auth_type"] == "none"), None)
+        if not none_server:
+            pytest.skip("No 'none' auth server available")
+
+        # Switch to header with headers
+        response = test_client.put(
+            f"/user-mcp-servers/{none_server['id']}",
+            json={"auth_type": "header", "headers": {"X-Api-Key": "test-key"}},
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["auth_type"] == "header"
+        assert data["has_headers"] is True
+
+        # Switch back to none (should clear headers)
+        response = test_client.put(
+            f"/user-mcp-servers/{none_server['id']}",
+            json={"auth_type": "none"},
+            headers=auth_headers
+        )
+        assert response.status_code == 200
+        assert response.json()["auth_type"] == "none"
+        assert response.json()["has_headers"] is False
+
+    def test_update_switch_auth_type_without_required_fields(self, test_client, auth_headers):
+        """Switching to header auth without headers should fail."""
+        list_resp = test_client.get("/user-mcp-servers", headers=auth_headers)
+        servers = list_resp.json()["servers"]
+        none_server = next((s for s in servers if s["auth_type"] == "none"), None)
+        if not none_server:
+            pytest.skip("No 'none' auth server available")
+
+        response = test_client.put(
+            f"/user-mcp-servers/{none_server['id']}",
+            json={"auth_type": "header"},
+            headers=auth_headers
+        )
+        assert response.status_code == 400
+
+
+# --- Delete Tests ---
+
+class TestDeleteServer:
+    def test_delete_server(self, test_client, auth_headers):
+        # Create a server to delete
+        create_data = {
+            "server_name": "to_delete",
+            "display_name": "To Delete",
+            "url": "http://localhost:5555/mcp",
+            "auth_type": "none"
+        }
+        create_resp = test_client.post("/user-mcp-servers", json=create_data, headers=auth_headers)
+        assert create_resp.status_code == 201
+        server_id = create_resp.json()["id"]
+
+        response = test_client.delete(f"/user-mcp-servers/{server_id}", headers=auth_headers)
+        assert response.status_code == 204
+
+        # Verify it's gone
+        get_resp = test_client.get(f"/user-mcp-servers/{server_id}", headers=auth_headers)
+        assert get_resp.status_code == 404
+
+    def test_delete_nonexistent(self, test_client, auth_headers):
+        response = test_client.delete("/user-mcp-servers/nonexistent-id", headers=auth_headers)
+        assert response.status_code == 404
+
+    def test_delete_other_users_server(self, test_client, auth_headers, auth_headers_user2):
+        list_resp = test_client.get("/user-mcp-servers", headers=auth_headers_user2)
+        servers = list_resp.json()["servers"]
+        if servers:
+            server_id = servers[0]["id"]
+            response = test_client.delete(f"/user-mcp-servers/{server_id}", headers=auth_headers)
+            assert response.status_code == 404
+
+
+# --- Encryption Tests ---
+
+class TestEncryption:
+    def test_headers_encrypted_at_rest(self, test_client, auth_headers):
+        """Verify headers are encrypted in the database, not stored plaintext."""
+        from bondable.bond.providers.metadata import UserMcpServer
+
+        # Create a header server
+        data = {
+            "server_name": "encryption_test",
+            "display_name": "Encryption Test",
+            "url": "http://localhost:5555/mcp",
+            "auth_type": "header",
+            "headers": {"Authorization": "Bearer super-secret-key"}
+        }
+        resp = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert resp.status_code == 201
+        server_id = resp.json()["id"]
+
+        # Read directly from DB
+        db_session = Config.config().get_provider().metadata.get_db_session()
+        server = db_session.query(UserMcpServer).filter(UserMcpServer.id == server_id).first()
+        assert server is not None
+        assert server.headers_encrypted is not None
+        # The encrypted value should NOT contain the plaintext
+        assert "super-secret-key" not in server.headers_encrypted
+
+        # But should be decryptable
+        from bondable.bond.auth.token_encryption import decrypt_token
+        decrypted = json.loads(decrypt_token(server.headers_encrypted))
+        assert decrypted["Authorization"] == "Bearer super-secret-key"
+
+        # Cleanup
+        test_client.delete(f"/user-mcp-servers/{server_id}", headers=auth_headers)
+
+    def test_oauth_config_encrypted_at_rest(self, test_client, auth_headers):
+        """Verify oauth_config is encrypted in the database."""
+        from bondable.bond.providers.metadata import UserMcpServer
+
+        data = {
+            "server_name": "oauth_encrypt_test",
+            "display_name": "OAuth Encrypt Test",
+            "url": "https://oauth.example.com/mcp",
+            "auth_type": "oauth2",
+            "oauth_config": {
+                "client_id": "test-id",
+                "client_secret": "super-secret-oauth",
+                "authorize_url": "https://auth.example.com/authorize",
+                "token_url": "https://auth.example.com/token",
+                "redirect_uri": "http://localhost:8000/cb"
+            }
+        }
+        resp = test_client.post("/user-mcp-servers", json=data, headers=auth_headers)
+        assert resp.status_code == 201
+        server_id = resp.json()["id"]
+
+        # Read directly from DB
+        db_session = Config.config().get_provider().metadata.get_db_session()
+        server = db_session.query(UserMcpServer).filter(UserMcpServer.id == server_id).first()
+        assert server is not None
+        assert server.oauth_config_encrypted is not None
+        assert "super-secret-oauth" not in server.oauth_config_encrypted
+
+        # Response should have oauth_config WITHOUT client_secret
+        resp_data = resp.json()
+        assert resp_data["oauth_config"]["client_id"] == "test-id"
+        assert "client_secret" not in resp_data["oauth_config"]
+
+        # Cleanup
+        test_client.delete(f"/user-mcp-servers/{server_id}", headers=auth_headers)
+
+
+# --- Import/Export Tests ---
+
+class TestImportExport:
+    def test_import_json_config(self, test_client, auth_headers):
+        """Import a server from JSON matching BOND_MCP_CONFIG format."""
+        data = {
+            "server_name": "imported_microsoft",
+            "config": {
+                "url": "http://localhost:5557/mcp",
+                "auth_type": "oauth2",
+                "transport": "streamable-http",
+                "display_name": "Microsoft (Imported)",
+                "description": "Connect to Microsoft email",
+                "oauth_config": {
+                    "provider": "microsoft",
+                    "client_id": "test-client-id",
+                    "client_secret": "test-secret",
+                    "authorize_url": "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize",
+                    "token_url": "https://login.microsoftonline.com/consumers/oauth2/v2.0/token",
+                    "scopes": "Mail.Read Mail.ReadWrite offline_access",
+                    "redirect_uri": "http://localhost:8000/connections/imported_microsoft/callback"
+                },
+                "cloud_id": "test-cloud-123",
+                "site_url": "https://test.example.com"
+            }
+        }
+        response = test_client.post("/user-mcp-servers/import", json=data, headers=auth_headers)
+        assert response.status_code == 201
+        result = response.json()
+        assert result["server_name"] == "imported_microsoft"
+        assert result["display_name"] == "Microsoft (Imported)"
+        assert result["auth_type"] == "oauth2"
+        assert result["has_oauth_config"] is True
+        assert result["oauth_config"]["client_id"] == "test-client-id"
+        # Extra config should include cloud_id and site_url
+        assert result["extra_config"]["cloud_id"] == "test-cloud-123"
+        assert result["extra_config"]["site_url"] == "https://test.example.com"
+        # Cleanup
+        test_client.delete(f"/user-mcp-servers/{result['id']}", headers=auth_headers)
+
+    def test_import_validates_server_name(self, test_client, auth_headers):
+        data = {
+            "server_name": "Invalid-Name",
+            "config": {"url": "http://localhost:5555/mcp"}
+        }
+        response = test_client.post("/user-mcp-servers/import", json=data, headers=auth_headers)
+        assert response.status_code == 400
+
+    def test_import_requires_url(self, test_client, auth_headers):
+        data = {
+            "server_name": "no_url",
+            "config": {"display_name": "No URL"}
+        }
+        response = test_client.post("/user-mcp-servers/import", json=data, headers=auth_headers)
+        assert response.status_code == 400
+
+    def test_export_json_config(self, test_client, auth_headers):
+        """Export a server and verify it matches the import format."""
+        # Create a server first
+        create_data = {
+            "server_name": "export_test",
+            "display_name": "Export Test",
+            "url": "http://localhost:5555/mcp",
+            "auth_type": "header",
+            "headers": {"X-Api-Key": "secret-123"},
+            "extra_config": {"cloud_id": "abc123"}
+        }
+        create_resp = test_client.post("/user-mcp-servers", json=create_data, headers=auth_headers)
+        assert create_resp.status_code == 201
+        server_id = create_resp.json()["id"]
+
+        # Export
+        export_resp = test_client.get(f"/user-mcp-servers/{server_id}/export", headers=auth_headers)
+        assert export_resp.status_code == 200
+        exported = export_resp.json()
+        assert exported["server_name"] == "export_test"
+        assert exported["config"]["url"] == "http://localhost:5555/mcp"
+        assert exported["config"]["display_name"] == "Export Test"
+        # Headers should be included in export (decrypted)
+        assert exported["config"]["headers"]["X-Api-Key"] == "secret-123"
+        # Extra config fields should be at top level
+        assert exported["config"]["cloud_id"] == "abc123"
+
+        # Cleanup
+        test_client.delete(f"/user-mcp-servers/{server_id}", headers=auth_headers)
+
+    def test_export_roundtrip(self, test_client, auth_headers):
+        """Export then re-import should create an equivalent server."""
+        # Create original
+        create_data = {
+            "server_name": "roundtrip_orig",
+            "display_name": "Roundtrip Original",
+            "url": "http://localhost:5555/mcp",
+            "auth_type": "none",
+            "extra_config": {"site_url": "https://example.com"}
+        }
+        create_resp = test_client.post("/user-mcp-servers", json=create_data, headers=auth_headers)
+        assert create_resp.status_code == 201
+        server_id = create_resp.json()["id"]
+
+        # Export
+        export_resp = test_client.get(f"/user-mcp-servers/{server_id}/export", headers=auth_headers)
+        exported = export_resp.json()
+
+        # Delete original
+        test_client.delete(f"/user-mcp-servers/{server_id}", headers=auth_headers)
+
+        # Import with new name
+        import_data = {
+            "server_name": "roundtrip_copy",
+            "config": exported["config"]
+        }
+        import_resp = test_client.post("/user-mcp-servers/import", json=import_data, headers=auth_headers)
+        assert import_resp.status_code == 201
+        imported = import_resp.json()
+        assert imported["server_name"] == "roundtrip_copy"
+        assert imported["display_name"] == "Roundtrip Original"
+        assert imported["url"] == "http://localhost:5555/mcp"
+        assert imported["extra_config"]["site_url"] == "https://example.com"
+
+        # Cleanup
+        test_client.delete(f"/user-mcp-servers/{imported['id']}", headers=auth_headers)
+
+
+# --- Internal Name Tests ---
+
+class TestInternalName:
+    def test_internal_name_format(self):
+        from bondable.rest.routers.user_mcp_servers import get_user_server_internal_name
+        name = get_user_server_internal_name("user-12345678-abcd", "my_server")
+        assert name == "user_user-123_my_server"
+
+    def test_internal_name_uniqueness(self):
+        from bondable.rest.routers.user_mcp_servers import get_user_server_internal_name
+        name1 = get_user_server_internal_name("user-aaa", "server")
+        name2 = get_user_server_internal_name("user-bbb", "server")
+        assert name1 != name2


### PR DESCRIPTION
## Summary
- Users can add their own MCP server configs via the Connections screen (form or JSON import)
- Supports none, header (API key), and OAuth2 auth types with secrets encrypted at rest (AES-256-GCM)
- User-defined servers appear alongside global servers in agent tool selection with a "Personal" badge
- Agents using personal MCP tools can be shared — other users can use them via the agent owner's config
- JSON import/export for easy config backup and transfer (supports BOND_MCP_CONFIG entry format)
- SSRF validation on all user-provided URLs including OAuth token_url/authorize_url

## Test plan
- [x] 43 backend integration tests (CRUD, validation, SSRF, encryption, auth isolation, import/export roundtrip)
- [x] 16 Flutter model tests (parsing, equality, isUserDefined flag)
- [x] 1212 existing backend tests pass (0 regressions)
- [x] 127 existing Flutter tests pass (0 regressions)
- [x] Security review: SSRF via token_url identified and fixed
- [ ] Manual E2E: add server via form, test connectivity, create agent with tools, share agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)