### PR TITLE
fix(infra): include bond_chat_ui package in Docker build hash detection

### DIFF
--- a/deployment/terraform-existing-vpc/build-stages.tf
+++ b/deployment/terraform-existing-vpc/build-stages.tf
@@ -25,6 +25,10 @@ locals {
       for f in fileset("${path.module}/../../flutterui/lib", "**/*.dart") :
       filemd5("${path.module}/../../flutterui/lib/${f}")
     ])),
+    md5(join("", [
+      for f in fileset("${path.module}/../../packages/bond_chat_ui/lib", "**/*.dart") :
+      filemd5("${path.module}/../../packages/bond_chat_ui/lib/${f}")
+    ])),
     var.maintenance_mode ? "maintenance" : "normal",
     var.maintenance_message,
     var.theme_config_path,


### PR DESCRIPTION
## Summary
- Add `packages/bond_chat_ui/lib/**/*.dart` to the Terraform content-hash image tag computation in `build-stages.tf`
- Without this, changes to the refactored chat UI package (moved from `flutterui/` to `packages/bond_chat_ui/`) would not trigger a Docker rebuild

## Test plan
- [x] `terraform validate` passes
- [x] `terraform plan` shows new image tag (`61c917eeead4` → `f64196a614b6`), confirming the hash now includes bond_chat_ui files
- [x] Deployed successfully — smoke test passes (health 200, frontend 200, CRM MCP 200)

🤖 Generated with [Claude Code](https://claude.com/claude-code)