### PR TITLE
feat(terraform): add ECS Express Mode as third compute platform

### DIFF
--- a/bondable/bond/providers/bedrock/BedrockAgent.py
+++ b/bondable/bond/providers/bedrock/BedrockAgent.py
@@ -87,6 +87,10 @@ MIN_RECORDS_FOR_CSV = 5
 # Retry configuration for transient connection errors on invoke_agent calls
 MAX_INVOKE_RETRIES = 2
 INVOKE_RETRY_BASE_DELAY = 1.0  # seconds; exponential backoff (1s, 2s)
+# Retry configuration for EventStreamError during continuation stream processing.
+# Stream failures (e.g. dependencyFailedException after 30-60s) are different from
+# connection errors at call time — if a stream retry fails, a second is almost certainly wasted.
+MAX_STREAM_RETRIES = 1
 
 class BedrockAgent(Agent):
     """Bedrock implementation of the Agent interface"""
@@ -2242,7 +2246,7 @@ Please integrate any relevant insights from the documents with your analysis of 
                 "actionGroup": action_group,
                 "apiPath": api_path,
                 "httpMethod": "POST",
-                "httpStatusCode": 500,
+                "httpStatusCode": 200,
                 "responseBody": {
                     "application/json": {
                         "body": json.dumps({"error": "Tool execution failed - no response was generated. Please inform the user that the operation could not be completed."})
@@ -2286,163 +2290,214 @@ Please integrate any relevant insights from the documents with your analysis of 
             }
         }
 
-        # Get continuation response with retry for transient connection errors.
-        # Bedrock may close the connection if the payload is large or on transient network issues.
-        continuation_stream = None
-        for attempt in range(MAX_INVOKE_RETRIES + 1):
-            invoke_start = time.monotonic()
-            try:
-                if attempt > 0:
-                    delay = INVOKE_RETRY_BASE_DELAY * (2 ** (attempt - 1))
-                    LOGGER.warning(
-                        f"[Continuation] Retry {attempt}/{MAX_INVOKE_RETRIES} "
-                        f"after {delay}s delay (invocationId={invocation_id}, depth={depth})"
-                    )
-                    time.sleep(delay)
+        # Outer retry loop: wraps both invoke_agent and stream processing.
+        # Retries on EventStreamError (e.g. dependencyFailedException) only if no content
+        # has been yielded yet. Stream failures are different from connection errors —
+        # they occur after the call succeeds but the model fails mid-generation.
+        any_content_yielded = False
 
+        for stream_attempt in range(MAX_STREAM_RETRIES + 1):
+            # Get continuation response with retry for transient connection errors.
+            # Bedrock may close the connection if the payload is large or on transient network issues.
+            continuation_stream = None
+            for attempt in range(MAX_INVOKE_RETRIES + 1):
                 invoke_start = time.monotonic()
-                total_elapsed = invoke_start - continuation_start_time
-                LOGGER.info(
-                    f"[Continuation] Calling invoke_agent at depth={depth}, attempt={attempt + 1}, "
-                    f"elapsed_since_returnControl={total_elapsed:.3f}s, session={session_id}"
-                )
-                continuation_response = self.bond_provider.bedrock_agent_runtime_client.invoke_agent(**continuation_request)
-                continuation_stream = continuation_response.get('completion')
-                invoke_elapsed = time.monotonic() - invoke_start
-                LOGGER.info(
-                    f"[Continuation] invoke_agent succeeded at depth={depth} in {invoke_elapsed:.3f}s, "
-                    f"payload={total_result_bytes} bytes, "
-                    f"stream={'present' if continuation_stream else 'absent'}"
-                    f"{f', attempt={attempt + 1}' if attempt > 0 else ''}"
-                )
-                break  # Success - exit retry loop
+                try:
+                    if attempt > 0:
+                        delay = INVOKE_RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                        LOGGER.warning(
+                            f"[Continuation] Retry {attempt}/{MAX_INVOKE_RETRIES} "
+                            f"after {delay}s delay (invocationId={invocation_id}, depth={depth})"
+                        )
+                        time.sleep(delay)
 
-            except (RemoteDisconnected, ConnectionClosedError, ConnectionError, OSError) as e:
-                invoke_elapsed = time.monotonic() - invoke_start
-                LOGGER.warning(
-                    f"[Continuation] Connection error on attempt {attempt + 1}/"
-                    f"{MAX_INVOKE_RETRIES + 1} at depth={depth} after {invoke_elapsed:.3f}s, "
-                    f"payload={total_result_bytes} bytes: {type(e).__name__}: {e}"
-                )
-                if attempt == MAX_INVOKE_RETRIES:
-                    LOGGER.error(
-                        f"[Continuation] All {MAX_INVOKE_RETRIES + 1} attempts failed. "
-                        f"Tool result payload size: {total_result_bytes} bytes. "
-                        f"This may indicate the payload exceeds the model's context window or a transient network issue."
+                    invoke_start = time.monotonic()
+                    total_elapsed = invoke_start - continuation_start_time
+                    LOGGER.info(
+                        f"[Continuation] Calling invoke_agent at depth={depth}, attempt={attempt + 1}, "
+                        f"stream_attempt={stream_attempt + 1}/{MAX_STREAM_RETRIES + 1}, "
+                        f"elapsed_since_returnControl={total_elapsed:.3f}s, session={session_id}"
+                    )
+                    continuation_response = self.bond_provider.bedrock_agent_runtime_client.invoke_agent(**continuation_request)
+                    continuation_stream = continuation_response.get('completion')
+                    invoke_elapsed = time.monotonic() - invoke_start
+                    LOGGER.info(
+                        f"[Continuation] invoke_agent succeeded at depth={depth} in {invoke_elapsed:.3f}s, "
+                        f"payload={total_result_bytes} bytes, "
+                        f"stream={'present' if continuation_stream else 'absent'}"
+                        f"{f', attempt={attempt + 1}' if attempt > 0 else ''}"
+                    )
+                    break  # Success - exit inner retry loop
+
+                except (RemoteDisconnected, ConnectionClosedError, ConnectionError, OSError) as e:
+                    invoke_elapsed = time.monotonic() - invoke_start
+                    LOGGER.warning(
+                        f"[Continuation] Connection error on attempt {attempt + 1}/"
+                        f"{MAX_INVOKE_RETRIES + 1} at depth={depth} after {invoke_elapsed:.3f}s, "
+                        f"payload={total_result_bytes} bytes: {type(e).__name__}: {e}"
+                    )
+                    if attempt == MAX_INVOKE_RETRIES:
+                        LOGGER.error(
+                            f"[Continuation] All {MAX_INVOKE_RETRIES + 1} attempts failed. "
+                            f"Tool result payload size: {total_result_bytes} bytes. "
+                            f"This may indicate the payload exceeds the model's context window or a transient network issue."
+                        )
+                        yield (
+                            f"\n\nI was unable to send the tool results back to the agent because "
+                            f"the response was too large ({total_result_bytes} bytes), even after compaction. "
+                            f"Please try a more specific query to get fewer results.\n"
+                        )
+                        return
+
+                except Exception as e:
+                    LOGGER.exception(
+                        f"[Continuation] invoke_agent failed at depth={depth}, "
+                        f"invocationId={invocation_id}: {type(e).__name__}: {e}"
                     )
                     yield (
-                        f"\n\nI was unable to send the tool results back to the agent because "
-                        f"the response was too large ({total_result_bytes} bytes), even after compaction. "
-                        f"Please try a more specific query to get fewer results.\n"
+                        f"\n\nI encountered an error while processing the tool results "
+                        f"({type(e).__name__}). Please try your request again.\n"
                     )
                     return
 
-            except Exception as e:
-                LOGGER.exception(
-                    f"[Continuation] invoke_agent failed at depth={depth}, "
-                    f"invocationId={invocation_id}: {type(e).__name__}: {e}"
+            # Process continuation stream with error handling
+            try:
+                if continuation_stream:
+                    cont_event_count = 0
+                    for cont_event in continuation_stream:
+                        cont_event_count += 1
+                        cont_event_type = list(cont_event.keys())[0] if cont_event else 'unknown'
+                        LOGGER.debug(f"[Continuation] depth={depth}, event #{cont_event_count}, type: {cont_event_type}")
+
+                        if 'chunk' in cont_event:
+                            text = self._handle_chunk_event(cont_event['chunk'])
+                            if text:
+                                yield text
+                                full_content += text
+                                any_content_yielded = True
+                        elif 'files' in cont_event:
+                            # Note: File handling in continuation is handled by the caller
+                            # We just pass the event through
+                            yield {'files_event': cont_event}
+                            any_content_yielded = True
+                        elif 'returnControl' in cont_event:
+                            # Agent wants to call another tool - handle recursively
+                            nested_return_control = cont_event['returnControl']
+                            LOGGER.info(f"[Continuation] Received nested returnControl at depth={depth} - recursing to depth={depth + 1}")
+
+                            # Recursively call ourselves to handle the nested tool call
+                            nested_generator = self._handle_continuation_response(
+                                return_control=nested_return_control,
+                                session_id=session_id,
+                                thread_id=thread_id,
+                                seen_file_hashes=seen_file_hashes,
+                                attachments=attachments,
+                                depth=depth + 1
+                            )
+
+                            # Forward all yielded items from nested handler
+                            nested_text_len = 0
+                            for nested_item in nested_generator:
+                                if isinstance(nested_item, str):
+                                    yield nested_item
+                                    full_content += nested_item
+                                    any_content_yielded = True
+                                    nested_text_len += len(nested_item)
+                                elif isinstance(nested_item, dict):
+                                    # Forward files_event and capture session_state
+                                    if 'files_event' in nested_item:
+                                        yield nested_item
+                                        any_content_yielded = True
+                                    if nested_item.get('session_state'):
+                                        new_session_state = nested_item['session_state']
+
+                            LOGGER.info(f"[Continuation] Nested handler at depth={depth + 1} completed, yielded {nested_text_len} chars of text")
+
+                        elif 'sessionState' in cont_event:
+                            new_session_state = cont_event['sessionState']
+                            LOGGER.debug(f"[Continuation] Received sessionState update at depth={depth}")
+
+                        elif 'trace' in cont_event:
+                            LOGGER.debug(f"[Continuation] Received trace event at depth={depth}")
+
+                    LOGGER.info(f"[Continuation] Processed {cont_event_count} events from continuation stream at depth={depth}")
+                else:
+                    LOGGER.warning(f"[Continuation] No continuation stream received at depth={depth}")
+
+                # Stream completed successfully - exit outer retry loop
+                break
+
+            except EventStreamError as e:
+                # Bedrock raises EventStreamError (e.g. dependencyFailedException) when the
+                # underlying model fails during generation. This can be transient.
+                error_code = getattr(e, 'code', 'unknown')
+                LOGGER.error(
+                    f"[Continuation] EventStreamError at depth={depth}: {error_code} - {e}. "
+                    f"Tool result status codes: {result_summary}. "
+                    f"stream_attempt={stream_attempt + 1}/{MAX_STREAM_RETRIES + 1}, "
+                    f"any_content_yielded={any_content_yielded}, "
+                    f"content_length={len(full_content)}"
+                )
+
+                if any_content_yielded or stream_attempt >= MAX_STREAM_RETRIES:
+                    # Cannot retry: content already sent to user, or retries exhausted
+                    if any_content_yielded:
+                        LOGGER.warning(
+                            f"[Continuation] Cannot retry EventStreamError - "
+                            f"content already yielded to user (text={len(full_content)} chars)"
+                        )
+                        yield (
+                            f"\n\nThe agent encountered an error processing the tool results "
+                            f"(Bedrock error: {error_code}). This can happen when tool results "
+                            f"are very large or in an unexpected format. "
+                            f"Please try a more specific query.\n"
+                        )
+                    else:
+                        LOGGER.warning(
+                            f"[Continuation] All {MAX_STREAM_RETRIES + 1} stream attempts exhausted "
+                            f"for EventStreamError ({error_code})"
+                        )
+                        yield (
+                            f"\n\nThe agent encountered a transient error "
+                            f"(Bedrock error: {error_code}). "
+                            f"Please try your request again.\n"
+                        )
+                    break
+                else:
+                    # Safe to retry - no content yielded yet
+                    delay = INVOKE_RETRY_BASE_DELAY * (2 ** stream_attempt)
+                    LOGGER.warning(
+                        f"[Continuation] Best-effort retry after EventStreamError ({error_code}) - "
+                        f"no content yielded yet, retrying with same invocationId={invocation_id}. "
+                        f"stream_attempt={stream_attempt + 1}/{MAX_STREAM_RETRIES + 1}, "
+                        f"retry_delay={delay}s"
+                    )
+                    time.sleep(delay)
+                    continue  # Retry the outer loop
+
+            except (ReadTimeoutError, Urllib3ReadTimeoutError):
+                LOGGER.error(
+                    f"[Continuation] Read timeout waiting for Bedrock continuation stream at depth={depth}. "
+                    f"Tool result status codes: {result_summary}. "
+                    f"The agent may need more time to process complex tool results. "
+                    f"Consider increasing BEDROCK_AGENT_RUNTIME_READ_TIMEOUT (current default: 300s)."
                 )
                 yield (
-                    f"\n\nI encountered an error while processing the tool results "
-                    f"({type(e).__name__}). Please try your request again.\n"
+                    f"\n\nThe request timed out while the agent was processing the tool results. "
+                    f"This can happen with complex queries. Please try simplifying your request or try again.\n"
                 )
-                return
+                break
 
-        # Process continuation stream with error handling
-        try:
-            if continuation_stream:
-                cont_event_count = 0
-                for cont_event in continuation_stream:
-                    cont_event_count += 1
-                    cont_event_type = list(cont_event.keys())[0] if cont_event else 'unknown'
-                    LOGGER.debug(f"[Continuation] depth={depth}, event #{cont_event_count}, type: {cont_event_type}")
-
-                    if 'chunk' in cont_event:
-                        text = self._handle_chunk_event(cont_event['chunk'])
-                        if text:
-                            yield text
-                            full_content += text
-                    elif 'files' in cont_event:
-                        # Note: File handling in continuation is handled by the caller
-                        # We just pass the event through
-                        yield {'files_event': cont_event}
-                    elif 'returnControl' in cont_event:
-                        # Agent wants to call another tool - handle recursively
-                        nested_return_control = cont_event['returnControl']
-                        LOGGER.info(f"[Continuation] Received nested returnControl at depth={depth} - recursing to depth={depth + 1}")
-
-                        # Recursively call ourselves to handle the nested tool call
-                        nested_generator = self._handle_continuation_response(
-                            return_control=nested_return_control,
-                            session_id=session_id,
-                            thread_id=thread_id,
-                            seen_file_hashes=seen_file_hashes,
-                            attachments=attachments,
-                            depth=depth + 1
-                        )
-
-                        # Forward all yielded items from nested handler
-                        nested_text_len = 0
-                        for nested_item in nested_generator:
-                            if isinstance(nested_item, str):
-                                yield nested_item
-                                full_content += nested_item
-                                nested_text_len += len(nested_item)
-                            elif isinstance(nested_item, dict):
-                                # Forward files_event and capture session_state
-                                if 'files_event' in nested_item:
-                                    yield nested_item
-                                if nested_item.get('session_state'):
-                                    new_session_state = nested_item['session_state']
-
-                        LOGGER.info(f"[Continuation] Nested handler at depth={depth + 1} completed, yielded {nested_text_len} chars of text")
-
-                    elif 'sessionState' in cont_event:
-                        new_session_state = cont_event['sessionState']
-                        LOGGER.debug(f"[Continuation] Received sessionState update at depth={depth}")
-
-                    elif 'trace' in cont_event:
-                        LOGGER.debug(f"[Continuation] Received trace event at depth={depth}")
-
-                LOGGER.info(f"[Continuation] Processed {cont_event_count} events from continuation stream at depth={depth}")
-            else:
-                LOGGER.warning(f"[Continuation] No continuation stream received at depth={depth}")
-
-        except EventStreamError as e:
-            # Bedrock raises EventStreamError (e.g. dependencyFailedException) when it
-            # can't process the tool results - commonly when a tool returned a 500 error.
-            error_code = getattr(e, 'code', 'unknown')
-            LOGGER.error(
-                f"[Continuation] EventStreamError at depth={depth}: {error_code} - {e}. "
-                f"Tool result status codes: {result_summary}. "
-                f"This typically means Bedrock rejected the tool result."
-            )
-            yield (
-                f"\n\nThe agent encountered an error processing the tool results "
-                f"(Bedrock error: {error_code}). This can happen when tool results "
-                f"are very large or in an unexpected format. "
-                f"Please try a more specific query.\n"
-            )
-        except (ReadTimeoutError, Urllib3ReadTimeoutError):
-            LOGGER.error(
-                f"[Continuation] Read timeout waiting for Bedrock continuation stream at depth={depth}. "
-                f"Tool result status codes: {result_summary}. "
-                f"The agent may need more time to process complex tool results. "
-                f"Consider increasing BEDROCK_AGENT_RUNTIME_READ_TIMEOUT (current default: 300s)."
-            )
-            yield (
-                f"\n\nThe request timed out while the agent was processing the tool results. "
-                f"This can happen with complex queries. Please try simplifying your request or try again.\n"
-            )
-        except Exception as e:
-            error_type = type(e).__name__
-            LOGGER.exception(
-                f"[Continuation] {error_type} processing continuation stream at depth={depth}: {e}"
-            )
-            yield (
-                f"\n\nAn unexpected error occurred while processing the response "
-                f"({error_type}). Please try again.\n"
-            )
+            except Exception as e:
+                error_type = type(e).__name__
+                LOGGER.exception(
+                    f"[Continuation] {error_type} processing continuation stream at depth={depth}: {e}"
+                )
+                yield (
+                    f"\n\nAn unexpected error occurred while processing the response "
+                    f"({error_type}). Please try again.\n"
+                )
+                break
 
         # Yield the final session state so callers can capture it
         if new_session_state:

--- a/deployment/nginx-combined.conf
+++ b/deployment/nginx-combined.conf
@@ -146,7 +146,7 @@ server {
         # - script-src: 'unsafe-eval' (dart2js), 'unsafe-inline' (flutter_bootstrap.js), gstatic.com (CanvasKit)
         # - connect-src: gstatic.com (CanvasKit WASM + fonts)
         # - font-src: fonts.gstatic.com (Google Fonts / Roboto)
-        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.gstatic.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://www.gstatic.com https://fonts.gstatic.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; frame-ancestors 'none'" always;
+        add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-eval' 'unsafe-inline' https://www.gstatic.com; style-src 'self' 'unsafe-inline'; connect-src 'self' https://www.gstatic.com https://fonts.gstatic.com; img-src 'self' data: blob:; font-src 'self' https://fonts.gstatic.com; frame-src 'self' blob:; frame-ancestors 'none'" always;
         try_files $uri $uri/ /index.html;
     }
 

--- a/deployment/terraform-existing-vpc/backend.tf
+++ b/deployment/terraform-existing-vpc/backend.tf
@@ -1,11 +1,75 @@
 # App Runner Combined Service (Backend + Frontend)
 # All App Runner resources gated by var.enable_apprunner (default: true)
+# NOTE: ECS Express Mode (ecs-express.tf) is an alternative compute target.
+# Use enable_ecs_express to deploy on ECS Express instead of App Runner.
 
 locals {
   # When private, service_url is null — use VPC Ingress Connection domain instead
   backend_url = var.enable_apprunner ? (
     var.backend_is_private ? aws_apprunner_vpc_ingress_connection.backend[0].domain_name : aws_apprunner_service.backend[0].service_url
   ) : null
+
+  # ==========================================================================
+  # Shared environment variables for all compute platforms
+  # Used by App Runner (backend.tf) and ECS Express (ecs-express.tf)
+  # Same pattern as local.backend_shared_policy_statements in iam.tf
+  # ==========================================================================
+  backend_env_vars = {
+    AWS_REGION                = var.aws_region
+    BOND_PROVIDER_CLASS       = "bondable.bond.providers.bedrock.BedrockProvider.BedrockProvider"
+    DATABASE_SECRET_ARN       = aws_secretsmanager_secret.db_credentials.arn
+    S3_BUCKET_NAME            = aws_s3_bucket.uploads.id
+    BEDROCK_S3_BUCKET         = aws_s3_bucket.uploads.id
+    BEDROCK_AGENT_ROLE_ARN    = aws_iam_role.bedrock_agent.arn
+    BEDROCK_DEFAULT_MODEL     = var.bedrock_default_model
+    BEDROCK_SELECTABLE_MODELS = var.bedrock_selectable_models
+
+    # App config secret (JWT key, OAuth client IDs/secrets read at runtime)
+    APP_CONFIG_SECRET_NAME = aws_secretsmanager_secret.app_config.name
+
+    # Okta OAuth Configuration
+    OAUTH2_ENABLED_PROVIDERS = var.oauth2_providers
+    OKTA_DOMAIN              = var.okta_domain
+    OKTA_SECRET_NAME         = var.okta_secret_name
+    OKTA_REDIRECT_URI        = var.okta_redirect_uri != "" ? var.okta_redirect_uri : "https://BACKEND_URL_PLACEHOLDER/auth/okta/callback"
+    OKTA_SCOPES              = var.okta_scopes
+
+    # AWS Cognito OAuth Configuration (only if configured)
+    COGNITO_DOMAIN       = var.cognito_domain
+    COGNITO_SECRET_NAME  = var.cognito_secret_name
+    COGNITO_REDIRECT_URI = var.cognito_redirect_uri != "" ? var.cognito_redirect_uri : (var.cognito_domain != "" ? "https://BACKEND_URL_PLACEHOLDER/auth/cognito/callback" : "")
+    COGNITO_SCOPES       = var.cognito_scopes
+    COGNITO_REGION       = var.cognito_region
+
+    # JWT redirect URI for frontend - same origin now (root of the service)
+    JWT_REDIRECT_URI = var.jwt_redirect_uri != "" ? var.jwt_redirect_uri : "*"
+
+    # CORS configuration - keep for local dev compatibility
+    CORS_ALLOWED_ORIGINS = var.cors_allowed_origins
+
+    # Allowed redirect domains for OAuth callbacks (security)
+    ALLOWED_REDIRECT_DOMAINS = var.allowed_redirect_domains
+
+    # Knowledge Base configuration (only set when KB is enabled)
+    BEDROCK_KNOWLEDGE_BASE_ID = try(aws_bedrockagent_knowledge_base.main[0].id, "")
+    BEDROCK_KB_DATA_SOURCE_ID = try(aws_bedrockagent_data_source.s3[0].data_source_id, "")
+    BEDROCK_KB_S3_PREFIX      = var.enable_knowledge_base ? "knowledge-base/" : ""
+
+    # Admin configuration (prefer ADMIN_USERS for multiple admins)
+    ADMIN_USERS = var.admin_users
+    ADMIN_EMAIL = var.admin_email # Legacy fallback for backward compatibility
+
+    # Email validation: allow all authenticated IdP users (T-O6)
+    ALLOW_ALL_EMAILS       = var.allow_all_emails
+    SCHEDULED_JOBS_ENABLED = var.scheduled_jobs_enabled
+
+    # Cookie security: "true" in production (HTTPS), "false" for local dev (HTTP)
+    COOKIE_SECURE = "true"
+
+    # Bedrock Guardrails
+    BEDROCK_GUARDRAIL_ID      = var.enable_guardrails ? aws_bedrock_guardrail.main[0].guardrail_id : ""
+    BEDROCK_GUARDRAIL_VERSION = var.enable_guardrails ? (var.bedrock_guardrail_version != "" ? var.bedrock_guardrail_version : aws_bedrock_guardrail_version.main[0].version) : ""
+  }
 }
 
 # App Runner VPC Connector for database access
@@ -120,65 +184,7 @@ resource "aws_apprunner_service" "backend" {
       image_configuration {
         port = "8080"
 
-        runtime_environment_variables = {
-          AWS_REGION             = var.aws_region
-          BOND_PROVIDER_CLASS    = "bondable.bond.providers.bedrock.BedrockProvider.BedrockProvider"
-          DATABASE_SECRET_ARN    = aws_secretsmanager_secret.db_credentials.arn
-          S3_BUCKET_NAME         = aws_s3_bucket.uploads.id
-          BEDROCK_S3_BUCKET      = aws_s3_bucket.uploads.id
-          BEDROCK_AGENT_ROLE_ARN = aws_iam_role.bedrock_agent.arn
-          BEDROCK_DEFAULT_MODEL      = var.bedrock_default_model
-          BEDROCK_SELECTABLE_MODELS  = var.bedrock_selectable_models
-
-          # App config secret (JWT key, OAuth client IDs/secrets read at runtime)
-          APP_CONFIG_SECRET_NAME = aws_secretsmanager_secret.app_config.name
-
-          # Okta OAuth Configuration
-          OAUTH2_ENABLED_PROVIDERS = var.oauth2_providers
-          OKTA_DOMAIN              = var.okta_domain
-          OKTA_SECRET_NAME         = var.okta_secret_name
-          OKTA_REDIRECT_URI = var.okta_redirect_uri != "" ? var.okta_redirect_uri : "https://BACKEND_URL_PLACEHOLDER/auth/okta/callback"
-          OKTA_SCOPES       = var.okta_scopes
-
-          # AWS Cognito OAuth Configuration (only if configured)
-          COGNITO_DOMAIN       = var.cognito_domain
-          COGNITO_SECRET_NAME  = var.cognito_secret_name
-          COGNITO_REDIRECT_URI = var.cognito_redirect_uri != "" ? var.cognito_redirect_uri : (var.cognito_domain != "" ? "https://BACKEND_URL_PLACEHOLDER/auth/cognito/callback" : "")
-          COGNITO_SCOPES       = var.cognito_scopes
-          COGNITO_REGION       = var.cognito_region
-
-          # JWT redirect URI for frontend - same origin now (root of the service)
-          JWT_REDIRECT_URI = var.jwt_redirect_uri != "" ? var.jwt_redirect_uri : "*"
-
-          # CORS configuration - keep for local dev compatibility
-          CORS_ALLOWED_ORIGINS = var.cors_allowed_origins
-
-          # Allowed redirect domains for OAuth callbacks (security)
-          # Localhost and *.awsapprunner.com are always allowed by default
-          ALLOWED_REDIRECT_DOMAINS = var.allowed_redirect_domains
-
-          # Knowledge Base configuration (only set when KB is enabled)
-          BEDROCK_KNOWLEDGE_BASE_ID = try(aws_bedrockagent_knowledge_base.main[0].id, "")
-          BEDROCK_KB_DATA_SOURCE_ID = try(aws_bedrockagent_data_source.s3[0].data_source_id, "")
-          BEDROCK_KB_S3_PREFIX      = var.enable_knowledge_base ? "knowledge-base/" : ""
-
-          # Admin configuration (prefer ADMIN_USERS for multiple admins)
-          ADMIN_USERS = var.admin_users
-          ADMIN_EMAIL = var.admin_email  # Legacy fallback for backward compatibility
-
-          # Email validation: allow all authenticated IdP users (T-O6)
-          # Set to "true" when IdP app assignment controls access (e.g., Okta groups)
-          # Set to "false" and configure *_VALID_EMAILS to restrict by email list
-          ALLOW_ALL_EMAILS       = var.allow_all_emails
-          SCHEDULED_JOBS_ENABLED = var.scheduled_jobs_enabled
-
-          # Cookie security: "true" in production (HTTPS), "false" for local dev (HTTP)
-          COOKIE_SECURE = "true"
-
-          # Bedrock Guardrails
-          BEDROCK_GUARDRAIL_ID      = var.enable_guardrails ? aws_bedrock_guardrail.main[0].guardrail_id : ""
-          BEDROCK_GUARDRAIL_VERSION = var.enable_guardrails ? (var.bedrock_guardrail_version != "" ? var.bedrock_guardrail_version : aws_bedrock_guardrail_version.main[0].version) : ""
-        }
+        runtime_environment_variables = local.backend_env_vars
       }
     }
   }
@@ -219,7 +225,7 @@ resource "aws_apprunner_service" "backend" {
   depends_on = [
     null_resource.wait_for_backend_auto_deploy,
     aws_secretsmanager_secret_version.db_credentials,
-    null_resource.private_ingress_ready  # VPC endpoint must exist before going private
+    null_resource.private_ingress_ready # VPC endpoint must exist before going private
   ]
   # Note: Database dependency handled via local.database_endpoint
 }

--- a/deployment/terraform-existing-vpc/custom-domain.tf
+++ b/deployment/terraform-existing-vpc/custom-domain.tf
@@ -7,14 +7,15 @@
 #   - Leave custom_domain_name = "" (default) to skip custom domain setup
 
 locals {
-  custom_domain_enabled = var.custom_domain_name != "" && !var.backend_is_private && var.enable_apprunner
+  custom_domain_enabled = var.custom_domain_name != "" && !var.backend_is_private && var.enable_apprunner && var.primary_platform == "apprunner"
   # Use hosted_zone_name if provided, otherwise fall back to custom_domain_name (for root domains)
   hosted_zone_name = var.hosted_zone_name != "" ? var.hosted_zone_name : var.custom_domain_name
 }
 
 # Use the existing Route 53 Hosted Zone (created automatically during domain registration)
+# Shared by App Runner custom domain and ECS Express custom domain
 data "aws_route53_zone" "frontend" {
-  count = local.custom_domain_enabled ? 1 : 0
+  count = local.custom_domain_enabled || local.ecs_express_custom_domain_enabled ? 1 : 0
   name  = local.hosted_zone_name
 }
 

--- a/deployment/terraform-existing-vpc/data-sources.tf
+++ b/deployment/terraform-existing-vpc/data-sources.tf
@@ -58,6 +58,9 @@ locals {
   # Use explicitly provided subnet IDs if available, otherwise auto-detect
   app_runner_subnet_ids = length(var.app_runner_subnet_ids) > 0 ? var.app_runner_subnet_ids : slice(data.aws_subnets.private.ids, 0, min(3, length(data.aws_subnets.private.ids)))
 
+  # Select subnets for ECS Express — use public subnets for internet-facing ALB
+  ecs_express_subnet_ids = length(var.ecs_express_subnet_ids) > 0 ? var.ecs_express_subnet_ids : local.app_runner_subnet_ids
+
   # Select subnets for VPC endpoints (need different AZs for interface endpoints)
   vpc_endpoint_subnet_ids = [
     for az in slice(local.availability_zones, 0, min(2, length(local.availability_zones))) :
@@ -72,8 +75,21 @@ locals {
 # Validate at least one compute platform is enabled
 check "at_least_one_platform" {
   assert {
-    condition     = var.enable_apprunner || var.enable_eks
-    error_message = "At least one of enable_apprunner or enable_eks must be true."
+    condition     = var.enable_apprunner || var.enable_eks || var.enable_ecs_express
+    error_message = "At least one of enable_apprunner, enable_eks, or enable_ecs_express must be true."
+  }
+}
+
+# Validate primary_platform matches an enabled platform (when custom domain is set)
+check "primary_platform_enabled" {
+  assert {
+    condition = (
+      var.custom_domain_name == "" ||
+      (var.primary_platform == "apprunner" && var.enable_apprunner) ||
+      (var.primary_platform == "ecs_express" && var.enable_ecs_express) ||
+      (var.primary_platform == "eks" && var.enable_eks)
+    )
+    error_message = "primary_platform '${var.primary_platform}' references a disabled platform while custom_domain_name is set. No custom domain will be configured."
   }
 }
 

--- a/deployment/terraform-existing-vpc/ecs-express-domain.tf
+++ b/deployment/terraform-existing-vpc/ecs-express-domain.tf
@@ -1,0 +1,282 @@
+# =============================================================================
+# ECS Express Custom Domain + TLS Certificate (Optional)
+#
+# Follows the eks-domain.tf pattern:
+# 1. custom_domain_name provided + primary_platform=ecs_express → create ACM cert + Route53 alias
+# 2. No custom domain → use raw ALB DNS endpoint (auto-provisioned by ECS Express)
+#
+# All resources gated by var.enable_ecs_express (default: false)
+# =============================================================================
+
+locals {
+  ecs_express_custom_domain_enabled = (
+    var.enable_ecs_express &&
+    var.custom_domain_name != "" &&
+    !var.backend_is_private &&
+    var.primary_platform == "ecs_express" &&
+    var.ecs_express_configure_alb
+  )
+
+  # Resolved service URL: custom domain > ALB endpoint
+  ecs_express_service_url = var.enable_ecs_express ? (
+    local.ecs_express_custom_domain_enabled ? var.custom_domain_name : local.ecs_express_backend_url
+  ) : ""
+}
+
+# =============================================================================
+# ACM Certificate for ALB TLS
+# App Runner managed its own certs; ECS Express ALB needs a standard ACM cert.
+# =============================================================================
+
+resource "aws_acm_certificate" "ecs_express" {
+  count = local.ecs_express_custom_domain_enabled ? 1 : 0
+
+  domain_name               = var.custom_domain_name
+  subject_alternative_names = var.enable_www_subdomain ? ["www.${var.custom_domain_name}"] : []
+  validation_method         = "DNS"
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-ecs-express-cert"
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+# =============================================================================
+# Route53 DNS Validation Records (for ACM cert)
+# Uses the same hosted zone as App Runner custom domain
+# =============================================================================
+
+resource "aws_route53_record" "ecs_express_cert_validation" {
+  for_each = local.ecs_express_custom_domain_enabled ? {
+    for dvo in aws_acm_certificate.ecs_express[0].domain_validation_options : dvo.domain_name => {
+      name   = dvo.resource_record_name
+      record = dvo.resource_record_value
+      type   = dvo.resource_record_type
+    }
+  } : {}
+
+  allow_overwrite = true
+  name            = each.value.name
+  records         = [each.value.record]
+  ttl             = 60
+  type            = each.value.type
+  zone_id         = data.aws_route53_zone.frontend[0].zone_id
+}
+
+resource "aws_acm_certificate_validation" "ecs_express" {
+  count = local.ecs_express_custom_domain_enabled ? 1 : 0
+
+  certificate_arn         = aws_acm_certificate.ecs_express[0].arn
+  validation_record_fqdns = [for record in aws_route53_record.ecs_express_cert_validation : record.fqdn]
+}
+
+# =============================================================================
+# Route53 Alias Record (points custom domain to ALB)
+# =============================================================================
+
+# A alias record pointing to the public ALB (internet-facing).
+resource "aws_route53_record" "ecs_express_alias" {
+  count = local.ecs_express_custom_domain_enabled ? 1 : 0
+
+  zone_id = data.aws_route53_zone.frontend[0].zone_id
+  name    = var.custom_domain_name
+  type    = "A"
+
+  alias {
+    name                   = local.ecs_express_alb_dns_name
+    zone_id                = local.ecs_express_alb_zone_id
+    evaluate_target_health = true
+  }
+
+  depends_on = [aws_acm_certificate_validation.ecs_express]
+}
+
+# Optional: www subdomain A alias
+resource "aws_route53_record" "ecs_express_www_alias" {
+  count = local.ecs_express_custom_domain_enabled && var.enable_www_subdomain ? 1 : 0
+
+  zone_id = data.aws_route53_zone.frontend[0].zone_id
+  name    = "www.${var.custom_domain_name}"
+  type    = "A"
+
+  alias {
+    name                   = local.ecs_express_alb_dns_name
+    zone_id                = local.ecs_express_alb_zone_id
+    evaluate_target_health = true
+  }
+
+  depends_on = [aws_acm_certificate_validation.ecs_express]
+}
+
+# =============================================================================
+# Configure ALB for Custom Domain
+#
+# ECS Express ALB uses host-header routing — it only forwards requests for
+# the *.ecs.*.on.aws endpoint. We need to:
+# 1. Add our ACM cert to the HTTPS listener
+# 2. Add a listener rule forwarding our custom domain to the same target group
+# =============================================================================
+
+resource "null_resource" "ecs_express_alb_custom_domain" {
+  count = local.ecs_express_custom_domain_enabled ? 1 : 0
+
+  triggers = {
+    # Re-run on every apply to sync target groups after blue-green deployments
+    always_run = timestamp()
+    domain     = var.custom_domain_name
+    alb_arn    = local.ecs_express_alb_arn
+    region     = var.aws_region
+    cert_arn   = aws_acm_certificate.ecs_express[0].arn
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      REGION="${var.aws_region}"
+      ALB_ARN="${local.ecs_express_alb_arn}"
+      CERT_ARN="${aws_acm_certificate.ecs_express[0].arn}"
+      CUSTOM_DOMAIN="${var.custom_domain_name}"
+
+      echo "Configuring ALB for custom domain: $CUSTOM_DOMAIN"
+
+      # 1. Find the HTTPS listener
+      LISTENER_ARN=$(aws elbv2 describe-listeners \
+        --load-balancer-arn "$ALB_ARN" \
+        --region "$REGION" \
+        --query "Listeners[?Port==\`443\`].ListenerArn | [0]" \
+        --output text)
+
+      if [ -z "$LISTENER_ARN" ] || [ "$LISTENER_ARN" = "None" ]; then
+        echo "ERROR: No HTTPS listener found on ALB"
+        exit 1
+      fi
+      echo "HTTPS Listener: $LISTENER_ARN"
+
+      # 2. Add ACM certificate to listener
+      echo "Adding ACM certificate..."
+      aws elbv2 add-listener-certificates \
+        --listener-arn "$LISTENER_ARN" \
+        --certificates CertificateArn="$CERT_ARN" \
+        --region "$REGION" \
+        --output text 2>/dev/null || echo "Certificate may already be attached"
+
+      # 3. Find THIS service's forward config by matching the *.on.aws endpoint rule.
+      # CRITICAL: On a shared ALB, multiple services have rules. We must match
+      # our specific endpoint, not just the first rule (which could be another service).
+      # Strip protocol prefix if present (ingress_paths may include https://)
+      SERVICE_ENDPOINT=$(echo "${local.ecs_express_backend_url}" | sed 's|^https\?://||')
+      echo "Service Endpoint: $SERVICE_ENDPOINT"
+
+      FORWARD_CONFIG=$(aws elbv2 describe-rules \
+        --listener-arn "$LISTENER_ARN" \
+        --region "$REGION" \
+        --output json | jq -c --arg ep "$SERVICE_ENDPOINT" \
+        '[.Rules[] | select(.Conditions[]? | .Values[]? == $ep) | .Actions[0].ForwardConfig] | first // empty')
+
+      if [ -z "$FORWARD_CONFIG" ] || [ "$FORWARD_CONFIG" = "null" ]; then
+        echo "ERROR: Could not find listener rule for endpoint $SERVICE_ENDPOINT"
+        exit 1
+      fi
+
+      echo "Forward config: $FORWARD_CONFIG"
+
+      # 5. Check if a rule for our custom domain already exists
+      EXISTING_RULE=$(aws elbv2 describe-rules \
+        --listener-arn "$LISTENER_ARN" \
+        --region "$REGION" \
+        --output json | jq -r --arg domain "$CUSTOM_DOMAIN" \
+        '[.Rules[] | select(.Conditions[]? | .Field == "host-header" and (.Values[]? == $domain)) | .RuleArn] | first // empty')
+
+      if [ -n "$EXISTING_RULE" ]; then
+        echo "Updating existing listener rule for $CUSTOM_DOMAIN..."
+        # Build the actions JSON with the full forward config (both target groups)
+        ACTIONS_JSON=$(echo "$FORWARD_CONFIG" | jq -c '{Type: "forward", ForwardConfig: .}')
+        aws elbv2 modify-rule \
+          --rule-arn "$EXISTING_RULE" \
+          --actions "$ACTIONS_JSON" \
+          --region "$REGION" \
+          --output text
+        echo "Listener rule updated with current target groups"
+      else
+        echo "Creating listener rule for $CUSTOM_DOMAIN..."
+        # Find next available priority (shared ALB may have other services' rules)
+        USED_PRIORITIES=$(aws elbv2 describe-rules \
+          --listener-arn "$LISTENER_ARN" \
+          --region "$REGION" \
+          --output json | jq -r '[.Rules[].Priority | select(. != "default") | tonumber] | sort | last // 0')
+        NEXT_PRIORITY=$((USED_PRIORITIES + 1))
+        echo "Using priority: $NEXT_PRIORITY"
+
+        ACTIONS_JSON=$(echo "$FORWARD_CONFIG" | jq -c '{Type: "forward", ForwardConfig: .}')
+        aws elbv2 create-rule \
+          --listener-arn "$LISTENER_ARN" \
+          --priority "$NEXT_PRIORITY" \
+          --conditions Field=host-header,Values="$CUSTOM_DOMAIN" \
+          --actions "$ACTIONS_JSON" \
+          --region "$REGION" \
+          --output text
+        echo "Listener rule created"
+      fi
+
+      echo "Custom domain ALB configuration complete"
+    EOT
+  }
+
+  # Clean up the listener rule and certificate when this resource is destroyed
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOT
+      set -e
+      REGION="${self.triggers.region}"
+      ALB_ARN="${self.triggers.alb_arn}"
+      CUSTOM_DOMAIN="${self.triggers.domain}"
+
+      echo "Cleaning up ALB custom domain config for: $CUSTOM_DOMAIN"
+
+      LISTENER_ARN=$(aws elbv2 describe-listeners \
+        --load-balancer-arn "$ALB_ARN" \
+        --region "$REGION" \
+        --query "Listeners[?Port==\`443\`].ListenerArn | [0]" \
+        --output text 2>/dev/null || echo "None")
+
+      if [ -z "$LISTENER_ARN" ] || [ "$LISTENER_ARN" = "None" ]; then
+        echo "No HTTPS listener found — nothing to clean up"
+        exit 0
+      fi
+
+      # Find and delete the listener rule for our custom domain
+      RULE_ARN=$(aws elbv2 describe-rules \
+        --listener-arn "$LISTENER_ARN" \
+        --region "$REGION" \
+        --output json 2>/dev/null | jq -r --arg domain "$CUSTOM_DOMAIN" \
+        '[.Rules[] | select(.Conditions[]? | .Field == "host-header" and (.Values[]? | contains($domain))) | .RuleArn] | first // empty')
+
+      if [ -n "$RULE_ARN" ]; then
+        echo "Deleting listener rule: $RULE_ARN"
+        aws elbv2 delete-rule --rule-arn "$RULE_ARN" --region "$REGION" || echo "Warning: could not delete rule"
+      else
+        echo "No listener rule found for $CUSTOM_DOMAIN"
+      fi
+
+      # Remove the certificate from the listener
+      CERT_ARN="${self.triggers.cert_arn}"
+      if [ -n "$CERT_ARN" ]; then
+        echo "Removing certificate from listener..."
+        aws elbv2 remove-listener-certificates \
+          --listener-arn "$LISTENER_ARN" \
+          --certificates CertificateArn="$CERT_ARN" \
+          --region "$REGION" 2>/dev/null || echo "Warning: could not remove certificate"
+      fi
+
+      echo "ALB custom domain cleanup complete"
+    EOT
+  }
+
+  depends_on = [
+    aws_acm_certificate_validation.ecs_express,
+    aws_ecs_express_gateway_service.backend
+  ]
+}

--- a/deployment/terraform-existing-vpc/ecs-express-iam.tf
+++ b/deployment/terraform-existing-vpc/ecs-express-iam.tf
@@ -1,0 +1,206 @@
+# =============================================================================
+# ECS Express Mode IAM Roles
+# Uses the same shared policy as App Runner instance role to prevent drift.
+# All resources gated by var.enable_ecs_express (default: false)
+# =============================================================================
+
+# =============================================================================
+# Task Role — assumed by the running application container
+# Equivalent of App Runner instance role / EKS pod role (IRSA)
+# =============================================================================
+
+resource "aws_iam_role" "ecs_express_task" {
+  count = var.enable_ecs_express ? 1 : 0
+
+  name = "${var.project_name}-${var.environment}-ecs-express-task-role"
+
+  # Split trust policy: ECS tasks with SourceAccount condition (SA-8),
+  # Bedrock without it (Bedrock may not pass SourceAccount when assuming
+  # the caller's role during InvokeAgent).
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "ECSTasksAssume"
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      },
+      {
+        Sid    = "BedrockAssume"
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "bedrock.amazonaws.com"
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-ecs-express-task-role"
+  }
+}
+
+# Task role uses shared policy statements + its own PassRole
+resource "aws_iam_role_policy" "ecs_express_task" {
+  count = var.enable_ecs_express ? 1 : 0
+
+  name = "${var.project_name}-${var.environment}-ecs-express-task-policy"
+  role = aws_iam_role.ecs_express_task[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = concat(local.backend_shared_policy_statements, [
+      {
+        Sid    = "PassRole"
+        Effect = "Allow"
+        Action = [
+          "iam:PassRole"
+        ]
+        Resource = [
+          aws_iam_role.ecs_express_task[0].arn,
+          aws_iam_role.bedrock_agent.arn
+        ]
+        Condition = {
+          StringEquals = {
+            "iam:PassedToService" = "bedrock.amazonaws.com"
+          }
+        }
+      }
+    ])
+  })
+}
+
+# =============================================================================
+# Execution Role — used by the ECS agent to pull images and write logs
+# Equivalent of App Runner ECR access role
+# =============================================================================
+
+resource "aws_iam_role" "ecs_express_execution" {
+  count = var.enable_ecs_express ? 1 : 0
+
+  name = "${var.project_name}-${var.environment}-ecs-express-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs-tasks.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-ecs-express-execution-role"
+  }
+}
+
+# Standard ECS task execution policy (ECR pull, CloudWatch logs)
+resource "aws_iam_role_policy_attachment" "ecs_express_execution" {
+  count = var.enable_ecs_express ? 1 : 0
+
+  role       = aws_iam_role.ecs_express_execution[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# KMS decrypt for pulling images from CMK-encrypted ECR repos
+resource "aws_iam_role_policy" "ecs_express_execution_kms" {
+  count = var.enable_ecs_express ? 1 : 0
+
+  name = "${var.project_name}-${var.environment}-ecs-express-execution-kms"
+  role = aws_iam_role.ecs_express_execution[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = ["kms:Decrypt"]
+        Resource = [aws_kms_key.secrets.arn]
+      }
+    ]
+  })
+}
+
+# =============================================================================
+# Infrastructure Role — used by ECS to manage ALB, target groups, auto-scaling
+# This is a new role type specific to ECS Express Mode
+# =============================================================================
+
+resource "aws_iam_role" "ecs_express_infrastructure" {
+  count = var.enable_ecs_express ? 1 : 0
+
+  name = "${var.project_name}-${var.environment}-ecs-express-infra-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = "sts:AssumeRole"
+        Effect = "Allow"
+        Principal = {
+          Service = "ecs.amazonaws.com"
+        }
+        Condition = {
+          StringEquals = {
+            "aws:SourceAccount" = data.aws_caller_identity.current.account_id
+          }
+        }
+      }
+    ]
+  })
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-ecs-express-infra-role"
+  }
+}
+
+# Managed policy for Express Mode infrastructure management
+resource "aws_iam_role_policy_attachment" "ecs_express_infrastructure" {
+  count = var.enable_ecs_express ? 1 : 0
+
+  role       = aws_iam_role.ecs_express_infrastructure[0].name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSInfrastructureRoleforExpressGatewayServices"
+}
+
+# CloudWatch Logs permissions — the managed policy doesn't include these,
+# but ECS Express needs them to verify/configure log groups during service creation
+resource "aws_iam_role_policy" "ecs_express_infrastructure_logs" {
+  count = var.enable_ecs_express ? 1 : 0
+
+  name = "${var.project_name}-${var.environment}-ecs-express-infra-logs"
+  role = aws_iam_role.ecs_express_infrastructure[0].id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "logs:DescribeLogGroups",
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents"
+        ]
+        Resource = "arn:aws:logs:${var.aws_region}:${data.aws_caller_identity.current.account_id}:*"
+      }
+    ]
+  })
+}

--- a/deployment/terraform-existing-vpc/ecs-express.tf
+++ b/deployment/terraform-existing-vpc/ecs-express.tf
@@ -1,0 +1,175 @@
+# =============================================================================
+# ECS Express Mode Service (Backend + Frontend)
+# All resources gated by var.enable_ecs_express (default: false)
+#
+# ECS Express Mode auto-provisions an ALB, target groups, security groups,
+# and auto-scaling policies. Uses the same combined Docker image as App Runner.
+#
+# Key benefit: No 2-minute timeout — ALB idle timeout configurable up to 4000s
+# (set to 300s to match nginx proxy_read_timeout in nginx-combined.conf).
+# =============================================================================
+
+locals {
+  # Service endpoint URL from the ECS Express ingress path
+  ecs_express_backend_url = var.enable_ecs_express ? (
+    try(aws_ecs_express_gateway_service.backend[0].ingress_paths[0].endpoint, "pending")
+  ) : ""
+}
+
+# =============================================================================
+# CloudWatch Log Group
+# =============================================================================
+
+resource "aws_cloudwatch_log_group" "ecs_express" {
+  count = var.enable_ecs_express ? 1 : 0
+
+  name              = "/ecs/${var.project_name}-${var.environment}-backend"
+  retention_in_days = 30
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-ecs-express-logs"
+  }
+}
+
+# =============================================================================
+# ECS Express Gateway Service
+# =============================================================================
+
+resource "aws_ecs_express_gateway_service" "backend" {
+  count = var.enable_ecs_express ? 1 : 0
+
+  service_name            = "${var.project_name}-${var.environment}-pub-backend"
+  health_check_path       = "/health"
+  execution_role_arn      = aws_iam_role.ecs_express_execution[0].arn
+  infrastructure_role_arn = aws_iam_role.ecs_express_infrastructure[0].arn
+  task_role_arn           = aws_iam_role.ecs_express_task[0].arn
+
+  # Match current App Runner instance size: 1 vCPU, 2 GB
+  cpu    = "1024"
+  memory = "2048"
+
+  primary_container {
+    image          = "${aws_ecr_repository.backend.repository_url}:${local.combined_image_tag}"
+    container_port = 8080
+
+    aws_logs_configuration {
+      log_group         = aws_cloudwatch_log_group.ecs_express[0].name
+      log_stream_prefix = "backend"
+    }
+
+    # Environment variables — same as App Runner (shared via local.backend_env_vars)
+    dynamic "environment" {
+      for_each = local.backend_env_vars
+      content {
+        name  = environment.key
+        value = environment.value
+      }
+    }
+  }
+
+  network_configuration {
+    subnets         = local.ecs_express_subnet_ids
+    security_groups = [aws_security_group.app_runner.id]
+  }
+
+  scaling_target {
+    min_task_count            = 1
+    max_task_count            = var.environment == "prod" ? 10 : 2
+    auto_scaling_metric       = "AVERAGE_CPU"
+    auto_scaling_target_value = 70
+  }
+
+  # Wait for deployment to complete before Terraform proceeds.
+  # Ensures ALB, DNS, and tasks are fully ready for validation.
+  wait_for_steady_state = true
+
+  # ECS Express auto-creates and injects its own ALB security group into
+  # network_configuration.security_groups. This causes a provider bug where
+  # Terraform sees a mismatch between planned (1 SG) and actual (2 SGs).
+  # Ignoring this field prevents the inconsistent result error.
+  lifecycle {
+    ignore_changes = [network_configuration]
+  }
+
+  tags = {
+    Name = "${var.project_name}-${var.environment}-ecs-express-backend"
+  }
+
+  depends_on = [
+    null_resource.build_combined_image,
+    aws_secretsmanager_secret_version.db_credentials,
+  ]
+
+  timeouts {
+    create = "30m"
+    update = "30m"
+    delete = "20m"
+  }
+}
+
+# =============================================================================
+# ALB Configuration (Phase 2 — after first deploy)
+#
+# ECS Express auto-creates an ALB. On the first deploy, we discover and
+# configure it via CLI in the validation script. For Terraform-managed
+# resources (WAF, Route53), set ecs_express_configure_alb = true on the
+# second apply after verifying the service is running.
+#
+# Key benefit: ALB idle timeout set to 300s (matches nginx proxy_read_timeout).
+# This is the primary improvement over App Runner's 2-minute enforced timeout.
+# =============================================================================
+
+# Look up the auto-created ALB — only after ecs_express_configure_alb is enabled
+data "aws_lb" "ecs_express" {
+  count = var.enable_ecs_express && var.ecs_express_configure_alb ? 1 : 0
+
+  # ECS Express shares ALBs across services in the same VPC.
+  # The Name tag reflects whichever service created the ALB first.
+  # Filter on AmazonECSManaged only since there's one shared ALB per VPC.
+  tags = {
+    "AmazonECSManaged" = "true"
+  }
+}
+
+locals {
+  ecs_express_alb_arn      = var.enable_ecs_express && var.ecs_express_configure_alb ? data.aws_lb.ecs_express[0].arn : ""
+  ecs_express_alb_dns_name = var.enable_ecs_express && var.ecs_express_configure_alb ? data.aws_lb.ecs_express[0].dns_name : ""
+  ecs_express_alb_zone_id  = var.enable_ecs_express && var.ecs_express_configure_alb ? data.aws_lb.ecs_express[0].zone_id : ""
+  ecs_express_alb_found    = local.ecs_express_alb_arn != ""
+}
+
+# Set ALB idle timeout to 300s on every apply to prevent drift.
+# ECS Express updates can reset the timeout to the default 60s.
+resource "null_resource" "ecs_express_alb_timeout" {
+  count = var.enable_ecs_express && var.ecs_express_configure_alb ? 1 : 0
+
+  triggers = {
+    # Re-run on every apply to ensure timeout stays at 300s
+    always_run = timestamp()
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      ALB_ARN="${data.aws_lb.ecs_express[0].arn}"
+
+      CURRENT=$(aws elbv2 describe-load-balancer-attributes \
+        --load-balancer-arn "$ALB_ARN" \
+        --region ${var.aws_region} \
+        --query "Attributes[?Key=='idle_timeout.timeout_seconds'].Value | [0]" \
+        --output text 2>/dev/null || echo "unknown")
+
+      if [ "$CURRENT" = "300" ]; then
+        echo "ALB idle timeout already 300s — no change needed"
+      else
+        echo "ALB idle timeout is $${CURRENT}s — setting to 300s..."
+        aws elbv2 modify-load-balancer-attributes \
+          --load-balancer-arn "$ALB_ARN" \
+          --attributes Key=idle_timeout.timeout_seconds,Value=300 \
+          --region ${var.aws_region} \
+          --output text
+        echo "ALB idle timeout set to 300s (matches nginx proxy_read_timeout)"
+      fi
+    EOT
+  }
+}

--- a/deployment/terraform-existing-vpc/outputs.tf
+++ b/deployment/terraform-existing-vpc/outputs.tf
@@ -95,16 +95,19 @@ output "app_runner_security_group_id" {
 
 locals {
   # Safe versions for output interpolation (never null)
-  backend_url_display = coalesce(local.backend_url, "DISABLED")
-  eks_url_display     = local.eks_service_url != "" ? "${local.eks_service_protocol}://${local.eks_service_url}" : "DISABLED"
+  backend_url_display     = coalesce(local.backend_url, "DISABLED")
+  eks_url_display         = local.eks_service_url != "" ? "${local.eks_service_protocol}://${local.eks_service_url}" : "DISABLED"
+  ecs_express_url_display = local.ecs_express_service_url != "" ? local.ecs_express_service_url : "DISABLED"
 }
 
 output "deployment_instructions" {
   value       = <<-EOT
 
     Deployment Complete!
-    App Runner: ${var.enable_apprunner ? "https://${local.backend_url_display}${var.backend_is_private ? " (PRIVATE)" : ""}" : "DISABLED"}
-    EKS:        ${var.enable_eks ? "${local.eks_url_display} (PRIVATE — VPN required)" : "DISABLED"}
+    App Runner:   ${var.enable_apprunner ? "https://${local.backend_url_display}${var.backend_is_private ? " (PRIVATE)" : ""}" : "DISABLED"}
+    ECS Express:  ${var.enable_ecs_express ? local.ecs_express_url_display : "DISABLED"}
+    EKS:          ${var.enable_eks ? "${local.eks_url_display} (PRIVATE — VPN required)" : "DISABLED"}
+    Primary:      ${var.primary_platform}
   EOT
   description = "Post-deployment instructions"
 }
@@ -198,6 +201,35 @@ output "eks_kubectl_config" {
 }
 
 # =============================================================================
+# ECS Express Outputs (conditional on enable_ecs_express)
+# =============================================================================
+
+output "ecs_express_service_url" {
+  value       = var.enable_ecs_express ? local.ecs_express_service_url : null
+  description = "ECS Express service URL (null if disabled)"
+}
+
+output "ecs_express_service_arn" {
+  value       = var.enable_ecs_express ? aws_ecs_express_gateway_service.backend[0].service_arn : null
+  description = "ARN of the ECS Express service (null if disabled)"
+}
+
+output "ecs_express_alb_dns_name" {
+  value       = local.ecs_express_alb_dns_name != "" ? local.ecs_express_alb_dns_name : null
+  description = "DNS name of the auto-created ALB (null if disabled or not yet discovered)"
+}
+
+output "ecs_express_alb_arn" {
+  value       = local.ecs_express_alb_arn != "" ? local.ecs_express_alb_arn : null
+  description = "ARN of the auto-created ALB (null if disabled or not yet discovered)"
+}
+
+output "ecs_express_custom_domain_url" {
+  description = "ECS Express custom domain URL (null if not configured)"
+  value       = local.ecs_express_custom_domain_enabled ? "https://${var.custom_domain_name}" : null
+}
+
+# =============================================================================
 # Platform Status
 # =============================================================================
 
@@ -209,4 +241,14 @@ output "enable_apprunner" {
 output "enable_eks" {
   value       = var.enable_eks
   description = "Whether EKS is enabled"
+}
+
+output "enable_ecs_express" {
+  value       = var.enable_ecs_express
+  description = "Whether ECS Express Mode is enabled"
+}
+
+output "primary_platform" {
+  value       = var.primary_platform
+  description = "Which platform serves the custom domain"
 }

--- a/deployment/terraform-existing-vpc/validate-deployment.tf
+++ b/deployment/terraform-existing-vpc/validate-deployment.tf
@@ -84,3 +84,128 @@ moved {
   from = null_resource.validate_deployment
   to   = null_resource.validate_deployment[0]
 }
+
+# =============================================================================
+# ECS Express Deployment Validation
+# =============================================================================
+
+resource "null_resource" "validate_ecs_express_deployment" {
+  count = var.enable_ecs_express ? 1 : 0
+
+  triggers = {
+    service_arn = aws_ecs_express_gateway_service.backend[0].service_arn
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      echo ""
+      echo "========================================="
+      echo "Validating ECS Express Deployment"
+      echo "========================================="
+
+      SERVICE_URL="${local.ecs_express_backend_url}"
+      REGION="${var.aws_region}"
+      VPC_ID="${data.aws_vpc.existing.id}"
+      SERVICE_NAME="${var.project_name}-${var.environment}-backend"
+      CONFIGURE_ALB="${var.ecs_express_configure_alb}"
+
+      echo "Service Endpoint: $SERVICE_URL"
+      echo ""
+
+      # --- Discover ALB via CLI (works on first deploy before configure_alb is set) ---
+      echo "Discovering ALB..."
+      ALB_ARN=""
+      ALL_ALBS=$(aws elbv2 describe-load-balancers \
+        --region "$REGION" \
+        --query "LoadBalancers[?VpcId=='$VPC_ID' && Type=='application'].[LoadBalancerArn]" \
+        --output json 2>/dev/null || echo "[]")
+
+      for ARN in $(echo "$ALL_ALBS" | jq -r '.[][] // empty'); do
+        TAGS=$(aws elbv2 describe-tags \
+          --resource-arns "$ARN" \
+          --region "$REGION" \
+          --query "TagDescriptions[0].Tags" \
+          --output json 2>/dev/null || echo "[]")
+
+        MATCH=$(echo "$TAGS" | jq -r --arg svc "$SERVICE_NAME" \
+          '[.[] | select(.Value == $svc or (.Value | contains($svc)))] | length')
+
+        if [ "$MATCH" -gt "0" ]; then
+          ALB_ARN="$ARN"
+          break
+        fi
+      done
+
+      if [ -n "$ALB_ARN" ]; then
+        echo "ALB ARN: $ALB_ARN"
+
+        # Set idle timeout to 300s (matches nginx proxy_read_timeout)
+        echo "Setting ALB idle timeout to 300s..."
+        aws elbv2 modify-load-balancer-attributes \
+          --load-balancer-arn "$ALB_ARN" \
+          --attributes Key=idle_timeout.timeout_seconds,Value=300 \
+          --region "$REGION" \
+          --output text 2>/dev/null || echo "  Warning: could not set timeout"
+
+        TIMEOUT=$(aws elbv2 describe-load-balancer-attributes \
+          --load-balancer-arn "$ALB_ARN" \
+          --region "$REGION" \
+          --query "Attributes[?Key=='idle_timeout.timeout_seconds'].Value | [0]" \
+          --output text 2>/dev/null || echo "unknown")
+        echo "ALB idle timeout: $${TIMEOUT}s"
+      else
+        echo "ALB: not yet discovered (may still be provisioning)"
+      fi
+      echo ""
+
+      # --- Health checks ---
+      if [ -z "$SERVICE_URL" ] || [ "$SERVICE_URL" = "pending" ]; then
+        echo "Service endpoint not yet available — skipping health check"
+      else
+        echo "Checking backend health..."
+        BACKEND_RESPONSE=$(curl -s -o /dev/null -w "%%{http_code}" "https://$SERVICE_URL/health" 2>/dev/null || echo "000")
+
+        if [ "$BACKEND_RESPONSE" = "200" ] || [ "$BACKEND_RESPONSE" = "503" ]; then
+          echo "Backend is accessible (HTTP $BACKEND_RESPONSE)"
+        else
+          echo "Backend returned HTTP $BACKEND_RESPONSE"
+          echo "  This may be normal during initial deployment"
+        fi
+
+        echo "Checking frontend..."
+        FRONTEND_RESPONSE=$(curl -s -o /dev/null -w "%%{http_code}" "https://$SERVICE_URL/" 2>/dev/null || echo "000")
+
+        if [ "$FRONTEND_RESPONSE" = "200" ]; then
+          echo "Frontend is accessible (HTTP $FRONTEND_RESPONSE)"
+        else
+          echo "Frontend returned HTTP $FRONTEND_RESPONSE"
+          echo "  This may be normal during initial deployment"
+        fi
+      fi
+
+      echo ""
+      echo "========================================="
+      echo "ECS Express Validation Complete"
+      echo "========================================="
+      echo ""
+      if [ "$CONFIGURE_ALB" = "true" ]; then
+        echo "Next steps:"
+        echo "1. Test: curl https://$SERVICE_URL/health"
+        echo "2. Test streaming: send a long agent request and verify it exceeds 2 minutes"
+        echo "3. When ready to cut over domain: set primary_platform = \"ecs_express\""
+      else
+        echo "Next steps:"
+        echo "1. Test: curl https://$SERVICE_URL/health"
+        echo "2. Set ecs_express_configure_alb = true and re-apply for WAF + timeout"
+        echo "3. Test streaming beyond 2 minutes"
+        echo "4. When ready: set primary_platform = \"ecs_express\""
+      fi
+      echo ""
+    EOT
+  }
+
+  depends_on = [
+    aws_ecs_express_gateway_service.backend,
+  ]
+}

--- a/deployment/terraform-existing-vpc/variables.tf
+++ b/deployment/terraform-existing-vpc/variables.tf
@@ -356,6 +356,35 @@ variable "enable_eks" {
   default     = false
 }
 
+variable "enable_ecs_express" {
+  description = "Deploy on ECS Express Mode. Recommended App Runner replacement with configurable ALB timeouts. Can run alongside App Runner during migration."
+  type        = bool
+  default     = false
+}
+
+variable "ecs_express_subnet_ids" {
+  description = "Public subnet IDs for ECS Express (internet-facing ALB). Defaults to app_runner_subnet_ids (private)."
+  type        = list(string)
+  default     = []
+}
+
+variable "ecs_express_configure_alb" {
+  description = "Enable ALB configuration (WAF, timeout, domain). Set to true after first ECS Express deploy when service is running."
+  type        = bool
+  default     = false
+}
+
+variable "primary_platform" {
+  description = "Which platform serves the custom domain: apprunner, ecs_express, or eks. Only affects Route53/WAF routing."
+  type        = string
+  default     = "apprunner"
+
+  validation {
+    condition     = contains(["apprunner", "ecs_express", "eks"], var.primary_platform)
+    error_message = "primary_platform must be one of: apprunner, ecs_express, eks."
+  }
+}
+
 # =============================================================================
 # EKS Configuration
 # =============================================================================

--- a/deployment/terraform-existing-vpc/waf.tf
+++ b/deployment/terraform-existing-vpc/waf.tf
@@ -367,6 +367,14 @@ resource "aws_wafv2_web_acl_association" "backend" {
   depends_on = [null_resource.wait_for_backend_ready]
 }
 
+# ECS Express WAF association — attaches to the auto-created ALB.
+# Only created when ecs_express_configure_alb is enabled (after first deploy).
+resource "aws_wafv2_web_acl_association" "ecs_express_backend" {
+  count        = var.waf_enabled && var.enable_ecs_express && var.ecs_express_configure_alb ? 1 : 0
+  resource_arn = data.aws_lb.ecs_express[0].arn
+  web_acl_arn  = aws_wafv2_web_acl.backend[0].arn
+}
+
 resource "aws_wafv2_web_acl_association" "mcp_atlassian" {
   count        = var.waf_enabled && local.mcp_atlassian_can_deploy ? 1 : 0
   resource_arn = aws_apprunner_service.mcp_atlassian[0].arn

--- a/tests/test_continuation_error_handling.py
+++ b/tests/test_continuation_error_handling.py
@@ -304,6 +304,287 @@ class TestContinuationStreamErrors:
             f"Should mention timeout specifically: {text_results}"
 
 
+class TestContinuationStreamRetry:
+    """Tests for EventStreamError retry logic in _handle_continuation_response."""
+
+    @patch("bondable.bond.providers.bedrock.BedrockAgent.time.sleep")
+    def test_event_stream_error_retried_then_succeeds(self, mock_sleep):
+        """EventStreamError with no content yielded → retry succeeds on second attempt."""
+        agent = _make_agent()
+        agent._handle_return_control = MagicMock(return_value=_make_tool_results())
+        agent._handle_chunk_event = MagicMock(return_value="Success after retry")
+
+        # First stream: raises EventStreamError immediately (no content yielded)
+        failing_stream = MagicMock()
+        failing_stream.__iter__ = MagicMock(side_effect=EventStreamError(
+            {
+                "Error": {
+                    "Code": "dependencyFailedException",
+                    "Message": "Dependency resource: bedrock failed to process."
+                }
+            },
+            "InvokeAgent"
+        ))
+
+        # Second stream: succeeds with a text chunk
+        success_events = [
+            {"chunk": {"bytes": b"success data"}},
+            {"sessionState": {"some": "state"}}
+        ]
+
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.side_effect = [
+            {"completion": failing_stream},
+            {"completion": iter(success_events)},
+        ]
+
+        return_control = _make_return_control()
+        results = list(agent._handle_continuation_response(
+            return_control=return_control,
+            session_id="test-session",
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=0
+        ))
+
+        text_results = [r for r in results if isinstance(r, str)]
+        assert any("Success after retry" in r for r in text_results), \
+            f"Should contain success text from retry: {text_results}"
+        # No error message should be present
+        assert not any("error" in r.lower() for r in text_results), \
+            f"Should NOT have error message after successful retry: {text_results}"
+        # invoke_agent called exactly 2 times (original + 1 retry)
+        assert agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.call_count == 2
+        # sleep called once for the retry delay
+        assert mock_sleep.call_count >= 1
+
+    def test_event_stream_error_with_content_yielded_no_retry(self):
+        """Stream yields text chunk then EventStreamError → no retry."""
+        agent = _make_agent()
+        agent._handle_return_control = MagicMock(return_value=_make_tool_results())
+        agent._handle_chunk_event = MagicMock(return_value="Partial content")
+
+        # Stream yields one chunk then raises
+        def stream_events():
+            yield {"chunk": {"bytes": b"data"}}
+            raise EventStreamError(
+                {
+                    "Error": {
+                        "Code": "dependencyFailedException",
+                        "Message": "Failure after content"
+                    }
+                },
+                "InvokeAgent"
+            )
+
+        mock_stream = MagicMock()
+        mock_stream.__iter__ = MagicMock(side_effect=stream_events)
+
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.return_value = {
+            "completion": mock_stream
+        }
+
+        return_control = _make_return_control()
+        results = list(agent._handle_continuation_response(
+            return_control=return_control,
+            session_id="test-session",
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=0
+        ))
+
+        text_results = [r for r in results if isinstance(r, str)]
+        # Should have the partial content and an error message
+        assert any("Partial content" in r for r in text_results)
+        assert any("error" in r.lower() for r in text_results)
+        # Should NOT have retried - only 1 invoke_agent call
+        assert agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.call_count == 1
+
+    def test_event_stream_error_with_file_yielded_no_retry(self):
+        """Stream yields files_event then EventStreamError → no retry (file already sent)."""
+        agent = _make_agent()
+        agent._handle_return_control = MagicMock(return_value=_make_tool_results())
+
+        # Stream yields a files event then raises
+        def stream_events():
+            yield {"files": {"files": [{"name": "test.pdf", "bytes": b"data"}]}}
+            raise EventStreamError(
+                {
+                    "Error": {
+                        "Code": "dependencyFailedException",
+                        "Message": "Failure after file"
+                    }
+                },
+                "InvokeAgent"
+            )
+
+        mock_stream = MagicMock()
+        mock_stream.__iter__ = MagicMock(side_effect=stream_events)
+
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.return_value = {
+            "completion": mock_stream
+        }
+
+        return_control = _make_return_control()
+        results = list(agent._handle_continuation_response(
+            return_control=return_control,
+            session_id="test-session",
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=0
+        ))
+
+        text_results = [r for r in results if isinstance(r, str)]
+        dict_results = [r for r in results if isinstance(r, dict)]
+        # Should have yielded the file event
+        assert any('files_event' in r for r in dict_results), \
+            f"Should have yielded files_event: {dict_results}"
+        # Should have error message (no retry due to file yield)
+        assert any("error" in r.lower() for r in text_results), \
+            f"Should have error message: {text_results}"
+        # Should NOT have retried - only 1 invoke_agent call
+        assert agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.call_count == 1
+
+    @patch("bondable.bond.providers.bedrock.BedrockAgent.time.sleep")
+    def test_event_stream_error_all_retries_exhausted(self, mock_sleep):
+        """EventStreamError on all attempts → error message after exhausting retries."""
+        agent = _make_agent()
+        agent._handle_return_control = MagicMock(return_value=_make_tool_results())
+
+        # All streams raise EventStreamError
+        mock_stream = MagicMock()
+        mock_stream.__iter__ = MagicMock(side_effect=EventStreamError(
+            {
+                "Error": {
+                    "Code": "dependencyFailedException",
+                    "Message": "Persistent failure"
+                }
+            },
+            "InvokeAgent"
+        ))
+
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.return_value = {
+            "completion": mock_stream
+        }
+
+        return_control = _make_return_control()
+        results = list(agent._handle_continuation_response(
+            return_control=return_control,
+            session_id="test-session",
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=0
+        ))
+
+        text_results = [r for r in results if isinstance(r, str)]
+        assert len(text_results) > 0, "Should yield error message after exhausting retries"
+        assert any("transient error" in r.lower() for r in text_results), \
+            f"Should mention transient error: {text_results}"
+        # invoke_agent called 2 times (1 original + 1 retry = MAX_STREAM_RETRIES + 1)
+        assert agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.call_count == 2
+
+    @patch("bondable.bond.providers.bedrock.BedrockAgent.time.sleep")
+    def test_stream_retry_uses_exponential_backoff(self, mock_sleep):
+        """Assert time.sleep called with correct delay value on stream retry."""
+        agent = _make_agent()
+        agent._handle_return_control = MagicMock(return_value=_make_tool_results())
+        agent._handle_chunk_event = MagicMock(return_value="Success")
+
+        # First stream fails, second succeeds
+        failing_stream = MagicMock()
+        failing_stream.__iter__ = MagicMock(side_effect=EventStreamError(
+            {
+                "Error": {
+                    "Code": "dependencyFailedException",
+                    "Message": "Transient"
+                }
+            },
+            "InvokeAgent"
+        ))
+
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.side_effect = [
+            {"completion": failing_stream},
+            {"completion": iter([{"chunk": {"bytes": b"ok"}}])},
+        ]
+
+        return_control = _make_return_control()
+        list(agent._handle_continuation_response(
+            return_control=return_control,
+            session_id="test-session",
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=0
+        ))
+
+        # Verify exponential backoff: INVOKE_RETRY_BASE_DELAY * (2 ** stream_attempt)
+        # stream_attempt=0, so delay = 1.0 * (2 ** 0) = 1.0
+        sleep_calls = [call.args[0] for call in mock_sleep.call_args_list]
+        assert 1.0 in sleep_calls, \
+            f"Should have slept for 1.0s on first stream retry, got: {sleep_calls}"
+
+    def test_stream_retry_with_nested_return_control_before_error(self):
+        """Stream yields returnControl (nested tool call) then errors → no retry."""
+        agent = _make_agent()
+        agent._handle_return_control = MagicMock(return_value=_make_tool_results())
+        agent._handle_chunk_event = MagicMock(return_value="Nested text")
+
+        nested_return_control = _make_return_control(invocation_id="inv-nested")
+
+        # Depth-0 stream: yields returnControl then raises
+        def depth0_events():
+            yield {"returnControl": nested_return_control}
+            raise EventStreamError(
+                {
+                    "Error": {
+                        "Code": "dependencyFailedException",
+                        "Message": "Failure after nested"
+                    }
+                },
+                "InvokeAgent"
+            )
+
+        # Depth-1 stream: succeeds with text
+        depth1_stream = iter([
+            {"chunk": {"bytes": b"nested data"}},
+            {"sessionState": {"some": "state"}}
+        ])
+
+        call_count = [0]
+        def mock_invoke_agent(**kwargs):
+            call_count[0] += 1
+            if call_count[0] == 1:
+                # First call (depth=0): stream with returnControl then error
+                mock_stream = MagicMock()
+                mock_stream.__iter__ = MagicMock(side_effect=depth0_events)
+                return {"completion": mock_stream}
+            elif call_count[0] == 2:
+                # Second call (depth=1 nested): succeeds
+                return {"completion": depth1_stream}
+            else:
+                # Should not be called again (no retry since nested yielded content)
+                return {"completion": iter([])}
+
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.side_effect = mock_invoke_agent
+
+        return_control = _make_return_control()
+        results = list(agent._handle_continuation_response(
+            return_control=return_control,
+            session_id="test-session",
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=0
+        ))
+
+        text_results = [r for r in results if isinstance(r, str)]
+        # Should have the nested text and an error (no retry because content was yielded)
+        assert any("Nested text" in r for r in text_results), \
+            f"Should have nested text: {text_results}"
+        assert any("error" in r.lower() for r in text_results), \
+            f"Should have error message (no retry): {text_results}"
+        # invoke_agent called exactly 2 times (depth=0 + depth=1 nested, no retry)
+        assert call_count[0] == 2, \
+            f"Should have 2 invoke_agent calls (no retry), got: {call_count[0]}"
+
+
 class TestContinuationNormalFlow:
     """Tests that normal continuation flow still works with the new error handling."""
 
@@ -386,8 +667,14 @@ class TestContinuationNormalFlow:
 class TestContinuationNestedReturnControl:
     """Tests for nested returnControl handling with error paths."""
 
-    def test_nested_event_stream_error_caught_at_depth(self):
-        """EventStreamError at depth=1 should be caught and yield error message."""
+    @patch("bondable.bond.providers.bedrock.BedrockAgent.time.sleep")
+    def test_nested_event_stream_error_caught_at_depth(self, mock_sleep):
+        """EventStreamError at depth=1 should be caught and yield error message.
+
+        The depth-1 handler has its own independent retry loop (any_content_yielded=False
+        at depth=1), so it retries once before exhausting MAX_STREAM_RETRIES.
+        Total invoke_agent calls: 1 (depth=0) + 2 (depth=1 original + retry) = 3.
+        """
         agent = _make_agent()
 
         agent._handle_return_control = MagicMock(return_value=_make_tool_results())
@@ -401,7 +688,8 @@ class TestContinuationNestedReturnControl:
             {"returnControl": nested_return_control},
         ]
 
-        # Depth-1 continuation: raises EventStreamError
+        # Depth-1 continuation: always raises EventStreamError (fails on both
+        # the original attempt and the retry at depth=1)
         depth1_stream = MagicMock()
         depth1_stream.__iter__ = MagicMock(side_effect=EventStreamError(
             {
@@ -421,7 +709,7 @@ class TestContinuationNestedReturnControl:
                 # First call (depth=0): return stream with chunk + nested returnControl
                 return {"completion": iter(depth0_events)}
             else:
-                # Second call (depth=1): return stream that errors
+                # All subsequent calls (depth=1 original + depth=1 retry): return erroring stream
                 return {"completion": depth1_stream}
 
         agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.side_effect = mock_invoke_agent
@@ -441,6 +729,9 @@ class TestContinuationNestedReturnControl:
             f"Should preserve depth-0 text: {text_results}"
         assert any("error" in r.lower() for r in text_results), \
             f"Should have error message from depth-1: {text_results}"
+        # 3 invoke_agent calls: 1 for depth=0, 2 for depth=1 (original + stream retry)
+        assert call_count[0] == 3, \
+            f"Expected 3 invoke_agent calls (depth=0 + depth=1 with retry), got: {call_count[0]}"
 
     def test_depth_limit_exceeded_yields_error(self):
         """Exceeding MAX_TOOL_CALL_DEPTH should yield error, not recurse infinitely."""


### PR DESCRIPTION
## Summary

Adds **ECS Express Mode** as a third compute platform alongside the existing **App Runner** and **EKS** options. Default `enable_ecs_express = false` — existing deployments see zero behavior change unless they opt in.

Bundled with two small, independent bug fixes (nginx CSP follow-up and Bedrock stream retry) per scope discussion.

## Why ECS Express

- **App Runner enforces a hard 2-minute request timeout** that kills long-running agent responses.
- **AWS deprecates App Runner on 2026-04-30** — we need a viable successor regardless.
- **ECS Express auto-provisions an ALB** whose `idle_timeout` is configurable up to 4000s (set to 300s here, matching `nginx proxy_read_timeout`).

## EKS impact — verified safe

Detailed per-file audit (see plan doc for full notes):

- `local.backend_env_vars` refactor: consumed by App Runner + ECS Express only. EKS uses `eks-kubernetes.tf` with its own env vars built around `local.eks_oauth_base_url`.
- `custom-domain.tf` gating on `primary_platform == \"apprunner\"`: only affects App Runner's custom domain path. EKS has a separate `eks-domain.tf` using `var.eks_custom_domain_name`.
- New `check \"primary_platform_enabled\"`: uses `var.custom_domain_name` (the App Runner var), so EKS deployments using `eks_custom_domain_name` won't trigger it.
- `ecs-express-iam.tf` reuses unmodified `local.backend_shared_policy_statements` (same local EKS uses in `eks-iam.tf:48`).
- `nginx-combined.conf` CSP change: EKS uses the same combined Docker image, so the relaxation enables FilePreviewCard iframes on EKS too — strict improvement, not a regression.

## Commits (4)

1. `refactor(terraform): extract backend env vars to shared local` — pure refactor, zero resource diff.
2. `feat(terraform): add ECS Express Mode as third compute platform` — the bulk of the work. New: `ecs-express.tf`, `ecs-express-iam.tf`, `ecs-express-domain.tf`. Modified: variables, data-sources, outputs, waf, validate-deployment, custom-domain.
3. `fix(nginx): allow blob: iframes in CSP for FilePreviewCard` — 1-line follow-up to PR #190.
4. `fix(bedrock): retry transient EventStreamError when no content yielded` — `MAX_STREAM_RETRIES = 1` outer retry loop with safe-retry semantics; also fixes one missed `httpStatusCode: 500 → 200`.

## Test plan

- [x] `poetry run python -m pytest tests/test_continuation_error_handling.py -v` — **18/18 passing** (12 pre-existing + 6 new in `TestContinuationStreamRetry` + 1 updated nested case).
- [x] `terraform validate` — Success on touched files.
- [x] `terraform fmt -check` on touched files — clean (pre-existing fmt issues in `aurora.tf` / `cloudtrail.tf` / `eks*.tf` are out of scope).
- [ ] Deployment-time: `terraform plan` with default tfvars shows zero resource diff.
- [ ] Deployment-time: `terraform plan` with `enable_ecs_express = true` shows additive resources only (no App Runner or EKS destroys).
- [ ] Deployment-time (when cutover desired): two-phase deploy per `ecs-express.tf` header — first apply with `ecs_express_configure_alb = false`, verify service is up via the validation-script-printed endpoint, then re-apply with `= true` for WAF + custom domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)