### PR TITLE
fix(eks): resolve PDB deadlock and AL2 custom AMI bootstrap

### DIFF
--- a/deployment/terraform-existing-vpc/eks-kubernetes.tf
+++ b/deployment/terraform-existing-vpc/eks-kubernetes.tf
@@ -387,7 +387,7 @@ resource "kubernetes_pod_disruption_budget_v1" "backend" {
   }
 
   spec {
-    min_available = "1"
+    max_unavailable = "1"
 
     selector {
       match_labels = {

--- a/deployment/terraform-existing-vpc/eks.tf
+++ b/deployment/terraform-existing-vpc/eks.tf
@@ -109,9 +109,21 @@ module "eks" {
       desired_size = var.eks_node_desired_count
 
       # Custom AMI support for company-certified images
-      ami_id                     = var.eks_custom_ami_id != "" ? var.eks_custom_ami_id : null
-      ami_type                   = var.eks_custom_ami_id != "" ? "CUSTOM" : "AL2023_x86_64_STANDARD"
-      enable_bootstrap_user_data = var.eks_custom_ami_id != "" ? true : false
+      # The golden AMI is AL2-based (CIS hardened) and needs the AL2 bootstrap script,
+      # not the AL2023 NodeConfig YAML format. We set ami_type to CUSTOM and point
+      # user_data_template_path to the AL2 template to satisfy v21's requirement.
+      ami_id                         = var.eks_custom_ami_id != "" ? var.eks_custom_ami_id : null
+      ami_type                       = var.eks_custom_ami_id != "" ? "CUSTOM" : "AL2023_x86_64_STANDARD"
+      enable_bootstrap_user_data     = var.eks_custom_ami_id != "" ? true : false
+      use_latest_ami_release_version = var.eks_custom_ami_id != "" ? false : true
+      user_data_template_path        = var.eks_custom_ami_id != "" ? "${path.module}/templates/al2_user_data.tpl" : null
+
+      # Force node group updates through even if pod eviction fails (e.g. PDB deadlock).
+      # Without this, rolling updates fail after ~30 min with PodEvictionFailure.
+      force_update_version = true
+      update_config = {
+        max_unavailable = 1
+      }
 
       # v21 changed default from true to false — keep enabled for prod observability
       enable_monitoring = true

--- a/deployment/terraform-existing-vpc/templates/al2_user_data.tpl
+++ b/deployment/terraform-existing-vpc/templates/al2_user_data.tpl
@@ -1,0 +1,12 @@
+%{ if enable_bootstrap_user_data ~}
+#!/bin/bash
+set -e
+%{ endif ~}
+${pre_bootstrap_user_data ~}
+%{ if enable_bootstrap_user_data ~}
+B64_CLUSTER_CA=${cluster_auth_base64}
+API_SERVER_URL=${cluster_endpoint}
+/etc/eks/bootstrap.sh ${cluster_name} ${bootstrap_extra_args} --b64-cluster-ca $B64_CLUSTER_CA --apiserver-endpoint $API_SERVER_URL \
+  --ip-family ${cluster_ip_family} --service-${cluster_ip_family}-cidr ${cluster_service_cidr}
+${post_bootstrap_user_data ~}
+%{ endif ~}


### PR DESCRIPTION
## Summary
- Switch PDB from `min_available` to `max_unavailable` to prevent eviction deadlock during rolling updates with low replica counts
- Add AL2 user data bootstrap template for CIS-hardened golden AMIs (needed because custom AMI is AL2-based, not AL2023)
- Add `force_update_version` and `update_config.max_unavailable` to prevent 30min PodEvictionFailure timeouts
- Add `use_latest_ami_release_version = false` when using custom AMI

## Test plan
- [ ] `terraform plan` shows expected changes to PDB and node group config
- [ ] Rolling update completes without PodEvictionFailure timeout
- [ ] Nodes using custom AMI bootstrap correctly with AL2 script

🤖 Generated with [Claude Code](https://claude.com/claude-code)