### PR TITLE
fix(session): prevent token cache from rolling back uncommitted DB changes

### DIFF
--- a/bondable/bond/auth/mcp_token_cache.py
+++ b/bondable/bond/auth/mcp_token_cache.py
@@ -250,8 +250,6 @@ class MCPTokenCache:
         except Exception as e:
             LOGGER.error(f"Error loading token from database: {e}")
             return None
-        finally:
-            session.close()
 
     def _save_to_database(
         self,
@@ -320,8 +318,6 @@ class MCPTokenCache:
             LOGGER.error(f"Error saving token to database: {e}")
             session.rollback()
             return False
-        finally:
-            session.close()
 
     def _delete_from_database(self, user_id: str, connection_name: str) -> bool:
         """
@@ -355,8 +351,6 @@ class MCPTokenCache:
             LOGGER.error(f"Error deleting token from database: {e}")
             session.rollback()
             return False
-        finally:
-            session.close()
 
     def _refresh_token(
         self,
@@ -673,8 +667,6 @@ class MCPTokenCache:
             LOGGER.error(f"Error clearing user tokens from database: {e}")
             session.rollback()
             return 0
-        finally:
-            session.close()
 
     def has_token(self, user_id: str, connection_name: str) -> bool:
         """
@@ -747,8 +739,6 @@ class MCPTokenCache:
                     }
             except Exception as e:
                 LOGGER.error(f"Error getting user connections from database: {e}")
-            finally:
-                session.close()
 
         return connections
 

--- a/bondable/bond/providers/bedrock/BedrockAgent.py
+++ b/bondable/bond/providers/bedrock/BedrockAgent.py
@@ -2994,6 +2994,12 @@ Remember: Return ONLY the icon name that exists in the above list, and a valid h
                     LOGGER.debug(f"No icon update needed - name and description unchanged")
                     current_icon = bedrock_options.agent_metadata.get('icon_svg', 'none')
                     LOGGER.debug(f"Current icon for agent '{agent_def.name}': '{current_icon}'")
+                # Commit DB changes before calling update_bedrock_agent.
+                # update_bedrock_agent → create_mcp_action_groups → _get_mcp_tool_definitions
+                # triggers OAuth token lookups that open/close sessions on the shared SQLite
+                # connection, causing an implicit ROLLBACK of any uncommitted changes.
+                session.commit()
+
                 bedrock_agent_id, bedrock_agent_alias_id = update_bedrock_agent(
                     agent_def=agent_def,
                     bedrock_agent_id=bedrock_agent_id,

--- a/bondable/rest/routers/mcp.py
+++ b/bondable/rest/routers/mcp.py
@@ -9,7 +9,7 @@ from bondable.bond.config import Config
 from bondable.bond.auth.mcp_token_cache import get_mcp_token_cache
 from bondable.bond.providers.bedrock.BedrockMCP import _get_auth_headers_for_server as get_mcp_auth_headers, AuthorizationRequiredError, TokenExpiredError
 from bondable.rest.models.auth import User
-from bondable.rest.dependencies.auth import get_current_user
+from bondable.rest.dependencies.auth import get_current_user, get_current_user_with_token
 
 router = APIRouter(prefix="/mcp", tags=["MCP"])
 LOGGER = logging.getLogger(__name__)
@@ -66,7 +66,7 @@ class MCPToolsGroupedResponse(BaseModel):
 
 @router.get("/tools")
 async def list_mcp_tools(
-    current_user: Annotated[User, Depends(get_current_user)],
+    user_and_token: Annotated[tuple[User, str], Depends(get_current_user_with_token)],
     grouped: bool = Query(False, description="Return tools grouped by server with connection status")
 ) -> Union[List[MCPToolResponse], MCPToolsGroupedResponse]:
     """
@@ -82,6 +82,7 @@ async def list_mcp_tools(
     from fastmcp.client.transports import SSETransport
     from fastmcp.client.transports import StreamableHttpTransport  # Use fastmcp's wrapper which works with fastmcp.Client
 
+    current_user, jwt_token = user_and_token
     LOGGER.info(f"[MCP Tools] Request received from user: {current_user.user_id} ({current_user.email}), grouped={grouped}")
 
     try:
@@ -128,7 +129,7 @@ async def list_mcp_tools(
 
             try:
                 # Get authentication headers (handles oauth2, bond_jwt, static)
-                auth_headers = get_mcp_auth_headers(server_name, server_config, current_user)
+                auth_headers = get_mcp_auth_headers(server_name, server_config, current_user, jwt_token=jwt_token)
                 LOGGER.info(f"[MCP Tools] Server '{server_name}' authenticated, headers: {list(auth_headers.keys())}")
 
                 # Get server URL and transport type

--- a/tests/test_agent_record_transaction.py
+++ b/tests/test_agent_record_transaction.py
@@ -10,6 +10,7 @@ Verifies that:
 import pytest
 from unittest.mock import MagicMock, patch
 from bondable.bond.providers.bedrock.BedrockAgent import BedrockAgentProvider, BedrockAgent
+from bondable.bond.providers.bedrock.BedrockMetadata import BedrockAgentOptions
 from bondable.bond.providers.metadata import AgentRecord
 
 
@@ -67,8 +68,17 @@ class TestAgentRecordCommitBeforeBedrockCalls:
         provider, session = _make_provider()
         agent_def = MockAgentDef(id=None)  # New agent
 
-        # First query (line 2878 check for existing AgentRecord) returns None
-        session.query.return_value.filter_by.return_value.first.return_value = None
+        # Mock the query chain to return None for the initial AgentRecord check,
+        # then return a mock BedrockAgentOptions for the post-commit re-query.
+        mock_bedrock_options = MagicMock(spec=BedrockAgentOptions)
+        mock_bedrock_options.bedrock_agent_id = "bedrock-id-123"
+        mock_bedrock_options.bedrock_agent_alias_id = "alias-id-456"
+        mock_bedrock_options.mcp_tools = []
+        mock_bedrock_options.agent_metadata = {}
+        session.query.return_value.filter_by.return_value.first.side_effect = [
+            None,              # line 2878: no existing AgentRecord
+            mock_bedrock_options,  # line 3016: re-query BedrockAgentOptions after commit
+        ]
 
         provider.create_or_update_agent_resource(agent_def, owner_user_id="user-1")
 

--- a/tests/test_session_mcp_tools.py
+++ b/tests/test_session_mcp_tools.py
@@ -1,0 +1,205 @@
+"""Regression tests for MCP tools persistence through agent update flow.
+
+Verifies that mcp_tools survive the full create_or_update_agent pipeline,
+including the OAuth token lookups that previously rolled back uncommitted
+changes on the shared scoped SQLite session.
+"""
+import pytest
+import os
+import tempfile
+import uuid
+from unittest.mock import patch, MagicMock
+
+# --- Test Database Setup (must happen before app import) ---
+_test_db_file = tempfile.NamedTemporaryFile(suffix='.db', delete=False)
+TEST_METADATA_DB_URL = f"sqlite:///{_test_db_file.name}"
+os.environ['METADATA_DB_URL'] = TEST_METADATA_DB_URL
+os.environ['OAUTH2_ENABLED_PROVIDERS'] = 'cognito'
+os.environ['COOKIE_SECURE'] = 'false'
+os.environ['ALLOW_ALL_EMAILS'] = 'true'
+
+from bondable.bond.config import Config
+from bondable.bond.definition import AgentDefinition
+from bondable.bond.providers.metadata import AgentRecord
+from bondable.bond.providers.bedrock.BedrockMetadata import BedrockAgentOptions
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cleanup_test_db():
+    yield
+    db_path = TEST_METADATA_DB_URL.replace("sqlite:///", "")
+    if os.path.exists(db_path):
+        try:
+            os.remove(db_path)
+        except Exception:
+            pass
+
+
+@pytest.fixture
+def provider():
+    return Config.config().get_provider()
+
+
+def _unique_id():
+    return f"test_{uuid.uuid4().hex[:12]}"
+
+
+def _seed_agent(provider, agent_id, user_id, mcp_tools=None):
+    """Create an agent with BedrockAgentOptions directly in the DB."""
+    session = provider.metadata.get_db_session()
+    rec = AgentRecord(
+        agent_id=agent_id,
+        name="Test Agent",
+        introduction="",
+        reminder="",
+        owner_user_id=user_id,
+    )
+    session.add(rec)
+    session.flush()
+    opts = BedrockAgentOptions(
+        agent_id=agent_id,
+        bedrock_agent_id=f"FAKE{agent_id[:8]}",
+        bedrock_agent_alias_id=f"ALIAS{agent_id[:8]}",
+        temperature=0.0,
+        tools={},
+        tool_resources={},
+        mcp_tools=mcp_tools or [],
+        mcp_resources=[],
+        agent_metadata={},
+        file_storage="direct",
+    )
+    session.add(opts)
+    session.commit()
+    return opts
+
+
+class TestMcpToolsPersistence:
+    """Regression: mcp_tools must survive the full create_or_update_agent flow."""
+
+    def test_mcp_tools_persist_through_resource_update(self, provider):
+        """mcp_tools set during update must be in the DB after create_or_update_agent_resource.
+
+        This exercises the real DB session lifecycle (scoped session, commit ordering)
+        while mocking only the external AWS calls.
+        """
+        agent_id = _unique_id()
+        user_id = _unique_id()
+        bedrock_agent_id = f"FAKE{agent_id[:8]}"
+        bedrock_alias_id = f"ALIAS{agent_id[:8]}"
+        _seed_agent(provider, agent_id, user_id, mcp_tools=[])
+
+        agent_def = MagicMock()
+        agent_def.id = agent_id
+        agent_def.name = "Test Agent"
+        agent_def.description = "Test"
+        agent_def.instructions = "You are a test assistant."
+        agent_def.introduction = ""
+        agent_def.reminder = ""
+        agent_def.tools = {}
+        agent_def.tool_resources = {}
+        agent_def.metadata = {}
+        agent_def.model = "us.anthropic.claude-sonnet-4-6"
+        agent_def.temperature = 0.0
+        agent_def.mcp_tools = ["sbelcrm:search_contacts", "sbelcrm:get_contact"]
+        agent_def.mcp_resources = []
+        agent_def.file_storage = "direct"
+
+        with patch("bondable.bond.providers.bedrock.BedrockAgent.update_bedrock_agent",
+                    return_value=(bedrock_agent_id, bedrock_alias_id)), \
+             patch("bondable.bond.providers.bedrock.BedrockAgent.BedrockAgent") as MockBA:
+            mock_agent = MagicMock()
+            mock_agent.get_agent_id.return_value = agent_id
+            mock_agent.get_name.return_value = "Test Agent"
+            MockBA.return_value = mock_agent
+
+            # Mock the bedrock_agent_client.get_agent call inside create_or_update_agent_resource
+            provider.agents.bedrock_agent_client = MagicMock()
+            provider.agents.bedrock_agent_client.get_agent.return_value = {
+                "agent": {"description": "Test", "foundationModel": "claude"}
+            }
+
+            provider.agents.create_or_update_agent_resource(agent_def, owner_user_id=user_id)
+
+        # Verify directly in DB
+        session = provider.metadata.get_db_session()
+        session.expire_all()
+        opts = session.query(BedrockAgentOptions).filter_by(agent_id=agent_id).first()
+        assert opts is not None
+        assert opts.mcp_tools == ["sbelcrm:search_contacts", "sbelcrm:get_contact"], \
+            f"mcp_tools silently lost during agent update: {opts.mcp_tools}"
+
+    def test_mcp_tools_cleared_when_empty_list(self, provider):
+        """Setting mcp_tools=[] should clear them in the DB."""
+        agent_id = _unique_id()
+        user_id = _unique_id()
+        bedrock_agent_id = f"FAKE{agent_id[:8]}"
+        bedrock_alias_id = f"ALIAS{agent_id[:8]}"
+        _seed_agent(provider, agent_id, user_id, mcp_tools=["sbelcrm:old_tool"])
+
+        agent_def = MagicMock()
+        agent_def.id = agent_id
+        agent_def.name = "Test Agent"
+        agent_def.description = "Test"
+        agent_def.instructions = "You are a test assistant."
+        agent_def.introduction = ""
+        agent_def.reminder = ""
+        agent_def.tools = {}
+        agent_def.tool_resources = {}
+        agent_def.metadata = {}
+        agent_def.model = "us.anthropic.claude-sonnet-4-6"
+        agent_def.temperature = 0.0
+        agent_def.mcp_tools = []
+        agent_def.mcp_resources = []
+        agent_def.file_storage = "direct"
+
+        with patch("bondable.bond.providers.bedrock.BedrockAgent.update_bedrock_agent",
+                    return_value=(bedrock_agent_id, bedrock_alias_id)), \
+             patch("bondable.bond.providers.bedrock.BedrockAgent.BedrockAgent") as MockBA:
+            mock_agent = MagicMock()
+            mock_agent.get_agent_id.return_value = agent_id
+            mock_agent.get_name.return_value = "Test Agent"
+            MockBA.return_value = mock_agent
+
+            provider.agents.bedrock_agent_client = MagicMock()
+            provider.agents.bedrock_agent_client.get_agent.return_value = {
+                "agent": {"description": "Test", "foundationModel": "claude"}
+            }
+
+            provider.agents.create_or_update_agent_resource(agent_def, owner_user_id=user_id)
+
+        session = provider.metadata.get_db_session()
+        session.expire_all()
+        opts = session.query(BedrockAgentOptions).filter_by(agent_id=agent_id).first()
+        assert opts.mcp_tools == [], f"mcp_tools should be empty: {opts.mcp_tools}"
+
+    def test_token_cache_query_does_not_rollback_pending_changes(self, provider):
+        """Token cache reads must not rollback another module's uncommitted changes.
+
+        This is the exact failure mode: the mcp_token_cache used to call
+        session.close() on the shared scoped session, rolling back any
+        pending UPDATE from the agent update flow.
+        """
+        agent_id = _unique_id()
+        user_id = _unique_id()
+        _seed_agent(provider, agent_id, user_id, mcp_tools=[])
+
+        # Simulate: set mcp_tools but DON'T commit yet
+        session = provider.metadata.get_db_session()
+        opts = session.query(BedrockAgentOptions).filter_by(agent_id=agent_id).first()
+        opts.mcp_tools = ["sbelcrm:test_tool"]
+        assert opts in session.dirty
+
+        # Now simulate what _get_mcp_tool_definitions does: token cache lookup
+        from bondable.bond.auth.mcp_token_cache import get_mcp_token_cache
+        cache = get_mcp_token_cache()
+        # This read should NOT rollback our pending change
+        cache._load_from_database(user_id, "nonexistent_connection")
+
+        # Now commit — the change should still be there
+        session.commit()
+
+        # Verify
+        session.expire_all()
+        opts2 = session.query(BedrockAgentOptions).filter_by(agent_id=agent_id).first()
+        assert opts2.mcp_tools == ["sbelcrm:test_tool"], \
+            f"Token cache query rolled back pending mcp_tools change: {opts2.mcp_tools}"


### PR DESCRIPTION
## Summary
- **Remove `session.close()` from MCPTokenCache** — the shared `scoped_session` was being closed mid-transaction during agent updates, silently rolling back uncommitted changes (e.g., `mcp_tools`)
- **Add defensive early `session.commit()` in BedrockAgent** — commits DB changes before calling `update_bedrock_agent`, which triggers nested OAuth token lookups on the shared session
- **Pass JWT token through `/mcp/tools` endpoint** — `bond_jwt` auth type servers now receive proper Bearer authentication
- **Fix pre-existing broken test** in `test_agent_record_transaction.py` — mock now handles post-commit re-query of `BedrockAgentOptions`

## Test plan
- [x] 3 new regression tests in `test_session_mcp_tools.py` — verify mcp_tools survive full agent update pipeline
- [x] All 48 existing token cache tests pass
- [x] All 4 agent record transaction tests pass (including fixed test)
- [x] 1236 total backend tests passing, 0 new failures
- [ ] Manual: update an agent with MCP tools and verify they persist after save

🤖 Generated with [Claude Code](https://claude.com/claude-code)