### PR TITLE
feat(mcp): discover MCPs from bond-mcps and delegate OAuth connect

### DIFF
--- a/.env.combined.example
+++ b/.env.combined.example
@@ -38,3 +38,15 @@ CORS_ALLOWED_ORIGINS="http://localhost,http://localhost:8000,http://localhost:30
 # has no session and the UI thinks you're logged out, with no error anywhere.
 # Production stays secure=true by default.
 COOKIE_SECURE=false
+
+# bond-ai discovers MCPs from bond-mcps through the front door (nginx :8000 →
+# bond-mcps auth proxy :18000). One URL; bond-ai polls it so MCPs can change in
+# bond-mcps without restarting bond-ai.
+BOND_MCPS_DISCOVERY_URL="http://localhost:8000/connections/discovery"
+
+# To exercise the delegated Connect flow locally, bond-mcps must run with JWT
+# mode ON (this un-dormants its /connect/* routes) using the SHARED SECRET:
+#   in ../bond-mcps:  BOND_MCPS_JWT_PUBLIC_KEY=<bond-ai JWT_SECRET_KEY>
+#                     BOND_MCPS_JWT_ALGORITHM=HS256
+#                     BOND_MCPS_JWT_ISSUER=bond-ai
+#                     BOND_MCPS_JWT_AUDIENCE=mcp-server

--- a/.env.example
+++ b/.env.example
@@ -97,7 +97,28 @@ FIREBASE_USER_ID="test-user-id"  # Used for testing
 # ==============================================================================
 # MCP (Model Context Protocol) CONFIGURATION (Optional)
 # ==============================================================================
-# MCP Server Configuration (JSON format)
+# bond-ai discovers the set of bond-mcps-managed MCP servers from bond-mcps'
+# discovery endpoint instead of hard-configuring them here. Set ONE URL; bond-ai
+# polls it periodically (TTL below) so MCPs can be added/removed in bond-mcps
+# without restarting bond-ai. When unset, discovery is disabled and only the
+# static BOND_MCP_CONFIG below is used.
+#   local dev / combined mode: http://localhost:8000/connections/discovery
+#   deployed (same EKS cluster): http://auth.<namespace>.svc.cluster.local:8000/connections/discovery
+# BOND_MCPS_DISCOVERY_URL="http://localhost:8000/connections/discovery"
+# BOND_MCPS_DISCOVERY_TTL_SECONDS=300       # cache/poll interval (default 300)
+# BOND_MCPS_DISCOVERY_TIMEOUT_SECONDS=5     # per-request HTTP timeout (default 5)
+#
+# Shared-secret JWT trust: discovered MCPs are authenticated with bond-ai's Bond
+# JWT, which bond-mcps validates with the SAME secret. Configure bond-mcps with:
+#   BOND_MCPS_JWT_PUBLIC_KEY=<this app's JWT_SECRET_KEY>   (the shared secret)
+#   BOND_MCPS_JWT_ALGORITHM=HS256
+#   BOND_MCPS_JWT_ISSUER=bond-ai
+#   BOND_MCPS_JWT_AUDIENCE=mcp-server
+# bond-ai never stores provider tokens for managed MCPs — bond-mcps owns them.
+#
+# Static MCP Server Configuration (JSON format). Fallback set used when discovery
+# is disabled/unreachable, plus any non-managed servers. Do NOT put managed-
+# provider oauth_config (scopes/client_id/...) here anymore — bond-mcps owns it.
 BOND_MCP_CONFIG='{
     "mcpServers": {
         "my_client": {

--- a/bondable/bond/config.py
+++ b/bondable/bond/config.py
@@ -439,8 +439,13 @@ class Config:
         """
         Get MCP configuration in fastmcp format.
 
-        Tries app config secret first (bond_mcp_config key), then falls back
-        to BOND_MCP_CONFIG environment variable.
+        The set of bond-mcps-managed MCP servers is fetched from the bond-mcps
+        discovery endpoint (when ``BOND_MCPS_DISCOVERY_URL`` is set) and overlaid
+        on the static config so bond-ai does not hard-configure the list of MCPs.
+        Discovered servers are authenticated with the Bond JWT (``bond_jwt``);
+        bond-mcps owns their OAuth config and per-user tokens. The static config
+        (Secrets Manager ``bond_mcp_config`` key, then ``BOND_MCP_CONFIG`` env)
+        provides the fallback set used when discovery is disabled or unreachable.
 
         Example:
         BOND_MCP_CONFIG='{
@@ -460,6 +465,10 @@ class Config:
         Returns:
             Dict in fastmcp config format
         """
+        return self._overlay_discovered_mcps(self._load_static_mcp_config())
+
+    def _load_static_mcp_config(self):
+        """Load the static MCP config (Secrets Manager first, then env var)."""
         # Try app config secret first
         app_config = self._load_app_config()
         mcp_config = app_config.get('bond_mcp_config')
@@ -493,6 +502,53 @@ class Config:
         except json.JSONDecodeError as e:
             LOGGER.error(f"Error parsing BOND_MCP_CONFIG: {e}")
             return {"mcpServers": {}}
+
+    def _overlay_discovered_mcps(self, mcp_config):
+        """Overlay bond-mcps discovery results onto the static MCP config.
+
+        For each discovered MCP (``{name, display_name, url}``) the merged server
+        entry uses the discovered ``url``/``display_name`` and is forced to
+        ``auth_type=bond_jwt`` + ``transport=streamable-http`` (bond-mcps owns its
+        OAuth). Any non-OAuth annotations already present in the static config for
+        that name (e.g. ``description``, ``icon_url``, ``allowed_tools``) are
+        preserved; a stale inline ``oauth_config`` is dropped. Servers not present
+        in discovery (user-defined live in the DB, not here; ``command`` servers
+        like ``hello``) are left untouched. No-op when discovery is disabled.
+        """
+        try:
+            from bondable.bond.mcp_discovery import get_discovered_mcps
+            discovered = get_discovered_mcps()
+        except Exception as e:  # never let discovery break config loading
+            LOGGER.warning(f"MCP discovery overlay skipped due to error: {e}")
+            return mcp_config
+
+        if not discovered:
+            return mcp_config
+
+        if not isinstance(mcp_config, dict):
+            mcp_config = {}
+        servers = dict(mcp_config.get("mcpServers", {}))
+
+        for entry in discovered:
+            name = entry["name"]
+            existing = dict(servers.get(name, {}))
+            # Drop any stale inline OAuth config — bond-mcps owns OAuth now.
+            existing.pop("oauth_config", None)
+            existing.update({
+                "url": entry["url"],
+                "display_name": entry.get("display_name", existing.get("display_name", name)),
+                "transport": "streamable-http",
+                "auth_type": "bond_jwt",
+            })
+            servers[name] = existing
+
+        result = dict(mcp_config)
+        result["mcpServers"] = servers
+        LOGGER.info(
+            "Overlaid %d discovered MCP server(s); effective MCP count=%d",
+            len(discovered), len(servers),
+        )
+        return result
 
     def get_admin_users(self) -> list:
         """

--- a/bondable/bond/mcp_connect_client.py
+++ b/bondable/bond/mcp_connect_client.py
@@ -19,6 +19,7 @@ in that case so callers can omit it from the connectable list.
 from __future__ import annotations
 
 import logging
+import re
 from typing import Any, Dict, Optional
 from urllib.parse import urlparse
 
@@ -28,9 +29,26 @@ LOGGER = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_SECONDS = 10.0
 
+# Anything outside this set is stripped before a name is used as a URL path
+# segment. MCP/provider names are short identifiers (e.g. "atlassian",
+# "ms-graph"), so legitimate values pass through unchanged.
+_UNSAFE_NAME_CHARS = re.compile(r"[^A-Za-z0-9_.-]")
+
 
 class ConnectError(Exception):
     """Raised when a bond-mcps connect call fails (network/HTTP/parse)."""
+
+
+def _safe_name(name: str) -> str:
+    """Sanitize an MCP/provider name for safe use as a URL path segment.
+
+    The connection name originates from a request path parameter, so it must not
+    be able to alter the request host/path (SSRF) — strip ``/``, ``@``, ``?`` and
+    any other URL-control characters. This also breaks CodeQL's taint chain
+    (``py/partial-ssrf``), mirroring the same defense in ``connections.py``'s
+    ``oauth_callback``. Legitimate names are unaffected.
+    """
+    return _UNSAFE_NAME_CHARS.sub("_", name or "")
 
 
 def connect_base_url(mcp_url: str) -> str:
@@ -60,7 +78,7 @@ async def mint_connect_ticket(
     ``return_url`` through to the callback so the user is sent back to bond-ai.
     """
     base = connect_base_url(mcp_url)
-    url = f"{base}/connect/{name}/ticket"
+    url = f"{base}/connect/{_safe_name(name)}/ticket"
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
             resp = await client.post(
@@ -92,7 +110,7 @@ async def get_connect_status(
     error this raises :class:`ConnectError` (callers decide how to fail soft).
     """
     base = connect_base_url(mcp_url)
-    url = f"{base}/connect/{name}/status"
+    url = f"{base}/connect/{_safe_name(name)}/status"
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
             resp = await client.get(url, headers=_auth_headers(jwt_token))
@@ -116,7 +134,7 @@ async def delete_connection(
 ) -> bool:
     """Delete the user's stored provider token for an MCP via bond-mcps."""
     base = connect_base_url(mcp_url)
-    url = f"{base}/connect/{name}"
+    url = f"{base}/connect/{_safe_name(name)}"
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
             resp = await client.request("DELETE", url, headers=_auth_headers(jwt_token))

--- a/bondable/bond/mcp_connect_client.py
+++ b/bondable/bond/mcp_connect_client.py
@@ -1,0 +1,132 @@
+"""HTTP client for bond-mcps' per-MCP "connect" (OAuth delegation) endpoints.
+
+For bond-mcps-managed MCPs, bond-ai does NOT drive the provider OAuth flow or
+store provider tokens. It delegates to bond-mcps, forwarding the user's Bond JWT
+(which bond-mcps validates via the shared secret). These endpoints live on the
+same origin as each MCP's ``/mcp`` route (its discovered URL):
+
+    POST   {base}/connect/{name}/ticket   body {return_url} -> {ticket, connect_url}
+    GET    {base}/connect/{name}/status                      -> {connected, valid, scopes, expires_at}
+    DELETE {base}/connect/{name}                             -> {disconnected}
+
+``base`` is the origin (scheme://host[:port]) of the MCP's discovered URL — the
+discovery path (e.g. ``/mcp``) is stripped. All calls forward
+``Authorization: Bearer <jwt>``. A missing connect surface (HTTP 404) means the
+MCP has no OAuth connection to manage; :func:`get_connect_status` returns ``None``
+in that case so callers can omit it from the connectable list.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+LOGGER = logging.getLogger(__name__)
+
+DEFAULT_TIMEOUT_SECONDS = 10.0
+
+
+class ConnectError(Exception):
+    """Raised when a bond-mcps connect call fails (network/HTTP/parse)."""
+
+
+def connect_base_url(mcp_url: str) -> str:
+    """Return the ``scheme://host[:port]`` origin of a discovered MCP URL."""
+    parsed = urlparse(mcp_url)
+    if not parsed.scheme or not parsed.netloc:
+        raise ConnectError(f"invalid MCP URL: {mcp_url!r}")
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _auth_headers(jwt_token: Optional[str]) -> Dict[str, str]:
+    if not jwt_token:
+        raise ConnectError("a Bond JWT is required to call bond-mcps connect endpoints")
+    return {"Authorization": f"Bearer {jwt_token}", "Accept": "application/json"}
+
+
+async def mint_connect_ticket(
+    mcp_url: str,
+    name: str,
+    jwt_token: str,
+    return_url: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> str:
+    """Mint a connect ticket and return the browser ``connect_url``.
+
+    bond-mcps binds the ticket to the JWT's ``sub`` and (per the contract) carries
+    ``return_url`` through to the callback so the user is sent back to bond-ai.
+    """
+    base = connect_base_url(mcp_url)
+    url = f"{base}/connect/{name}/ticket"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.post(
+                url,
+                json={"return_url": return_url},
+                headers=_auth_headers(jwt_token),
+            )
+            resp.raise_for_status()
+            payload = resp.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise ConnectError(f"connect ticket failed for {name}: {type(exc).__name__}: {exc}") from exc
+
+    connect_url = payload.get("connect_url") if isinstance(payload, dict) else None
+    if not isinstance(connect_url, str) or not connect_url.strip():
+        raise ConnectError(f"connect ticket response for {name} missing connect_url")
+    return connect_url.strip()
+
+
+async def get_connect_status(
+    mcp_url: str,
+    name: str,
+    jwt_token: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Optional[Dict[str, Any]]:
+    """Return the user's connection status for an MCP, or ``None``.
+
+    ``None`` means the MCP exposes no connect surface (HTTP 404) — i.e. it needs
+    no provider connection and should not be shown as connectable. On any other
+    error this raises :class:`ConnectError` (callers decide how to fail soft).
+    """
+    base = connect_base_url(mcp_url)
+    url = f"{base}/connect/{name}/status"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.get(url, headers=_auth_headers(jwt_token))
+            if resp.status_code == 404:
+                return None
+            resp.raise_for_status()
+            payload = resp.json()
+    except (httpx.HTTPError, ValueError) as exc:
+        raise ConnectError(f"connect status failed for {name}: {type(exc).__name__}: {exc}") from exc
+
+    if not isinstance(payload, dict):
+        raise ConnectError(f"connect status response for {name} is not an object")
+    return payload
+
+
+async def delete_connection(
+    mcp_url: str,
+    name: str,
+    jwt_token: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> bool:
+    """Delete the user's stored provider token for an MCP via bond-mcps."""
+    base = connect_base_url(mcp_url)
+    url = f"{base}/connect/{name}"
+    try:
+        async with httpx.AsyncClient(timeout=timeout) as client:
+            resp = await client.request("DELETE", url, headers=_auth_headers(jwt_token))
+            if resp.status_code == 404:
+                return False
+            resp.raise_for_status()
+            payload = resp.json() if resp.content else {}
+    except (httpx.HTTPError, ValueError) as exc:
+        raise ConnectError(f"disconnect failed for {name}: {type(exc).__name__}: {exc}") from exc
+
+    if isinstance(payload, dict) and "disconnected" in payload:
+        return bool(payload["disconnected"])
+    return True

--- a/bondable/bond/mcp_discovery.py
+++ b/bondable/bond/mcp_discovery.py
@@ -1,0 +1,274 @@
+"""MCP discovery client.
+
+bond-ai no longer hard-configures the list of MCP servers and their endpoints.
+Instead it fetches the set of available MCPs from bond-mcps' discovery endpoint
+(``GET <BOND_MCPS_DISCOVERY_URL>``), which returns::
+
+    {"mcps": [{"name": "atlassian", "display_name": "Atlassian",
+               "url": "http://localhost:18003/mcp"}, ...]}
+
+Everything beyond the endpoint URL (tools, auth, capabilities) is learned via the
+MCP protocol itself. Discovery only answers "which MCPs exist and where".
+
+Results are cached in-process with a TTL and refreshed lazily on access (and
+optionally by a background poller started at app startup) so MCPs can be added or
+removed in bond-mcps **without restarting bond-ai**. On any fetch error or an
+empty response the client *fails soft*: it returns the last good result if one is
+cached, otherwise an empty list, and callers fall back to whatever static MCP
+config bond-ai still carries.
+
+Configuration (all via environment):
+
+- ``BOND_MCPS_DISCOVERY_URL`` — full discovery URL. When unset, discovery is
+  disabled and :func:`get_discovered_mcps` returns ``[]`` (pure static config).
+- ``BOND_MCPS_DISCOVERY_TTL_SECONDS`` — cache TTL (default 300).
+- ``BOND_MCPS_DISCOVERY_TIMEOUT_SECONDS`` — per-request HTTP timeout (default 5).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import os
+import threading
+import time
+from typing import Any, Dict, List, Optional
+from urllib.parse import urlparse
+
+import httpx
+
+LOGGER = logging.getLogger(__name__)
+
+ENV_DISCOVERY_URL = "BOND_MCPS_DISCOVERY_URL"
+ENV_DISCOVERY_TTL = "BOND_MCPS_DISCOVERY_TTL_SECONDS"
+ENV_DISCOVERY_TIMEOUT = "BOND_MCPS_DISCOVERY_TIMEOUT_SECONDS"
+
+DEFAULT_TTL_SECONDS = 300
+DEFAULT_TIMEOUT_SECONDS = 5.0
+
+# SSRF protection: never let a (mis)configured discovery URL reach a cloud
+# metadata endpoint. Mirrors the blocklist in
+# ``bondable/rest/routers/user_mcp_servers.py`` (localhost is intentionally
+# allowed — discovery is localhost in local dev).
+_SSRF_BLOCKED_HOSTNAMES = frozenset({
+    "metadata.google.internal",
+    "169.254.169.254",
+    "169.254.170.2",   # AWS ECS task metadata
+    "fd00:ec2::254",   # AWS IMDSv2 IPv6
+})
+
+
+class DiscoveryError(Exception):
+    """Raised internally when a discovery fetch cannot be completed."""
+
+
+def get_discovery_url() -> Optional[str]:
+    """Return the configured discovery URL, or ``None`` if discovery is off."""
+    url = os.environ.get(ENV_DISCOVERY_URL, "").strip()
+    return url or None
+
+
+def _get_ttl_seconds() -> float:
+    try:
+        return float(os.environ.get(ENV_DISCOVERY_TTL, DEFAULT_TTL_SECONDS))
+    except (TypeError, ValueError):
+        return float(DEFAULT_TTL_SECONDS)
+
+
+def _get_timeout_seconds() -> float:
+    try:
+        return float(os.environ.get(ENV_DISCOVERY_TIMEOUT, DEFAULT_TIMEOUT_SECONDS))
+    except (TypeError, ValueError):
+        return float(DEFAULT_TIMEOUT_SECONDS)
+
+
+def _validate_url_ssrf(url: str) -> None:
+    """Raise :class:`DiscoveryError` if ``url`` targets a blocked host/scheme."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        raise DiscoveryError(f"discovery URL scheme not allowed: {parsed.scheme!r}")
+    hostname = (parsed.hostname or "").lower()
+    if not hostname:
+        raise DiscoveryError("discovery URL has no hostname")
+    if hostname in _SSRF_BLOCKED_HOSTNAMES:
+        raise DiscoveryError(f"discovery URL hostname is blocked: {hostname}")
+    try:
+        if ipaddress.ip_address(hostname).is_link_local:
+            raise DiscoveryError(f"discovery URL hostname is blocked (link-local): {hostname}")
+    except ValueError:
+        pass  # not an IP literal — exact-match check above is sufficient
+
+
+def _parse_response(payload: Any) -> List[Dict[str, str]]:
+    """Coerce a discovery response into a clean list of MCP entries.
+
+    Malformed entries (missing ``name``/``url`` or wrong types) are skipped so a
+    single bad entry never breaks discovery for the others.
+    """
+    if not isinstance(payload, dict):
+        raise DiscoveryError("discovery response is not a JSON object")
+    raw = payload.get("mcps")
+    if not isinstance(raw, list):
+        raise DiscoveryError("discovery response missing 'mcps' list")
+
+    entries: List[Dict[str, str]] = []
+    for item in raw:
+        if not isinstance(item, dict):
+            continue
+        name = item.get("name")
+        url = item.get("url")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        if not isinstance(url, str) or not url.strip():
+            continue
+        url = url.strip()
+        # SSRF defense-in-depth: bond-ai dials these URLs server-side with the
+        # user's Bond JWT attached (connect flow + tool calls), so a poisoned or
+        # MITM'd discovery response must never point us at a metadata/link-local
+        # endpoint. Drop offenders rather than trust the discovery source blindly.
+        try:
+            _validate_url_ssrf(url)
+        except DiscoveryError as exc:
+            LOGGER.warning("Skipping discovered MCP %r: %s", name.strip(), exc)
+            continue
+        display_name = item.get("display_name")
+        if not isinstance(display_name, str) or not display_name.strip():
+            display_name = name
+        entries.append({
+            "name": name.strip(),
+            "display_name": display_name.strip(),
+            "url": url,
+        })
+    return entries
+
+
+class _DiscoveryCache:
+    """Thread-safe TTL cache for discovered MCP entries with fail-soft refresh."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._entries: Optional[List[Dict[str, str]]] = None
+        self._fetched_at: float = 0.0
+        self._poller: Optional[threading.Thread] = None
+        self._poller_stop: Optional[threading.Event] = None
+
+    def reset(self) -> None:
+        """Clear cached state (primarily for tests)."""
+        with self._lock:
+            self._entries = None
+            self._fetched_at = 0.0
+
+    def _is_fresh(self) -> bool:
+        return (
+            self._entries is not None
+            and (time.monotonic() - self._fetched_at) < _get_ttl_seconds()
+        )
+
+    def get(self, force_refresh: bool = False) -> List[Dict[str, str]]:
+        url = get_discovery_url()
+        if not url:
+            return []
+
+        with self._lock:
+            if not force_refresh:
+                # When a background poller owns refreshing (the server runs one via
+                # the app lifespan), request threads must NEVER do a synchronous
+                # fetch — they may be on an event loop, and a blocking HTTP call
+                # would stall the whole worker. Read whatever the poller cached
+                # (possibly empty on the brief startup window → the caller falls
+                # back to static config until the poller's first refresh lands).
+                # Without a poller (scripts/CLI, off the event loop) lazy fetch is
+                # the right behaviour, so we only short-circuit when one is alive.
+                poller_active = self._poller is not None and self._poller.is_alive()
+                if poller_active or self._is_fresh():
+                    return list(self._entries or [])
+
+        # Fetch outside the lock so a slow endpoint doesn't block other readers.
+        try:
+            entries = self._fetch(url)
+        except DiscoveryError as exc:
+            LOGGER.warning("MCP discovery fetch failed (%s); failing soft", exc)
+            with self._lock:
+                # Serve the last good result if we have one, else empty.
+                return list(self._entries or [])
+
+        with self._lock:
+            self._entries = entries
+            self._fetched_at = time.monotonic()
+            return list(entries)
+
+    def _fetch(self, url: str) -> List[Dict[str, str]]:
+        _validate_url_ssrf(url)
+        try:
+            resp = httpx.get(url, timeout=_get_timeout_seconds())  # nosec B113 - timeout always set (defaults to 5s)
+            resp.raise_for_status()
+            payload = resp.json()
+        except (httpx.HTTPError, ValueError) as exc:
+            raise DiscoveryError(f"{type(exc).__name__}: {exc}") from exc
+        entries = _parse_response(payload)
+        LOGGER.debug("MCP discovery returned %d server(s) from %s", len(entries), url)
+        return entries
+
+    def start_background_poller(self) -> None:
+        """Start a daemon thread that refreshes the cache every TTL seconds.
+
+        Idempotent and a no-op when discovery is disabled. Lazy TTL refresh on
+        access already keeps data fresh for active traffic; the poller guarantees
+        regular refresh even when nothing is reading (so a newly added MCP shows
+        up without waiting for the next request).
+        """
+        if not get_discovery_url():
+            return
+        with self._lock:
+            if self._poller is not None and self._poller.is_alive():
+                return
+            stop = threading.Event()
+            self._poller_stop = stop
+
+            def _loop() -> None:
+                while not stop.is_set():
+                    try:
+                        self.get(force_refresh=True)
+                    except Exception:  # noqa: BLE001 - poller must never die
+                        LOGGER.debug("MCP discovery poll iteration failed", exc_info=True)
+                    stop.wait(_get_ttl_seconds())
+
+            poller = threading.Thread(
+                target=_loop, name="mcp-discovery-poller", daemon=True
+            )
+            self._poller = poller
+            poller.start()
+
+    def stop_background_poller(self) -> None:
+        with self._lock:
+            if self._poller_stop is not None:
+                self._poller_stop.set()
+            self._poller = None
+            self._poller_stop = None
+
+
+_CACHE = _DiscoveryCache()
+
+
+def get_discovered_mcps(force_refresh: bool = False) -> List[Dict[str, str]]:
+    """Return the available MCPs from bond-mcps discovery.
+
+    Returns a list of ``{"name", "display_name", "url"}`` dicts (possibly empty).
+    Never raises: a discovery outage degrades to the last good result or ``[]``.
+    """
+    return _CACHE.get(force_refresh=force_refresh)
+
+
+def start_background_poller() -> None:
+    """Start the periodic discovery refresh thread (call once at app startup)."""
+    _CACHE.start_background_poller()
+
+
+def stop_background_poller() -> None:
+    """Stop the periodic discovery refresh thread (for shutdown / tests)."""
+    _CACHE.stop_background_poller()
+
+
+def reset_cache() -> None:
+    """Clear the in-process discovery cache (primarily for tests)."""
+    _CACHE.reset()

--- a/bondable/bond/providers/bedrock/BedrockMCP.py
+++ b/bondable/bond/providers/bedrock/BedrockMCP.py
@@ -50,6 +50,22 @@ def _is_401_error(exc: Exception) -> bool:
     return False
 
 
+# Matches a bond-mcps connect URL surfaced inside a MissingProviderConnection
+# tool error (e.g. ".../connect/atlassian?ticket=..."). bond-mcps raises this
+# when a managed (bond_jwt) MCP has no stored provider token for the user; the
+# message text is the documented surfacing channel, so we extract the URL to
+# return a structured "authorization_required" response the UI can act on.
+_CONNECT_URL_RE = re.compile(r"https?://[^\s'\"<>]+/connect/[^\s'\"<>]*")
+
+
+def _extract_connect_url(error_str: str) -> Optional[str]:
+    """Return the bond-mcps connect URL embedded in a tool error, if any."""
+    if not error_str:
+        return None
+    match = _CONNECT_URL_RE.search(error_str)
+    return match.group(0) if match else None
+
+
 # =============================================================================
 # Tool Naming Utilities
 # =============================================================================
@@ -1465,6 +1481,25 @@ async def execute_mcp_tool(
                 break  # Break retry loop, continue to next server
             except Exception as e:
                 error_str = str(e)
+
+                # bond-mcps-managed (bond_jwt) MCP with no provider connection:
+                # surface the connect URL so the UI/agent can offer to connect.
+                # The tool was found on this server, so this is the right target —
+                # return immediately rather than searching further.
+                connect_url = _extract_connect_url(error_str)
+                if connect_url:
+                    LOGGER.info(
+                        "[MCP Execute] Server '%s' requires a provider connection",
+                        safe_id(server_name),
+                    )
+                    return {
+                        "success": False,
+                        "error": error_str,
+                        "authorization_required": True,
+                        "server_name": server_name,
+                        "connect_url": connect_url,
+                    }
+
                 # Retry on 401 for oauth2 servers: token may have expired between
                 # the 5-minute buffer check and the actual API call
                 if attempt == 0 and auth_type == AUTH_TYPE_OAUTH2 and _is_401_error(e):

--- a/bondable/rest/main.py
+++ b/bondable/rest/main.py
@@ -41,6 +41,13 @@ LOGGER = logging.getLogger(__name__)
 # Lifespan for scheduler
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Keep the bond-mcps discovery cache warm via periodic polling so newly
+    # added/removed MCPs show up without restarting bond-ai, and so the cache is
+    # populated before requests arrive (no blocking fetch on the event loop).
+    # No-op when BOND_MCPS_DISCOVERY_URL is unset.
+    from bondable.bond.mcp_discovery import start_background_poller, stop_background_poller
+    start_background_poller()
+
     scheduler = None
     if os.getenv("SCHEDULED_JOBS_ENABLED", "false").lower() == "true":
         from bondable.bond.scheduler import JobScheduler
@@ -53,6 +60,7 @@ async def lifespan(app: FastAPI):
     if scheduler:
         scheduler.stop()
         LOGGER.info("Scheduled jobs scheduler stopped")
+    stop_background_poller()
 
 
 # Create FastAPI app

--- a/bondable/rest/routers/connections.py
+++ b/bondable/rest/routers/connections.py
@@ -504,8 +504,10 @@ async def authorize_connection(
                 detail="Server configuration error: invalid return URL",
             )
         try:
+            # Use the discovery-sourced name (managed["name"]), not the raw request
+            # path parameter, so no user-controlled value flows into the URL (SSRF).
             connect_url = await mcp_connect_client.mint_connect_ticket(
-                managed["url"], connection_name, jwt_token, return_url
+                managed["url"], managed["name"], jwt_token, return_url
             )
         except ConnectError as e:
             LOGGER.error("[Connections] failed to mint connect ticket for %s: %s", safe_id(connection_name), e)
@@ -763,7 +765,8 @@ async def get_connection_status(
     managed = _get_managed_connection(connection_name)
     if managed is not None:
         try:
-            mcps_status = await mcp_connect_client.get_connect_status(managed["url"], connection_name, jwt_token)
+            # discovery-sourced name (not the request path param) → no SSRF taint.
+            mcps_status = await mcp_connect_client.get_connect_status(managed["url"], managed["name"], jwt_token)
         except ConnectError as e:
             LOGGER.warning("[Connections] status check failed for managed %s: %s", safe_id(connection_name), e)
             mcps_status = {"connected": False, "valid": False}
@@ -841,7 +844,8 @@ async def disconnect(
     managed = _get_managed_connection(connection_name)
     if managed is not None:
         try:
-            removed = await mcp_connect_client.delete_connection(managed["url"], connection_name, jwt_token)
+            # discovery-sourced name (not the request path param) → no SSRF taint.
+            removed = await mcp_connect_client.delete_connection(managed["url"], managed["name"], jwt_token)
         except ConnectError as e:
             LOGGER.error("[Connections] disconnect failed for managed %s: %s", safe_id(connection_name), e)
             raise HTTPException(

--- a/bondable/rest/routers/connections.py
+++ b/bondable/rest/routers/connections.py
@@ -5,6 +5,7 @@ This router handles OAuth authentication with external services like Atlassian,
 storing tokens encrypted in the database for use with MCP tools.
 """
 
+import asyncio
 import logging
 import re
 from datetime import datetime, timezone, timedelta
@@ -19,8 +20,11 @@ from pydantic import BaseModel
 from bondable.bond.config import Config
 from bondable.bond.auth.mcp_token_cache import get_mcp_token_cache
 from bondable.bond.auth.oauth_utils import generate_pkce_pair, generate_oauth_state, resolve_client_secret
+from bondable.bond.mcp_discovery import get_discovered_mcps
+from bondable.bond import mcp_connect_client
+from bondable.bond.mcp_connect_client import ConnectError
 from bondable.rest.models.auth import User
-from bondable.rest.dependencies.auth import get_current_user
+from bondable.rest.dependencies.auth import get_current_user, get_current_user_with_token
 from bondable.utils.url_validation import is_safe_redirect_url
 from bondable.utils.logging_utils import safe_id
 
@@ -217,6 +221,54 @@ def _get_connection_config(connection_name: str, user_id: Optional[str] = None) 
 
 
 # =============================================================================
+# Managed (bond-mcps-delegated) connections
+# =============================================================================
+#
+# bond-mcps-managed MCPs are discovered (not hard-configured). bond-ai does not
+# drive their OAuth or store their tokens; it delegates to bond-mcps, forwarding
+# the user's Bond JWT. These appear as `bond_jwt` servers in the effective MCP
+# config (see Config._overlay_discovered_mcps). The Connections UI still shows
+# them as connectable tiles, but authorize/status/disconnect proxy to bond-mcps.
+
+def _get_managed_connection_configs() -> List[Dict[str, Any]]:
+    """Return discovered bond-mcps-managed MCPs as connection-config dicts."""
+    configs = []
+    for entry in get_discovered_mcps():
+        name = entry["name"]
+        display_name = entry.get("display_name", name.title())
+        configs.append({
+            "name": name,
+            "display_name": display_name,
+            "description": f"Connect to {display_name}",
+            "url": entry["url"],
+            "auth_type": "bond_jwt",
+            "is_managed": True,
+            "is_user_defined": False,
+            "icon_url": None,
+        })
+    return configs
+
+
+def _get_managed_connection(connection_name: str) -> Optional[Dict[str, Any]]:
+    """Get a specific managed (discovered) connection by name, or None."""
+    for config in _get_managed_connection_configs():
+        if config["name"] == connection_name:
+            return config
+    return None
+
+
+def _frontend_return_url(request: Request) -> str:
+    """Compute the bond-ai URL bond-mcps should return the user to after connect."""
+    from bondable.rest.routers.auth import _get_validated_origin_host
+    origin_host = _get_validated_origin_host(request)
+    if origin_host:
+        base = f"https://{origin_host}"
+    else:
+        base = Config.config().get_jwt_config().JWT_REDIRECT_URI.rstrip('/')
+    return f"{base}/connections"
+
+
+# =============================================================================
 # OAuth State Management (Database-backed)
 # =============================================================================
 
@@ -311,26 +363,77 @@ def _get_and_delete_oauth_state(state: str) -> Optional[Dict[str, Any]]:
 
 @router.get("", response_model=ConnectionsListResponse)
 async def list_connections(
-    current_user: Annotated[User, Depends(get_current_user)]
+    user_and_token: Annotated[tuple[User, str], Depends(get_current_user_with_token)]
 ) -> ConnectionsListResponse:
     """
     List all available connections with user's status.
 
     Returns both the connection configurations and whether the user
     has connected to each one, including whether tokens are expired.
+
+    Combines two tracks: bond-mcps-managed connections (status delegated to
+    bond-mcps, forwarding the Bond JWT) and the legacy/user-defined OAuth2
+    connections (status from bond-ai's own token cache).
     """
+    current_user, jwt_token = user_and_token
     LOGGER.debug(f"[Connections] Listing connections for user {current_user.email}")
 
+    connections = []
+    expired = []
 
-    # Get all connection configs (including user-defined OAuth servers)
+    # --- Managed (bond-mcps-delegated) connections -------------------------
+    # Query every managed MCP's status concurrently (each is a network round-trip
+    # to bond-mcps; sequential would block proportional to the MCP count).
+    managed_configs = _get_managed_connection_configs()
+
+    async def _managed_status(cfg):
+        try:
+            return cfg, await mcp_connect_client.get_connect_status(cfg["url"], cfg["name"], jwt_token)
+        except Exception as e:  # noqa: BLE001 - one bad MCP must not 500 the whole list
+            # bond-mcps unreachable / unexpected error: surface this provider as
+            # disconnected so the user can retry, without failing the page.
+            LOGGER.warning(
+                "[Connections] status check failed for managed %s: %s: %s",
+                safe_id(cfg["name"]), type(e).__name__, e,
+            )
+            return cfg, {"connected": False, "valid": False}
+
+    managed_results = await asyncio.gather(*(_managed_status(c) for c in managed_configs))
+
+    for config, mcps_status in managed_results:
+        name = config["name"]
+        if mcps_status is None:
+            # MCP exposes no connect surface → not a connectable provider; omit.
+            continue
+        connected = bool(mcps_status.get("connected", False))
+        valid = bool(mcps_status.get("valid", True)) if connected else True
+        connections.append(ConnectionStatusResponse(
+            name=name,
+            display_name=config.get("display_name", name.title()),
+            description=config.get("description"),
+            connected=connected,
+            valid=valid,
+            auth_type="bond_jwt",
+            icon_url=config.get("icon_url"),
+            scopes=mcps_status.get("scopes"),
+            expires_at=mcps_status.get("expires_at"),
+            requires_authorization=not connected,
+            has_refresh_token=bool(mcps_status.get("has_refresh_token", False)),
+            is_user_defined=False,
+        ))
+        if connected and not valid:
+            expired.append({
+                "name": name,
+                "display_name": config.get("display_name", name.title()),
+                "expires_at": mcps_status.get("expires_at"),
+            })
+
+    # --- Legacy / user-defined OAuth2 connections --------------------------
     configs = _get_connection_configs(user_id=current_user.user_id)
 
     # Get user's connection tokens
     token_cache = get_mcp_token_cache()
     user_connections = token_cache.get_user_connections(current_user.user_id)
-
-    connections = []
-    expired = []
 
     for config in configs:
         name = config["name"]
@@ -376,19 +479,47 @@ async def list_connections(
 async def authorize_connection(
     connection_name: str,
     request: Request,
-    current_user: Annotated[User, Depends(get_current_user)]
+    user_and_token: Annotated[tuple[User, str], Depends(get_current_user_with_token)]
 ) -> AuthorizeResponse:
     """
-    Initiate OAuth2 authorization for a connection.
+    Initiate authorization for a connection.
 
     Returns an authorization URL that the client should open in a browser/popup.
 
-    Args:
-        connection_name: Name of the connection to authorize
-
-    Returns:
-        Authorization URL to redirect user to
+    For bond-mcps-managed connections this delegates to bond-mcps: bond-ai mints a
+    connect ticket (forwarding the user's Bond JWT and a return URL) and returns
+    the resulting bond-mcps connect URL. For legacy/user-defined OAuth2 servers
+    bond-ai builds the provider authorize URL itself (unchanged).
     """
+    current_user, jwt_token = user_and_token
+
+    # --- Managed (bond-mcps-delegated) connection --------------------------
+    managed = _get_managed_connection(connection_name)
+    if managed is not None:
+        return_url = _frontend_return_url(request)
+        if not is_safe_redirect_url(return_url):
+            LOGGER.error("[Connections] computed return_url is not on the allowed domain list")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Server configuration error: invalid return URL",
+            )
+        try:
+            connect_url = await mcp_connect_client.mint_connect_ticket(
+                managed["url"], connection_name, jwt_token, return_url
+            )
+        except ConnectError as e:
+            LOGGER.error("[Connections] failed to mint connect ticket for %s: %s", safe_id(connection_name), e)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Failed to initiate connection with the MCP service",
+            )
+        return AuthorizeResponse(
+            authorization_url=connect_url,
+            connection_name=connection_name,
+            message="Open authorization_url in browser to authorize",
+        )
+
+    # --- Legacy / user-defined OAuth2 connection ---------------------------
     config = _get_connection_config(connection_name, user_id=current_user.user_id)
     if config is None:
         raise HTTPException(
@@ -620,14 +751,44 @@ async def oauth_callback(
 @router.get("/{connection_name}/status", response_model=ConnectionStatusResponse)
 async def get_connection_status(
     connection_name: str,
-    current_user: Annotated[User, Depends(get_current_user)]
+    user_and_token: Annotated[tuple[User, str], Depends(get_current_user_with_token)]
 ) -> ConnectionStatusResponse:
     """
     Get the status of a specific connection for the current user.
     """
+    current_user, jwt_token = user_and_token
     LOGGER.debug(f"[Connections] Checking status of {connection_name} for user {current_user.email}")
 
+    # --- Managed (bond-mcps-delegated) connection --------------------------
+    managed = _get_managed_connection(connection_name)
+    if managed is not None:
+        try:
+            mcps_status = await mcp_connect_client.get_connect_status(managed["url"], connection_name, jwt_token)
+        except ConnectError as e:
+            LOGGER.warning("[Connections] status check failed for managed %s: %s", safe_id(connection_name), e)
+            mcps_status = {"connected": False, "valid": False}
+        if mcps_status is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"Connection '{connection_name}' not found",
+            )
+        connected = bool(mcps_status.get("connected", False))
+        valid = bool(mcps_status.get("valid", True)) if connected else True
+        return ConnectionStatusResponse(
+            name=connection_name,
+            display_name=managed.get("display_name", connection_name.title()),
+            description=managed.get("description"),
+            connected=connected,
+            valid=valid,
+            auth_type="bond_jwt",
+            icon_url=managed.get("icon_url"),
+            scopes=mcps_status.get("scopes"),
+            expires_at=mcps_status.get("expires_at"),
+            requires_authorization=not connected,
+            has_refresh_token=bool(mcps_status.get("has_refresh_token", False)),
+        )
 
+    # --- Legacy / user-defined OAuth2 connection ---------------------------
     config = _get_connection_config(connection_name, user_id=current_user.user_id)
     if config is None:
         raise HTTPException(
@@ -665,14 +826,38 @@ async def get_connection_status(
 @router.delete("/{connection_name}")
 async def disconnect(
     connection_name: str,
-    current_user: Annotated[User, Depends(get_current_user)]
+    user_and_token: Annotated[tuple[User, str], Depends(get_current_user_with_token)]
 ) -> Dict[str, Any]:
     """
     Disconnect from a connection by removing the stored token.
+
+    For managed connections this deletes the provider token in bond-mcps; for
+    legacy/user-defined OAuth2 servers it clears bond-ai's own token cache.
     """
+    current_user, jwt_token = user_and_token
     LOGGER.info(f"User {current_user.email} disconnecting from {connection_name}")
 
+    # --- Managed (bond-mcps-delegated) connection --------------------------
+    managed = _get_managed_connection(connection_name)
+    if managed is not None:
+        try:
+            removed = await mcp_connect_client.delete_connection(managed["url"], connection_name, jwt_token)
+        except ConnectError as e:
+            LOGGER.error("[Connections] disconnect failed for managed %s: %s", safe_id(connection_name), e)
+            raise HTTPException(
+                status_code=status.HTTP_502_BAD_GATEWAY,
+                detail="Failed to disconnect from the MCP service",
+            )
+        return {
+            "message": (
+                f"Successfully disconnected from '{connection_name}'" if removed
+                else f"No connection found for '{connection_name}'"
+            ),
+            "connection_name": connection_name,
+            "disconnected": removed,
+        }
 
+    # --- Legacy / user-defined OAuth2 connection ---------------------------
     token_cache = get_mcp_token_cache()
     removed = token_cache.clear_token(current_user.user_id, connection_name)
 

--- a/deployment/nginx-local-combined.conf
+++ b/deployment/nginx-local-combined.conf
@@ -121,6 +121,26 @@ server {
     }
 
     # ------------------------------------------------------------------------
+    # /connect/<provider>/* → bond-mcps per-MCP FastMCP ports (delegated OAuth
+    # Connect flow). bond-ai mints the ticket server-side (direct to the MCP
+    # port), but the BROWSER hits these paths at the front door, so they must be
+    # routed to the MCP that serves each provider's /connect routes. Ports mirror
+    # bond-mcps combined-mode (mcp.json): ms-graph 18001, github 18002,
+    # atlassian 18003, databricks 18004. Requires bond-mcps to advertise
+    # BOND_MCPS_PUBLIC_URL=http://localhost:8000 and run with JWT mode ON (which
+    # un-dormants /connect/*). If bond-mcps later hosts /connect on the auth
+    # proxy, collapse these into one `location /connect/ → :18000` block.
+    # ------------------------------------------------------------------------
+    location /connect/ms-graph/   { proxy_pass http://host.docker.internal:18001; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+    location = /connect/ms-graph   { proxy_pass http://host.docker.internal:18001; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+    location /connect/github/     { proxy_pass http://host.docker.internal:18002; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+    location = /connect/github     { proxy_pass http://host.docker.internal:18002; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+    location /connect/atlassian/  { proxy_pass http://host.docker.internal:18003; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+    location = /connect/atlassian  { proxy_pass http://host.docker.internal:18003; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+    location /connect/databricks/ { proxy_pass http://host.docker.internal:18004; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+    location = /connect/databricks { proxy_pass http://host.docker.internal:18004; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+
+    # ------------------------------------------------------------------------
     # Forward-allocated: bond-mcps Authorization Server (JWT mode).
     # Uncomment when dev-multitenant becomes the default workflow.
     # ------------------------------------------------------------------------

--- a/docs/combined-mode-status.md
+++ b/docs/combined-mode-status.md
@@ -101,9 +101,28 @@ Browser / OAuth provider
    the other two user-login providers complete the full redirect → callback →
    session-cookie loop at `:8000`.
 
-3. **MCP OAuth connections** (`/connections/<svc>/callback` → bond-mcps :18000).
-   Atlassian / GitHub / Microsoft connect flows have NOT been exercised in
-   combined mode. Confirm a connection goes Active and an MCP tool call works.
+3. **MCP OAuth connections — now DELEGATED to bond-mcps** (branch
+   `mcp-discovery-delegation`). bond-ai no longer hard-configures MCPs or drives
+   their OAuth: it discovers the MCP set from `BOND_MCPS_DISCOVERY_URL`
+   (`http://localhost:8000/connections/discovery`, polled) and delegates Connect
+   to bond-mcps' `/connect/<name>` flow, forwarding the Bond JWT. bond-ai's side
+   is implemented + unit/integration-tested; **not yet exercised live** in
+   combined mode. To test, bond-mcps must run with JWT mode ON (shared secret =
+   bond-ai `JWT_SECRET_KEY`, `HS256`, `iss=bond-ai`, `aud=mcp-server`) and provide
+   the bond-mcps-side additions below. nginx now routes `/connect/<provider>/*` to
+   the per-MCP ports (18001-18004). Confirm: discovery lists MCPs → Connect on a
+   tile → bond-mcps consent → return to bond-ai Connected → an MCP tool call works.
+
+   **bond-mcps prerequisites (companion work, not in this repo):**
+   - JWT-mode config (shared secret, `HS256`, issuer/audience) — un-dormants
+     `/connect/*`.
+   - `return_url` support in `/connect/<name>/callback` (302 back to bond-ai with
+     `?connection_success=`/`connection_error=`, allowlisted) — today it renders a
+     terminal "close this tab" page.
+   - `GET /connect/<name>/status` + `DELETE /connect/<name>` (JWT-authed) backing
+     the Connections list/disconnect.
+   - Deployment-aware discovery URLs (it currently emits `localhost` and `[]` off
+     a dev checkout) — until then deployed bond-ai falls back to static config.
 
 4. **Session-cookie persistence.** Confirm `bond_session` / `bond_csrf` are set
    on `localhost:8000` and survive a page reload (`COOKIE_SECURE=false` over HTTP).

--- a/tests/test_connections_delegation.py
+++ b/tests/test_connections_delegation.py
@@ -1,0 +1,210 @@
+"""Integration tests for bond-mcps-delegated (managed) connections.
+
+Drives bond-ai's Connections endpoints (list / authorize / status / disconnect)
+through the real FastAPI router, with bond-mcps stubbed at the seam: discovery is
+patched to advertise managed MCPs and the connect client is patched to stand in
+for bond-mcps' /connect/<name>/{ticket,status} + DELETE. This exercises the full
+delegation choreography from bond-ai's side, including the return-URL handoff and
+fail-soft when bond-mcps is unreachable.
+"""
+
+import os
+import tempfile
+from datetime import timedelta
+
+import pytest
+
+_test_db_file = tempfile.NamedTemporaryFile(suffix="_deleg.db", delete=False)
+os.environ["METADATA_DB_URL"] = f"sqlite:///{_test_db_file.name}"
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-delegation")
+# Keep the static fallback empty-ish so only discovered managed MCPs appear.
+os.environ["BOND_MCP_CONFIG"] = '{"mcpServers": {}}'
+
+from fastapi.testclient import TestClient
+
+from bondable.rest.main import app, create_access_token
+import bondable.rest.routers.connections as conn
+
+TEST_EMAIL = "deleg-test@example.com"
+TEST_USER_ID = "deleg-user-1"
+
+DISCOVERED = [
+    {"name": "atlassian", "display_name": "Atlassian", "url": "http://localhost:18003/mcp"},
+    {"name": "github", "display_name": "GitHub", "url": "http://localhost:18002/mcp"},
+]
+
+
+@pytest.fixture
+def client():
+    return TestClient(app)
+
+
+@pytest.fixture
+def headers():
+    token = create_access_token(
+        data={"sub": TEST_EMAIL, "user_id": TEST_USER_ID, "provider": "okta"},
+        expires_delta=timedelta(minutes=15),
+    )
+    return {"Authorization": f"Bearer {token}"}
+
+
+@pytest.fixture(autouse=True)
+def patch_discovery(monkeypatch):
+    """Advertise managed MCPs via discovery (used by the overlay + router)."""
+    monkeypatch.setattr(conn, "get_discovered_mcps", lambda force_refresh=False: list(DISCOVERED))
+    yield
+
+
+class _StubMcps:
+    """In-memory stand-in for bond-mcps connect endpoints."""
+
+    def __init__(self):
+        self.connected = set()
+        self.tickets = []
+        self.no_surface = set()  # providers that 404 (no connect flow)
+
+    async def mint_connect_ticket(self, mcp_url, name, jwt_token, return_url):
+        assert jwt_token, "JWT must be forwarded to bond-mcps"
+        self.tickets.append({"name": name, "return_url": return_url, "url": mcp_url})
+        return f"http://localhost:8000/connect/{name}?ticket=TKT&return_url={return_url}"
+
+    async def get_connect_status(self, mcp_url, name, jwt_token):
+        if name in self.no_surface:
+            return None
+        connected = name in self.connected
+        return {"connected": connected, "valid": connected, "scopes": "s" if connected else None}
+
+    async def delete_connection(self, mcp_url, name, jwt_token):
+        existed = name in self.connected
+        self.connected.discard(name)
+        return existed
+
+
+@pytest.fixture
+def stub(monkeypatch):
+    s = _StubMcps()
+    monkeypatch.setattr(conn.mcp_connect_client, "mint_connect_ticket", s.mint_connect_ticket)
+    monkeypatch.setattr(conn.mcp_connect_client, "get_connect_status", s.get_connect_status)
+    monkeypatch.setattr(conn.mcp_connect_client, "delete_connection", s.delete_connection)
+    return s
+
+
+# --- list -----------------------------------------------------------------
+
+def test_list_includes_managed_disconnected(client, headers, stub):
+    resp = client.get("/connections", headers=headers)
+    assert resp.status_code == 200
+    by_name = {c["name"]: c for c in resp.json()["connections"]}
+    assert set(by_name) >= {"atlassian", "github"}
+    assert by_name["atlassian"]["auth_type"] == "bond_jwt"
+    assert by_name["atlassian"]["connected"] is False
+    assert by_name["atlassian"]["requires_authorization"] is True
+
+
+def test_list_reflects_connected_state(client, headers, stub):
+    stub.connected.add("atlassian")
+    by_name = {c["name"]: c for c in client.get("/connections", headers=headers).json()["connections"]}
+    assert by_name["atlassian"]["connected"] is True
+    assert by_name["github"]["connected"] is False
+
+
+def test_list_omits_mcp_without_connect_surface(client, headers, stub):
+    stub.no_surface.add("github")  # github has no provider connection (404 on status)
+    names = {c["name"] for c in client.get("/connections", headers=headers).json()["connections"]}
+    assert "atlassian" in names
+    assert "github" not in names
+
+
+def test_list_failsoft_when_mcps_down(client, headers, monkeypatch):
+    async def boom(*a, **k):
+        raise conn.ConnectError("bond-mcps down")
+    monkeypatch.setattr(conn.mcp_connect_client, "get_connect_status", boom)
+    by_name = {c["name"]: c for c in client.get("/connections", headers=headers).json()["connections"]}
+    # Still listed (so user can retry), shown disconnected.
+    assert by_name["atlassian"]["connected"] is False
+
+
+def test_list_failsoft_on_unexpected_error(client, headers, monkeypatch):
+    """One MCP raising a non-ConnectError must not 500 the whole list."""
+    async def kaboom(*a, **k):
+        raise ValueError("unexpected")
+    monkeypatch.setattr(conn.mcp_connect_client, "get_connect_status", kaboom)
+    resp = client.get("/connections", headers=headers)
+    assert resp.status_code == 200
+    by_name = {c["name"]: c for c in resp.json()["connections"]}
+    assert by_name["atlassian"]["connected"] is False
+    assert by_name["github"]["connected"] is False
+
+
+# --- authorize (delegation) ----------------------------------------------
+
+def test_authorize_delegates_and_returns_connect_url(client, headers, stub):
+    resp = client.get("/connections/atlassian/authorize", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["authorization_url"].startswith("http://localhost:8000/connect/atlassian?ticket=")
+    # bond-ai passed a return_url back to its own /connections page.
+    assert stub.tickets and stub.tickets[0]["name"] == "atlassian"
+    assert stub.tickets[0]["return_url"].endswith("/connections")
+
+
+def test_authorize_502_when_ticket_fails(client, headers, monkeypatch):
+    async def boom(*a, **k):
+        raise conn.ConnectError("ticket mint failed")
+    monkeypatch.setattr(conn.mcp_connect_client, "mint_connect_ticket", boom)
+    resp = client.get("/connections/atlassian/authorize", headers=headers)
+    assert resp.status_code == 502
+
+
+# --- status ---------------------------------------------------------------
+
+def test_status_managed(client, headers, stub):
+    stub.connected.add("github")
+    resp = client.get("/connections/github/status", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["connected"] is True
+    assert resp.json()["auth_type"] == "bond_jwt"
+
+
+def test_status_404_for_no_surface(client, headers, stub):
+    stub.no_surface.add("atlassian")
+    resp = client.get("/connections/atlassian/status", headers=headers)
+    assert resp.status_code == 404
+
+
+# --- disconnect -----------------------------------------------------------
+
+def test_disconnect_managed(client, headers, stub):
+    stub.connected.add("atlassian")
+    resp = client.delete("/connections/atlassian", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["disconnected"] is True
+    assert "atlassian" not in stub.connected
+
+
+def test_disconnect_managed_not_connected(client, headers, stub):
+    resp = client.delete("/connections/github", headers=headers)
+    assert resp.status_code == 200
+    assert resp.json()["disconnected"] is False
+
+
+# --- full choreography ----------------------------------------------------
+
+def test_full_connect_choreography(client, headers, stub):
+    # 1. Initially disconnected.
+    assert client.get("/connections/atlassian/status", headers=headers).json()["connected"] is False
+    # 2. Authorize -> get connect_url (browser would visit bond-mcps).
+    connect_url = client.get("/connections/atlassian/authorize", headers=headers).json()["authorization_url"]
+    assert "/connect/atlassian" in connect_url
+    # 3. Simulate bond-mcps completing the provider OAuth + storing the token.
+    stub.connected.add("atlassian")
+    # 4. Back in bond-ai: status now shows connected.
+    assert client.get("/connections/atlassian/status", headers=headers).json()["connected"] is True
+    # 5. Disconnect cleans up in bond-mcps.
+    assert client.delete("/connections/atlassian", headers=headers).json()["disconnected"] is True
+    assert client.get("/connections/atlassian/status", headers=headers).json()["connected"] is False
+
+
+def test_managed_endpoints_require_auth(client, stub):
+    assert client.get("/connections/atlassian/authorize").status_code == 401
+    assert client.delete("/connections/atlassian").status_code == 401

--- a/tests/test_jwt_mcps_trust.py
+++ b/tests/test_jwt_mcps_trust.py
@@ -1,0 +1,76 @@
+"""Contract test for the shared-secret JWT trust between bond-ai and bond-mcps.
+
+bond-ai mints HS256 JWTs (sub=email, iss=bond-ai, aud includes 'mcp-server').
+bond-mcps validates them with the SAME secret using fastmcp's JWTVerifier, which
+is PyJWT (jwt.decode) under the hood. This test pins bond-ai's token shape to the
+agreed bond-mcps verifier config so the integration can't silently drift:
+
+    BOND_MCPS_JWT_PUBLIC_KEY = <bond-ai JWT_SECRET_KEY>   (shared secret)
+    BOND_MCPS_JWT_ALGORITHM  = HS256
+    BOND_MCPS_JWT_ISSUER     = bond-ai
+    BOND_MCPS_JWT_AUDIENCE   = mcp-server
+"""
+
+import os
+from datetime import timedelta
+
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-jwt-trust")
+
+import jwt
+import pytest
+
+from bondable.rest.utils.auth import create_access_token, jwt_config
+
+SHARED_SECRET = jwt_config.JWT_SECRET_KEY
+MCPS_AUDIENCE = "mcp-server"
+MCPS_ISSUER = "bond-ai"
+
+
+def _verify_like_bond_mcps(token, *, secret=SHARED_SECRET, audience=MCPS_AUDIENCE, issuer=MCPS_ISSUER):
+    """Mirror bond-mcps' fastmcp JWTVerifier(HS256) validation."""
+    return jwt.decode(
+        token,
+        secret,
+        algorithms=["HS256"],
+        audience=audience,
+        issuer=issuer,
+    )
+
+
+def _mint(**claims):
+    data = {"sub": "user@example.com", "user_id": "u-1", "provider": "okta"}
+    data.update(claims)
+    return create_access_token(data, expires_delta=timedelta(minutes=15))
+
+
+def test_bond_ai_token_has_expected_shape():
+    decoded = jwt.decode(_mint(), SHARED_SECRET, algorithms=["HS256"], audience=MCPS_AUDIENCE)
+    assert decoded["sub"] == "user@example.com"
+    assert decoded["iss"] == MCPS_ISSUER
+    assert MCPS_AUDIENCE in decoded["aud"]
+
+
+def test_bond_mcps_accepts_valid_token():
+    claims = _verify_like_bond_mcps(_mint())
+    assert claims["sub"] == "user@example.com"  # bond-mcps user_key
+
+
+def test_rejected_wrong_secret():
+    with pytest.raises(jwt.InvalidSignatureError):
+        _verify_like_bond_mcps(_mint(), secret="not-the-shared-secret")
+
+
+def test_rejected_wrong_audience():
+    with pytest.raises(jwt.InvalidAudienceError):
+        _verify_like_bond_mcps(_mint(), audience="some-other-api")
+
+
+def test_rejected_wrong_issuer():
+    with pytest.raises(jwt.InvalidIssuerError):
+        _verify_like_bond_mcps(_mint(), issuer="evil-issuer")
+
+
+def test_rejected_expired_token():
+    expired = create_access_token({"sub": "user@example.com"}, expires_delta=timedelta(seconds=-5))
+    with pytest.raises(jwt.ExpiredSignatureError):
+        _verify_like_bond_mcps(expired)

--- a/tests/test_local_nginx_config.py
+++ b/tests/test_local_nginx_config.py
@@ -131,6 +131,24 @@ def test_nginx_local_combined_conf_routes_connections_to_mcps_18000():
     )
 
 
+def test_nginx_local_combined_conf_routes_connect_to_mcp_ports():
+    """Delegated OAuth Connect (/connect/<provider>) lands on the front door but
+    must route to each provider's bond-mcps MCP port (combined-mode 18001-18004),
+    NOT to the auth proxy :18000."""
+    text = NGINX_CONF.read_text()
+    expected = {
+        "/connect/atlassian/": "host.docker.internal:18003",
+        "/connect/github/": "host.docker.internal:18002",
+        "/connect/ms-graph/": "host.docker.internal:18001",
+        "/connect/databricks/": "host.docker.internal:18004",
+    }
+    for path, upstream in expected.items():
+        assert _has_active_location_block(text, path), f"missing {path} proxy block"
+        start = text.index(f"location {path}")
+        block = text[start : start + 300]
+        assert upstream in block, f"{path} must proxy to {upstream}"
+
+
 def test_nginx_local_combined_conf_routes_rest_and_root():
     """The two app-serving routes: /rest/ to bond-ai backend, / to the
     static Flutter build (served from /usr/share/nginx/html, mounted by

--- a/tests/test_mcp_connect_client.py
+++ b/tests/test_mcp_connect_client.py
@@ -1,0 +1,133 @@
+"""Unit tests for the bond-mcps connect (OAuth delegation) HTTP client."""
+
+import httpx
+import pytest
+
+from bondable.bond import mcp_connect_client as cc
+from bondable.bond.mcp_connect_client import ConnectError
+
+
+MCP_URL = "http://localhost:18003/mcp"
+
+
+class FakeResp:
+    def __init__(self, payload=None, status_code=200, content=b"{}"):
+        self._payload = payload if payload is not None else {}
+        self.status_code = status_code
+        self.content = content
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise httpx.HTTPStatusError("err", request=None, response=None)
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    """Patch the async httpx client; tests set `handler` and inspect `calls`."""
+    state = {"handler": lambda method, url, **kw: FakeResp(), "calls": []}
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            state["calls"].append({"method": "POST", "url": url, "json": json, "headers": headers})
+            return state["handler"]("POST", url, json=json, headers=headers)
+
+        async def get(self, url, headers=None):
+            state["calls"].append({"method": "GET", "url": url, "headers": headers})
+            return state["handler"]("GET", url, headers=headers)
+
+        async def request(self, method, url, headers=None):
+            state["calls"].append({"method": method, "url": url, "headers": headers})
+            return state["handler"](method, url, headers=headers)
+
+    monkeypatch.setattr(cc.httpx, "AsyncClient", FakeClient)
+    return state
+
+
+# --- base URL (sync helpers) ----------------------------------------------
+
+def test_connect_base_url_strips_path():
+    assert cc.connect_base_url("http://localhost:18003/mcp") == "http://localhost:18003"
+    assert cc.connect_base_url("https://github.mcps.example.com/mcp") == "https://github.mcps.example.com"
+
+
+def test_connect_base_url_rejects_garbage():
+    with pytest.raises(ConnectError):
+        cc.connect_base_url("not-a-url")
+
+
+# --- mint ticket ----------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_mint_ticket_posts_and_returns_connect_url(fake_http):
+    fake_http["handler"] = lambda *a, **k: FakeResp(
+        {"ticket": "t", "connect_url": "http://localhost:8000/connect/atlassian?ticket=t"})
+    out = await cc.mint_connect_ticket(MCP_URL, "atlassian", "JWT123", "http://localhost:8000/connections")
+
+    assert out == "http://localhost:8000/connect/atlassian?ticket=t"
+    call = fake_http["calls"][0]
+    assert call["url"] == "http://localhost:18003/connect/atlassian/ticket"
+    assert call["json"] == {"return_url": "http://localhost:8000/connections"}
+    assert call["headers"]["Authorization"] == "Bearer JWT123"
+
+
+@pytest.mark.asyncio
+async def test_mint_ticket_requires_jwt(fake_http):
+    with pytest.raises(ConnectError):
+        await cc.mint_connect_ticket(MCP_URL, "atlassian", "", "http://x/connections")
+
+
+@pytest.mark.asyncio
+async def test_mint_ticket_missing_connect_url_raises(fake_http):
+    fake_http["handler"] = lambda *a, **k: FakeResp({"ticket": "t"})
+    with pytest.raises(ConnectError):
+        await cc.mint_connect_ticket(MCP_URL, "atlassian", "JWT", "http://x/connections")
+
+
+# --- status ---------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_status_returns_payload(fake_http):
+    fake_http["handler"] = lambda *a, **k: FakeResp({"connected": True, "valid": True, "scopes": "s"})
+    out = await cc.get_connect_status(MCP_URL, "atlassian", "JWT")
+    assert out == {"connected": True, "valid": True, "scopes": "s"}
+
+
+@pytest.mark.asyncio
+async def test_status_404_means_no_connect_surface(fake_http):
+    fake_http["handler"] = lambda *a, **k: FakeResp(status_code=404)
+    assert await cc.get_connect_status(MCP_URL, "weather", "JWT") is None
+
+
+@pytest.mark.asyncio
+async def test_status_other_error_raises(fake_http):
+    def boom(*a, **k):
+        raise httpx.ConnectError("down")
+    fake_http["handler"] = boom
+    with pytest.raises(ConnectError):
+        await cc.get_connect_status(MCP_URL, "atlassian", "JWT")
+
+
+# --- disconnect -----------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_delete_returns_flag(fake_http):
+    fake_http["handler"] = lambda *a, **k: FakeResp({"disconnected": True})
+    assert await cc.delete_connection(MCP_URL, "atlassian", "JWT") is True
+
+
+@pytest.mark.asyncio
+async def test_delete_404_returns_false(fake_http):
+    fake_http["handler"] = lambda *a, **k: FakeResp(status_code=404, content=b"")
+    assert await cc.delete_connection(MCP_URL, "atlassian", "JWT") is False

--- a/tests/test_mcp_connect_client.py
+++ b/tests/test_mcp_connect_client.py
@@ -67,6 +67,38 @@ def test_connect_base_url_rejects_garbage():
         cc.connect_base_url("not-a-url")
 
 
+def test_safe_name_passes_legitimate_names():
+    for name in ("atlassian", "github", "ms-graph", "databricks", "foo_bar.v2"):
+        assert cc._safe_name(name) == name
+
+
+@pytest.mark.parametrize("evil,expected", [
+    ("../../evil", ".._.._evil"),
+    ("a/b", "a_b"),
+    ("x?y=1", "x_y_1"),
+    ("host@evil.com", "host_evil.com"),
+    ("a b", "a_b"),
+])
+def test_safe_name_neutralizes_url_control_chars(evil, expected):
+    safe = cc._safe_name(evil)
+    assert safe == expected
+    for ch in "/?@: ":
+        assert ch not in safe
+
+
+@pytest.mark.asyncio
+async def test_malicious_name_cannot_escape_path(fake_http):
+    """A name with path-traversal/host chars stays a single sanitized segment."""
+    fake_http["handler"] = lambda *a, **k: FakeResp(
+        {"ticket": "t", "connect_url": "http://localhost:8000/connect/x?ticket=t"})
+    await cc.mint_connect_ticket(MCP_URL, "../@evil.com/x", "JWT", "http://localhost:8000/connections")
+    url = fake_http["calls"][0]["url"]
+    # Host is unchanged; the name became one inert path segment.
+    assert url.startswith("http://localhost:18003/connect/")
+    assert "evil.com" not in url.split("/connect/")[0]
+    assert "@" not in url and "?" not in url
+
+
 # --- mint ticket ----------------------------------------------------------
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_discovery.py
+++ b/tests/test_mcp_discovery.py
@@ -1,0 +1,283 @@
+"""Unit tests for the MCP discovery client and the config overlay.
+
+Covers parsing, TTL caching, the SSRF guard, fail-soft behaviour (outage and
+empty response degrade to the last good result / static config), dynamic
+add/remove between polls, and Config._overlay_discovered_mcps merge semantics.
+"""
+
+import os
+
+import pytest
+
+from bondable.bond import mcp_discovery
+from bondable.bond.mcp_discovery import (
+    DiscoveryError,
+    _parse_response,
+    _validate_url_ssrf,
+    get_discovered_mcps,
+    get_discovery_url,
+)
+
+
+DISCOVERY_URL = "http://localhost:8000/connections/discovery"
+
+
+class FakeResp:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            import httpx
+            raise httpx.HTTPStatusError("boom", request=None, response=None)
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    """Reset cache + discovery env around every test."""
+    mcp_discovery.reset_cache()
+    mcp_discovery._CACHE._poller = None  # ensure no stale poller leaks across tests
+    monkeypatch.delenv(mcp_discovery.ENV_DISCOVERY_URL, raising=False)
+    monkeypatch.delenv(mcp_discovery.ENV_DISCOVERY_TTL, raising=False)
+    yield
+    mcp_discovery.reset_cache()
+    mcp_discovery._CACHE._poller = None
+
+
+def _set_response(monkeypatch, payload, calls=None):
+    """Install a fake httpx.get returning ``payload``; counts calls if given."""
+    def fake_get(url, timeout=None):
+        if calls is not None:
+            calls.append(url)
+        return FakeResp(payload)
+    monkeypatch.setattr(mcp_discovery.httpx, "get", fake_get)
+
+
+# --- URL config -----------------------------------------------------------
+
+def test_discovery_disabled_when_url_unset():
+    assert get_discovery_url() is None
+    assert get_discovered_mcps() == []
+
+
+def test_discovery_url_read_from_env(monkeypatch):
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_URL, DISCOVERY_URL)
+    assert get_discovery_url() == DISCOVERY_URL
+
+
+# --- Parsing --------------------------------------------------------------
+
+def test_parse_skips_malformed_entries():
+    payload = {"mcps": [
+        {"name": "atlassian", "display_name": "Atlassian", "url": "http://h:1/mcp"},
+        {"name": "noformat"},                 # missing url
+        {"url": "http://h:2/mcp"},            # missing name
+        {"name": "  ", "url": "http://h:3/mcp"},  # blank name
+        "not-a-dict",
+        {"name": "github", "url": "http://h:4/mcp"},  # missing display_name -> defaults
+    ]}
+    out = _parse_response(payload)
+    assert out == [
+        {"name": "atlassian", "display_name": "Atlassian", "url": "http://h:1/mcp"},
+        {"name": "github", "display_name": "github", "url": "http://h:4/mcp"},
+    ]
+
+
+def test_parse_rejects_non_object_and_missing_list():
+    with pytest.raises(DiscoveryError):
+        _parse_response(["nope"])
+    with pytest.raises(DiscoveryError):
+        _parse_response({"no_mcps": []})
+
+
+def test_parse_drops_ssrf_blocked_urls():
+    """A poisoned discovery response pointing at a metadata endpoint is dropped
+    so bond-ai never forwards the Bond JWT there."""
+    payload = {"mcps": [
+        {"name": "good", "url": "http://localhost:18003/mcp"},
+        {"name": "evil", "url": "http://169.254.169.254/mcp"},
+        {"name": "meta", "url": "http://metadata.google.internal/mcp"},
+    ]}
+    out = _parse_response(payload)
+    assert [e["name"] for e in out] == ["good"]
+
+
+# --- SSRF guard -----------------------------------------------------------
+
+@pytest.mark.parametrize("bad", [
+    "http://169.254.169.254/latest",
+    "http://metadata.google.internal/x",
+    "ftp://localhost/x",
+    "http:///nohost",
+])
+def test_ssrf_guard_blocks(bad):
+    with pytest.raises(DiscoveryError):
+        _validate_url_ssrf(bad)
+
+
+@pytest.mark.parametrize("ok", [
+    "http://localhost:8000/connections/discovery",
+    "http://auth.bond-mcps.svc.cluster.local:8000/connections/discovery",
+    "https://mcps.example.com/connections/discovery",
+])
+def test_ssrf_guard_allows(ok):
+    _validate_url_ssrf(ok)  # no raise
+
+
+def test_get_discovered_mcps_blocks_ssrf_url(monkeypatch):
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_URL, "http://169.254.169.254/discovery")
+    # Should fail soft (SSRF -> DiscoveryError -> empty), never reach httpx.
+    called = []
+    monkeypatch.setattr(mcp_discovery.httpx, "get", lambda *a, **k: called.append(1))
+    assert get_discovered_mcps() == []
+    assert called == []
+
+
+# --- Caching / TTL --------------------------------------------------------
+
+def test_results_cached_within_ttl(monkeypatch):
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_URL, DISCOVERY_URL)
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_TTL, "300")
+    calls = []
+    _set_response(monkeypatch, {"mcps": [{"name": "a", "url": "http://h/mcp"}]}, calls)
+
+    first = get_discovered_mcps()
+    second = get_discovered_mcps()
+    assert first == second
+    assert len(calls) == 1  # second served from cache
+
+
+def test_ttl_zero_refetches(monkeypatch):
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_URL, DISCOVERY_URL)
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_TTL, "0")
+    calls = []
+    _set_response(monkeypatch, {"mcps": [{"name": "a", "url": "http://h/mcp"}]}, calls)
+
+    get_discovered_mcps()
+    get_discovered_mcps()
+    assert len(calls) == 2  # TTL 0 -> always refetch
+
+
+def test_dynamic_add_remove_between_polls(monkeypatch):
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_URL, DISCOVERY_URL)
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_TTL, "0")
+    state = {"payload": {"mcps": [{"name": "a", "url": "http://h/mcp"}]}}
+    monkeypatch.setattr(mcp_discovery.httpx, "get", lambda *a, **k: FakeResp(state["payload"]))
+
+    assert [m["name"] for m in get_discovered_mcps()] == ["a"]
+    state["payload"] = {"mcps": [
+        {"name": "a", "url": "http://h/mcp"}, {"name": "b", "url": "http://h2/mcp"}]}
+    assert [m["name"] for m in get_discovered_mcps()] == ["a", "b"]
+    state["payload"] = {"mcps": []}
+    assert get_discovered_mcps() == []
+
+
+# --- Poller as sole fetcher (no event-loop blocking) ----------------------
+
+def test_request_thread_skips_fetch_when_poller_active(monkeypatch):
+    """With an active background poller, request-path reads must never trigger a
+    synchronous fetch (which could block an event loop). They read the cache."""
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_URL, DISCOVERY_URL)
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_TTL, "0")  # always "stale"
+    calls = []
+    _set_response(monkeypatch, {"mcps": [{"name": "a", "url": "http://h/mcp"}]}, calls)
+
+    class _AlivePoller:
+        def is_alive(self):
+            return True
+
+    mcp_discovery._CACHE._poller = _AlivePoller()
+    # Cache empty + poller active → return [] (static fallback), NO fetch.
+    assert get_discovered_mcps() == []
+    assert get_discovered_mcps() == []
+    assert calls == []  # request threads never fetched
+
+
+def test_force_refresh_fetches_even_with_poller(monkeypatch):
+    """The poller itself (force_refresh=True) must still fetch."""
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_URL, DISCOVERY_URL)
+    calls = []
+    _set_response(monkeypatch, {"mcps": [{"name": "a", "url": "http://h/mcp"}]}, calls)
+
+    class _AlivePoller:
+        def is_alive(self):
+            return True
+
+    mcp_discovery._CACHE._poller = _AlivePoller()
+    out = get_discovered_mcps(force_refresh=True)
+    assert [m["name"] for m in out] == ["a"]
+    assert len(calls) == 1
+    # Subsequent request-path read now sees the poller-populated cache.
+    assert [m["name"] for m in get_discovered_mcps()] == ["a"]
+    assert len(calls) == 1  # still no request-path fetch
+
+
+# --- Fail soft ------------------------------------------------------------
+
+def test_failsoft_returns_last_good_on_error(monkeypatch):
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_URL, DISCOVERY_URL)
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_TTL, "0")
+    good = {"mcps": [{"name": "a", "url": "http://h/mcp"}]}
+    monkeypatch.setattr(mcp_discovery.httpx, "get", lambda *a, **k: FakeResp(good))
+    assert [m["name"] for m in get_discovered_mcps()] == ["a"]
+
+    def boom(*a, **k):
+        import httpx
+        raise httpx.ConnectError("down")
+    monkeypatch.setattr(mcp_discovery.httpx, "get", boom)
+    # Outage -> serve last good (not empty).
+    assert [m["name"] for m in get_discovered_mcps()] == ["a"]
+
+
+def test_failsoft_empty_when_no_prior_success(monkeypatch):
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_URL, DISCOVERY_URL)
+
+    def boom(*a, **k):
+        import httpx
+        raise httpx.ConnectError("down")
+    monkeypatch.setattr(mcp_discovery.httpx, "get", boom)
+    assert get_discovered_mcps() == []
+
+
+# --- Config overlay -------------------------------------------------------
+
+def _overlay(monkeypatch, static, discovered):
+    monkeypatch.setattr(
+        "bondable.bond.mcp_discovery.get_discovered_mcps",
+        lambda force_refresh=False: discovered,
+    )
+    from bondable.bond.config import Config
+    cfg = Config.__new__(Config)
+    return cfg._overlay_discovered_mcps(static)
+
+
+def test_overlay_merges_and_strips_oauth(monkeypatch):
+    static = {"mcpServers": {
+        "atlassian_v2": {"url": "http://old", "auth_type": "oauth2",
+                          "oauth_config": {"scopes": "stale"}, "icon_url": "x.png"},
+        "hello": {"command": "python", "args": ["h.py"]},
+    }}
+    discovered = [
+        {"name": "atlassian_v2", "display_name": "Atlassian", "url": "http://localhost:18003/mcp"},
+        {"name": "github", "display_name": "GitHub", "url": "http://localhost:18002/mcp"},
+    ]
+    out = _overlay(monkeypatch, static, discovered)["mcpServers"]
+
+    atl = out["atlassian_v2"]
+    assert atl["url"] == "http://localhost:18003/mcp"
+    assert atl["auth_type"] == "bond_jwt"
+    assert atl["transport"] == "streamable-http"
+    assert "oauth_config" not in atl          # stale OAuth dropped
+    assert atl["icon_url"] == "x.png"          # annotation preserved
+    assert out["hello"] == {"command": "python", "args": ["h.py"]}  # untouched
+    assert out["github"]["auth_type"] == "bond_jwt"
+
+
+def test_overlay_noop_when_no_discovery(monkeypatch):
+    static = {"mcpServers": {"hello": {"command": "python"}}}
+    out = _overlay(monkeypatch, static, [])
+    assert out == static

--- a/tests/test_mcp_managed_runtime.py
+++ b/tests/test_mcp_managed_runtime.py
@@ -1,0 +1,92 @@
+"""Runtime tests for executing tools on bond-mcps-managed (bond_jwt) MCPs.
+
+Covers: the Bond JWT is forwarded as the Bearer token to a discovered server,
+and a MissingProviderConnection-shaped tool error (carrying a /connect URL) is
+surfaced as a structured authorization_required response with the connect_url.
+"""
+
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from bondable.bond.providers.bedrock.BedrockMCP import (
+    _extract_connect_url,
+    execute_mcp_tool,
+)
+
+
+MANAGED_CONFIG = {
+    "mcpServers": {
+        "atlassian": {
+            "url": "http://localhost:18003/mcp",
+            "transport": "streamable-http",
+            "auth_type": "bond_jwt",
+        }
+    }
+}
+
+
+def _mock_tool(name):
+    t = Mock()
+    t.name = name
+    t.inputSchema = {}
+    return t
+
+
+def test_extract_connect_url():
+    msg = ("atlassian is not connected for the current user. Open "
+           "http://localhost:8000/connect/atlassian?ticket=abc in a browser to authorize.")
+    assert _extract_connect_url(msg) == "http://localhost:8000/connect/atlassian?ticket=abc"
+    assert _extract_connect_url("boom") is None
+    assert _extract_connect_url("") is None
+
+
+@pytest.mark.asyncio
+async def test_bond_jwt_forwarded_to_managed_server():
+    """The user's Bond JWT becomes the Bearer token for a bond_jwt server."""
+    result_obj = Mock()
+    result_obj.content = [Mock(text="ok")]
+
+    with patch("bondable.bond.providers.bedrock.BedrockMCP.StreamableHttpTransport") as transport_cls, \
+         patch("bondable.bond.providers.bedrock.BedrockMCP.Client") as client_cls:
+        client = AsyncMock()
+        client.list_tools = AsyncMock(return_value=[_mock_tool("getJiraIssue")])
+        client.call_tool = AsyncMock(return_value=result_obj)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client_cls.return_value = client
+
+        out = await execute_mcp_tool(
+            MANAGED_CONFIG, "getJiraIssue", {"issueKey": "X-1"},
+            current_user=Mock(user_id="u-1"), jwt_token="BONDJWT", target_server="atlassian",
+        )
+
+    assert out["success"] is True
+    headers = transport_cls.call_args.kwargs.get("headers", {})
+    assert headers.get("Authorization") == "Bearer BONDJWT"
+
+
+@pytest.mark.asyncio
+async def test_missing_connection_surfaces_connect_url():
+    """A tool error carrying a /connect URL becomes a structured response."""
+    with patch("bondable.bond.providers.bedrock.BedrockMCP.StreamableHttpTransport"), \
+         patch("bondable.bond.providers.bedrock.BedrockMCP.Client") as client_cls:
+        client = AsyncMock()
+        client.list_tools = AsyncMock(return_value=[_mock_tool("getJiraIssue")])
+        client.call_tool = AsyncMock(side_effect=Exception(
+            "atlassian is not connected. Open "
+            "http://localhost:8000/connect/atlassian?ticket=TKT in a browser to authorize."
+        ))
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client_cls.return_value = client
+
+        out = await execute_mcp_tool(
+            MANAGED_CONFIG, "getJiraIssue", {"issueKey": "X-1"},
+            current_user=Mock(user_id="u-1"), jwt_token="BONDJWT", target_server="atlassian",
+        )
+
+    assert out["success"] is False
+    assert out["authorization_required"] is True
+    assert out["connect_url"] == "http://localhost:8000/connect/atlassian?ticket=TKT"
+    assert out["server_name"] == "atlassian"


### PR DESCRIPTION
## Summary

bond-ai no longer hard-configures the MCP list or drives provider OAuth. It now:

- **Discovers** the available MCPs from bond-mcps' `/connections/discovery` endpoint via a single env var `BOND_MCPS_DISCOVERY_URL`, polled in the background so MCPs can be added/removed without restarting bond-ai.
- **Authenticates** tool calls with the **Bond JWT** (HS256), which bond-mcps validates via a **shared secret** (= bond-ai `JWT_SECRET_KEY`). bond-ai stops storing provider tokens for managed MCPs.
- **Delegates** the OAuth Connect flow to bond-mcps' `/connect/<name>` endpoints — bond-ai mints a ticket (forwarding the JWT + a return URL), the provider redirect lands on bond-mcps (which stores the token), and the user returns to bond-ai with the connection established.

This is **full delegation** (handoff-doc "Option A"); the shipped discovery endpoint carries only `{name, display_name, url}`, so the original "overlay OAuth scopes from discovery" plan was not implementable.

## Changes
- `bondable/bond/mcp_discovery.py` (new) — polled, TTL-cached, SSRF-guarded discovery client. The background poller is the **sole fetcher**, so request threads never do a blocking fetch on the event loop.
- `bondable/bond/config.py` — `get_mcp_config()` overlays discovered MCPs as `bond_jwt` servers, dropping stale inline `oauth_config`, preserving annotations, leaving `command`/user-defined servers untouched.
- `bondable/bond/mcp_connect_client.py` (new) — **async** client for bond-mcps `/connect` ticket / status / delete.
- `bondable/rest/routers/connections.py` — managed (delegated) track alongside the preserved user-defined OAuth2 path; concurrent status checks (`asyncio.gather`) with per-MCP fail-soft.
- `bondable/bond/providers/bedrock/BedrockMCP.py` — surface `MissingProviderConnection` `connect_url` as a structured `authorization_required` result.
- `bondable/rest/main.py` — start/stop the discovery poller in the app lifespan.
- `deployment/nginx-local-combined.conf` — route `/connect/<provider>/*` to per-MCP ports (18001–18004).
- `.env.example` / `.env.combined.example` — discovery URL + shared-secret mapping documented.

## Tests
New: `test_mcp_discovery`, `test_mcp_connect_client`, `test_jwt_mcps_trust` (HS256 accept/reject contract), `test_mcp_managed_runtime`, `test_connections_delegation` (full Connect choreography against a stubbed bond-mcps), plus a `/connect` nginx invariant. Full backend suite: **1422 passed, 0 failed**; nginx validated via real `nginx -t`.

## ⚠️ bond-mcps companion work required before this works end-to-end
Tracked in `docs/combined-mode-status.md` §3:
1. **JWT-mode config** with the shared secret (`HS256`, `iss=bond-ai`, `aud=mcp-server`) — also un-dormants `/connect/*`.
2. **`return_url`** in `/connect/<name>/callback` (today it renders a terminal page).
3. **`GET /connect/<name>/status`** + **`DELETE /connect/<name>`** (JWT-authed).
4. **Deployment-aware discovery URLs** (currently emits `localhost` and `[]` off a non-checkout) — until then deployed bond-ai falls back to static config.

## Open coordination items
- Where `/connect` is hosted (per-MCP ports vs. auth-proxy single block) and the `ms-graph` vs `microsoft` connect-route naming.
- `user_key` = JWT `sub` (email) at both connect-time and tool-time — confirm vs. internal `user_id`.
- Registering the new `/connect/<name>/callback` redirect URIs at each provider console.
- Optional: Flutter "Connect" affordance consuming the surfaced `connect_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)