### PR TITLE
Fix/bundle test issues

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from bondable.rest.routers.auth import limiter as _auth_limiter
+
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -50,10 +52,5 @@ def _reset_rate_limiter():
     (e.g. /auth/cognito/callback at 10/min). Without per-test reset,
     later tests in the suite see 429s purely from earlier tests' calls.
     """
-    try:
-        from bondable.rest.routers.auth import limiter
-        limiter.reset()
-    except Exception:
-        # Don't fail collection if the import path changes; the fixture is best-effort.
-        pass
+    _auth_limiter.reset()
     yield

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,3 +40,20 @@ def pytest_collection_modifyitems(config, items):
         for item in items:
             if "investigation" in item.keywords:
                 item.add_marker(skip_investigation)
+
+
+@pytest.fixture(autouse=True)
+def _reset_rate_limiter():
+    """Reset slowapi rate limiter before each test.
+
+    Multiple tests across the suite hit rate-limited auth endpoints
+    (e.g. /auth/cognito/callback at 10/min). Without per-test reset,
+    later tests in the suite see 429s purely from earlier tests' calls.
+    """
+    try:
+        from bondable.rest.routers.auth import limiter
+        limiter.reset()
+    except Exception:
+        # Don't fail collection if the import path changes; the fixture is best-effort.
+        pass
+    yield

--- a/tests/test_alembic_migrations.py
+++ b/tests/test_alembic_migrations.py
@@ -365,6 +365,18 @@ class TestMetadataInit:
                     "created_at DATETIME, updated_at DATETIME, "
                     "PRIMARY KEY (thread_id, user_id))"
                 ))
+                # OAuth state tables required by later migrations (c4d2e8f10a7b, d5e3f9a21b8c)
+                conn.execute(sa.text(
+                    "CREATE TABLE auth_oauth_states (state VARCHAR PRIMARY KEY, "
+                    "provider_name VARCHAR NOT NULL, code_verifier VARCHAR, "
+                    "redirect_uri VARCHAR, platform VARCHAR, created_at DATETIME)"
+                ))
+                conn.execute(sa.text(
+                    "CREATE TABLE connection_oauth_states (state VARCHAR PRIMARY KEY, "
+                    "user_id VARCHAR NOT NULL REFERENCES users(id), "
+                    "connection_name VARCHAR NOT NULL, code_verifier VARCHAR, "
+                    "redirect_uri VARCHAR, created_at DATETIME)"
+                ))
                 conn.commit()
             engine.dispose()
 
@@ -443,6 +455,18 @@ class TestMetadataInit:
                     "headers_encrypted VARCHAR, oauth_config_encrypted VARCHAR, "
                     "is_active BOOLEAN NOT NULL DEFAULT 1, "
                     "created_at DATETIME, updated_at DATETIME)"
+                ))
+                # OAuth state tables required by later migrations (c4d2e8f10a7b, d5e3f9a21b8c)
+                conn.execute(sa.text(
+                    "CREATE TABLE auth_oauth_states (state VARCHAR PRIMARY KEY, "
+                    "provider_name VARCHAR NOT NULL, code_verifier VARCHAR, "
+                    "redirect_uri VARCHAR, platform VARCHAR, created_at DATETIME)"
+                ))
+                conn.execute(sa.text(
+                    "CREATE TABLE connection_oauth_states (state VARCHAR PRIMARY KEY, "
+                    "user_id VARCHAR NOT NULL REFERENCES users(id), "
+                    "connection_name VARCHAR NOT NULL, code_verifier VARCHAR, "
+                    "redirect_uri VARCHAR, created_at DATETIME)"
                 ))
                 conn.commit()
             engine.dispose()

--- a/tests/test_atlassian_mcp.py
+++ b/tests/test_atlassian_mcp.py
@@ -9,7 +9,10 @@ Usage:
 import asyncio
 import json
 import logging
+import pytest
 from bondable.bond.config import Config
+
+pytestmark = pytest.mark.integration
 
 logger = logging.getLogger(__name__)
 from bondable.bond.providers.bedrock.BedrockMCP import _get_mcp_tool_definitions
@@ -19,6 +22,7 @@ print("Atlassian MCP Connection Test")
 print("=" * 70)
 print()
 
+@pytest.mark.asyncio
 async def test_atlassian_mcp():
     """Test connection to Atlassian MCP server."""
 

--- a/tests/test_bedrock_mcp_functionality.py
+++ b/tests/test_bedrock_mcp_functionality.py
@@ -11,6 +11,8 @@ from unittest.mock import patch
 from bondable.bond.config import Config
 from bondable.bond.definition import AgentDefinition
 
+pytestmark = pytest.mark.integration
+
 
 @pytest.fixture(scope="module")
 def provider():

--- a/tests/test_mcp_allowed_tools.py
+++ b/tests/test_mcp_allowed_tools.py
@@ -110,7 +110,14 @@ class TestBedrockMCPAllowedToolsFilter:
 
     def _run_sync(self, coro):
         import asyncio
-        return asyncio.get_event_loop().run_until_complete(coro)
+        # asyncio.get_event_loop() raises in Py3.10+ when no loop exists in the
+        # current thread (e.g. after an earlier test closed its loop). Create a
+        # fresh loop per test to keep behavior independent of test ordering.
+        loop = asyncio.new_event_loop()
+        try:
+            return loop.run_until_complete(coro)
+        finally:
+            loop.close()
 
     @patch("bondable.bond.providers.bedrock.BedrockMCP.StreamableHttpTransport")
     @patch("bondable.bond.providers.bedrock.BedrockMCP.Client")

--- a/tests/test_mcp_running_server.py
+++ b/tests/test_mcp_running_server.py
@@ -15,7 +15,10 @@ import asyncio
 import json
 import logging
 import jwt
+import pytest
 from bondable.bond.config import Config
+
+pytestmark = pytest.mark.integration
 
 logger = logging.getLogger(__name__)
 from bondable.bond.providers.bedrock.BedrockMCP import execute_mcp_tool
@@ -35,6 +38,7 @@ print("=" * 70)
 print()
 
 
+@pytest.mark.asyncio
 async def test_mcp_auth():
     """Test MCP authentication with a running server."""
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the test suite, focusing on test isolation, database migration test coverage, and test organization. Key changes include resetting the rate limiter before each test to avoid cross-test interference, adding missing OAuth state tables to migration tests, marking integration tests for clarity, and ensuring event loop isolation in async tests.

**Test isolation and reliability:**

* Added an autouse pytest fixture in `conftest.py` to reset the auth rate limiter (`_auth_limiter`) before each test, preventing rate limit errors from affecting subsequent tests. [[1]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R3-R4) [[2]](diffhunk://#diff-e52e4ddd58b7ef887ab03c04116e676f6280b824ab7469d5d3080e5cba4f2128R45-R56)
* Modified `_run_sync` in `test_mcp_allowed_tools.py` to create a new asyncio event loop per test, ensuring tests remain independent and do not fail due to closed or missing event loops.

**Database migration test improvements:**

* Added creation of `auth_oauth_states` and `connection_oauth_states` tables to migration tests in `test_alembic_migrations.py` to ensure coverage of later migration dependencies. [[1]](diffhunk://#diff-50886598bbec85c3c9a90c166c061067cee560cdfdceeb24cea601ca53b7a891R368-R379) [[2]](diffhunk://#diff-50886598bbec85c3c9a90c166c061067cee560cdfdceeb24cea601ca53b7a891R459-R470)

**Test organization and clarity:**

* Marked relevant test modules (`test_atlassian_mcp.py`, `test_bedrock_mcp_functionality.py`, `test_mcp_running_server.py`) with `pytest.mark.integration` to distinguish integration tests from unit tests. [[1]](diffhunk://#diff-071a15089896c5708d05ba9b095ee56db0e302c6f611360a529eb0dffc2c1a2eR12-R16) [[2]](diffhunk://#diff-222e9ac573268a359b345ccaeb3f97e1b73a5b3babe9ac1616d5b9564190ac4fR14-R15) [[3]](diffhunk://#diff-f7ca1f95e61ad858717fb3aeb7f28c64ed1a6b7f3871ad422532119d71b86e60R18-R22)
* Marked asynchronous test functions with `pytest.mark.asyncio` to ensure proper async test execution. [[1]](diffhunk://#diff-071a15089896c5708d05ba9b095ee56db0e302c6f611360a529eb0dffc2c1a2eR25) [[2]](diffhunk://#diff-f7ca1f95e61ad858717fb3aeb7f28c64ed1a6b7f3871ad422532119d71b86e60R41)