### PR TITLE
Fix mcp callback connections path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -256,26 +256,34 @@ backend-combined: _check-backend-port
 # first service stopped, since subsequent iterations find nothing.
 # Also stops the nginx container (no-op if it's not running) so `make stop`
 # covers both split and combined modes uniformly.
+# Robust stop: uvicorn --reload runs TWO processes on :$(BACKEND_PORT) (the
+# reloader + its worker), so killing a single `lsof | head -1` PID left the
+# port bound and made `make dev-combined` fail its port check. Instead, for
+# each port: kill ALL listeners (TERM the whole process group + the pid), then
+# poll up to ~5s and escalate to KILL until the socket is actually free. This
+# makes `make stop && make dev-combined` reliable.
 stop:
 	@$(MAKE) --no-print-directory nginx-stop
-	@pids_to_kill=""; \
-	for entry in "backend:$(BACKEND_PORT)" "frontend:$(FRONTEND_PORT)"; do \
-	  name=$${entry%%:*}; port=$${entry##*:}; \
-	  pid=$$(lsof -nP -iTCP:$$port -sTCP:LISTEN -t 2>/dev/null | head -1); \
-	  if [ -n "$$pid" ]; then \
-	    echo "Stopping $$name :$$port (pid $$pid)"; \
-	    pids_to_kill="$$pids_to_kill $$pid"; \
-	  fi; \
+	@any=0; \
+	for port in $(BACKEND_PORT) $(FRONTEND_PORT); do \
+	  pids=$$(lsof -nP -iTCP:$$port -sTCP:LISTEN -t 2>/dev/null | sort -u); \
+	  [ -z "$$pids" ] && continue; \
+	  any=1; echo "Stopping :$$port ($$(echo $$pids | tr '\n' ' '))"; \
+	  for pid in $$pids; do \
+	    pgid=$$(ps -o pgid= -p $$pid 2>/dev/null | tr -d ' '); \
+	    [ -n "$$pgid" ] && kill -TERM -- -$$pgid 2>/dev/null || true; \
+	    kill -TERM $$pid 2>/dev/null || true; \
+	  done; \
+	  for i in 1 2 3 4 5 6 7 8 9 10; do \
+	    rem=$$(lsof -nP -iTCP:$$port -sTCP:LISTEN -t 2>/dev/null); \
+	    [ -z "$$rem" ] && break; \
+	    sleep 0.5; \
+	    for pid in $$rem; do kill -KILL $$pid 2>/dev/null || true; done; \
+	  done; \
+	  rem=$$(lsof -nP -iTCP:$$port -sTCP:LISTEN -t 2>/dev/null); \
+	  [ -n "$$rem" ] && echo "  WARN: :$$port still in use ($$rem)" >&2 || echo "  :$$port free"; \
 	done; \
-	if [ -z "$$pids_to_kill" ]; then \
-	  echo "  nothing to stop (no process on :$(BACKEND_PORT) or :$(FRONTEND_PORT))"; \
-	  exit 0; \
-	fi; \
-	for pid in $$pids_to_kill; do \
-	  pgid=$$(ps -o pgid= -p $$pid 2>/dev/null | tr -d ' '); \
-	  if [ -n "$$pgid" ]; then kill -- -$$pgid 2>/dev/null; fi; \
-	  kill $$pid 2>/dev/null || true; \
-	done
+	[ $$any -eq 0 ] && echo "  nothing to stop (no process on :$(BACKEND_PORT) or :$(FRONTEND_PORT))" || true
 
 restart: stop
 	@sleep 1

--- a/bondable/bond/config.py
+++ b/bondable/bond/config.py
@@ -539,6 +539,11 @@ class Config:
                 "display_name": entry.get("display_name", existing.get("display_name", name)),
                 "transport": "streamable-http",
                 "auth_type": "bond_jwt",
+                # Marks a bond-mcps-managed MCP: bond_jwt auth, but its per-user
+                # connection status is delegated (queried via bond-mcps'
+                # /connect/<name>/status), NOT "always connected" like internal
+                # bond_jwt servers (sbelcrm, admin, common).
+                "is_managed": True,
             })
             servers[name] = existing
 

--- a/bondable/bond/mcp_connect_client.py
+++ b/bondable/bond/mcp_connect_client.py
@@ -126,6 +126,62 @@ async def get_connect_status(
     return payload
 
 
+def _iso_expires_at(value: Any) -> Optional[str]:
+    """Normalize bond-mcps' ``expires_at`` (epoch seconds) to ISO-8601 UTC.
+
+    bond-ai's REST models (and the Flutter UI) carry ``expires_at`` as an
+    ISO string — the same shape the legacy token-cache path produces. None or
+    an unparseable value maps to None.
+    """
+    if value is None:
+        return None
+    try:
+        from datetime import datetime, timezone
+
+        return datetime.fromtimestamp(float(value), tz=timezone.utc).isoformat()
+    except (TypeError, ValueError, OSError, OverflowError):
+        return None
+
+
+async def get_connect_status_safe(
+    mcp_url: str,
+    name: str,
+    jwt_token: str,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> Optional[Dict[str, Any]]:
+    """:func:`get_connect_status`, but never raises — for status listings.
+
+    Returns the status dict with ``expires_at`` normalized to ISO-8601, or
+    ``None`` for "no connect surface" (HTTP 404). When bond-mcps is
+    unreachable or errors, returns a disconnected-shaped dict carrying an
+    ``"error"`` key, so one bad MCP never fails a whole listing.
+
+    Callers decide what ``None`` means for their surface: the Connections
+    screen omits the tile (not a connectable provider), while the tools list
+    reports the server as connected (nothing to connect, still usable).
+    """
+    try:
+        status = await get_connect_status(mcp_url, name, jwt_token, timeout=timeout)
+    except Exception as exc:  # noqa: BLE001 - fail soft; listings must render
+        LOGGER.warning(
+            "connect status for %s failed; reporting disconnected: %s: %s",
+            name, type(exc).__name__, exc,
+        )
+        return {
+            "connected": False,
+            "valid": False,
+            "scopes": None,
+            "expires_at": None,
+            "has_refresh_token": False,
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+    if status is None:
+        return None
+    status = dict(status)
+    status["expires_at"] = _iso_expires_at(status.get("expires_at"))
+    return status
+
+
 async def delete_connection(
     mcp_url: str,
     name: str,

--- a/bondable/bond/mcp_discovery.py
+++ b/bondable/bond/mcp_discovery.py
@@ -46,6 +46,15 @@ ENV_DISCOVERY_TIMEOUT = "BOND_MCPS_DISCOVERY_TIMEOUT_SECONDS"
 DEFAULT_TTL_SECONDS = 300
 DEFAULT_TIMEOUT_SECONDS = 5.0
 
+# Poller retry interval while the cache has never been populated. Until the
+# first successful fetch, waiting a full TTL leaves managed MCPs invisible for
+# minutes when bond-ai starts before its discovery upstream is reachable
+# (locally `make dev-combined` starts the backend before nginx; in deployment
+# a bond-ai pod can start before the bond-mcps AS). Once a fetch has
+# succeeded, transient failures fall back to the last-good cache, so the
+# normal TTL cadence is fine.
+STARTUP_RETRY_SECONDS = 10.0
+
 # SSRF protection: never let a (mis)configured discovery URL reach a cloud
 # metadata endpoint. Mirrors the blocklist in
 # ``bondable/rest/routers/user_mcp_servers.py`` (localhost is intentionally
@@ -209,13 +218,23 @@ class _DiscoveryCache:
         LOGGER.debug("MCP discovery returned %d server(s) from %s", len(entries), url)
         return entries
 
+    def _next_poll_interval(self) -> float:
+        """Poll cadence: fast retry until the first successful fetch lands."""
+        with self._lock:
+            never_fetched = self._entries is None
+        ttl = _get_ttl_seconds()
+        return min(STARTUP_RETRY_SECONDS, ttl) if never_fetched else ttl
+
     def start_background_poller(self) -> None:
         """Start a daemon thread that refreshes the cache every TTL seconds.
 
         Idempotent and a no-op when discovery is disabled. Lazy TTL refresh on
         access already keeps data fresh for active traffic; the poller guarantees
         regular refresh even when nothing is reading (so a newly added MCP shows
-        up without waiting for the next request).
+        up without waiting for the next request). Until the first fetch
+        succeeds it polls every ``STARTUP_RETRY_SECONDS`` instead, so a backend
+        that boots before its discovery upstream recovers in seconds, not a
+        full TTL.
         """
         if not get_discovery_url():
             return
@@ -231,7 +250,7 @@ class _DiscoveryCache:
                         self.get(force_refresh=True)
                     except Exception:  # noqa: BLE001 - poller must never die
                         LOGGER.debug("MCP discovery poll iteration failed", exc_info=True)
-                    stop.wait(_get_ttl_seconds())
+                    stop.wait(self._next_poll_interval())
 
             poller = threading.Thread(
                 target=_loop, name="mcp-discovery-poller", daemon=True

--- a/bondable/bond/providers/bedrock/BedrockMCP.py
+++ b/bondable/bond/providers/bedrock/BedrockMCP.py
@@ -1283,12 +1283,27 @@ def _get_auth_headers_for_server(
         LOGGER.debug("Using OAuth2 token for MCP server %s", safe_id(server_name))
 
     elif auth_type == AUTH_TYPE_BOND_JWT:
-        # Bond JWT: Use the passed JWT token
-        if jwt_token:
-            headers['Authorization'] = f'Bearer {jwt_token}'
+        # Bond JWT: use the forwarded token, or mint one for the user. Server-side
+        # flows (agent tool-def fetch at create time) call this without a
+        # forwarded request JWT; without a token, bond-mcps-managed MCPs 401 and
+        # the agent gets no tools. bond-mcps validates the Bond JWT (HS256,
+        # iss=bond-ai, aud includes mcp-server, sub=email), so minting from the
+        # authenticated user's email yields a token the MCPs accept.
+        token = jwt_token
+        if not token and current_user is not None:
+            email = getattr(current_user, 'email', None)
+            if email:
+                try:
+                    from bondable.rest.utils.auth import create_access_token
+                    token = create_access_token({"sub": email})
+                    LOGGER.debug("Minted Bond JWT for bond_jwt server %s (user %s)", safe_id(server_name), safe_id(email))
+                except Exception as e:  # noqa: BLE001 - fall through to no-auth + log
+                    LOGGER.warning("Failed to mint Bond JWT for server %s: %s", safe_id(server_name), e)
+        if token:
+            headers['Authorization'] = f'Bearer {token}'
             LOGGER.debug("Using Bond JWT for MCP server %s", safe_id(server_name))
         else:
-            LOGGER.debug("No JWT token provided for bond_jwt auth on server %s", safe_id(server_name))
+            LOGGER.debug("No JWT token or current_user for bond_jwt auth on server %s", safe_id(server_name))
 
     elif auth_type == AUTH_TYPE_STATIC:
         # Static: Only use headers from config (already set above)

--- a/bondable/bond/providers/bedrock/BedrockMCP.py
+++ b/bondable/bond/providers/bedrock/BedrockMCP.py
@@ -930,6 +930,30 @@ def create_mcp_action_groups(bedrock_agent_id: str, mcp_tools: List[str], mcp_re
         # Continue without MCP tools rather than failing agent creation
 
 
+def _resolve_user_email(user_id: str) -> Optional[str]:
+    """Resolve a user's email from the users table.
+
+    Server-side flows (agent tool-def fetch at create time) only carry a
+    user_id, but the Bond JWT identity contract keys on email (sub claim).
+    Returns None when the lookup fails — callers must then skip minting
+    rather than fabricate an identity.
+    """
+    try:
+        from bondable.bond.providers.metadata import User
+
+        provider = Config.config().get_provider()
+        if not provider or not hasattr(provider, 'metadata'):
+            return None
+        session = provider.metadata.get_db_session()
+        if not session:
+            return None
+        record = session.query(User).filter(User.id == user_id).first()
+        return record.email if record else None
+    except Exception as e:  # noqa: BLE001 - lookup failure must not break tool-def fetch
+        LOGGER.warning("[MCP Auth] Could not resolve email for user %s: %s", safe_id(user_id), e)
+        return None
+
+
 async def _get_mcp_tool_definitions(mcp_config: Dict[str, Any], tool_names: List[str], user_id: Optional[str] = None) -> List[Dict[str, Any]]:
     """
     Get tool definitions from MCP servers.
@@ -951,14 +975,17 @@ async def _get_mcp_tool_definitions(mcp_config: Dict[str, Any], tool_names: List
 
     LOGGER.debug(f"[MCP Tool Defs] Searching {len(servers)} servers for {len(tool_names)} tools: {tool_names}")
 
-    # Create user context for OAuth lookup if user_id is provided
+    # Create user context for OAuth lookup if user_id is provided. The email
+    # is resolved from the users table because bond_jwt minting asserts it as
+    # the JWT sub — a placeholder like 'unknown' would fabricate an identity
+    # that bond-mcps trusts. None (lookup failed) means "don't mint".
     current_user = None
     if user_id:
         class UserContext:
-            def __init__(self, uid):
+            def __init__(self, uid, email):
                 self.user_id = uid
-                self.email = 'unknown'
-        current_user = UserContext(user_id)
+                self.email = email
+        current_user = UserContext(user_id, _resolve_user_email(user_id))
 
     tool_definitions = []
 
@@ -1288,17 +1315,29 @@ def _get_auth_headers_for_server(
         # forwarded request JWT; without a token, bond-mcps-managed MCPs 401 and
         # the agent gets no tools. bond-mcps validates the Bond JWT (HS256,
         # iss=bond-ai, aud includes mcp-server, sub=email), so minting from the
-        # authenticated user's email yields a token the MCPs accept.
+        # user's real email yields a token the MCPs accept.
         token = jwt_token
         if not token and current_user is not None:
             email = getattr(current_user, 'email', None)
-            if email:
+            # Only mint for a real email identity — a placeholder ('unknown',
+            # empty) would sign a JWT asserting an identity that doesn't exist.
+            if email and '@' in email:
                 try:
+                    from datetime import timedelta
                     from bondable.rest.utils.auth import create_access_token
-                    token = create_access_token({"sub": email})
+                    # Narrow audience + short expiry: this token is consumed
+                    # immediately by an MCP call. The session defaults (aud
+                    # includes bond-ai-api, 24h expiry) would hand the MCP
+                    # server a full bond-ai API session — mint the minimum.
+                    token = create_access_token(
+                        {"sub": email, "aud": ["mcp-server"]},
+                        expires_delta=timedelta(minutes=5),
+                    )
                     LOGGER.debug("Minted Bond JWT for bond_jwt server %s (user %s)", safe_id(server_name), safe_id(email))
                 except Exception as e:  # noqa: BLE001 - fall through to no-auth + log
                     LOGGER.warning("Failed to mint Bond JWT for server %s: %s", safe_id(server_name), e)
+            else:
+                LOGGER.debug("No real email for bond_jwt mint on server %s; skipping", safe_id(server_name))
         if token:
             headers['Authorization'] = f'Bearer {token}'
             LOGGER.debug("Using Bond JWT for MCP server %s", safe_id(server_name))

--- a/bondable/rest/routers/connections.py
+++ b/bondable/rest/routers/connections.py
@@ -387,16 +387,12 @@ async def list_connections(
     managed_configs = _get_managed_connection_configs()
 
     async def _managed_status(cfg):
-        try:
-            return cfg, await mcp_connect_client.get_connect_status(cfg["url"], cfg["name"], jwt_token)
-        except Exception as e:  # noqa: BLE001 - one bad MCP must not 500 the whole list
-            # bond-mcps unreachable / unexpected error: surface this provider as
-            # disconnected so the user can retry, without failing the page.
-            LOGGER.warning(
-                "[Connections] status check failed for managed %s: %s: %s",
-                safe_id(cfg["name"]), type(e).__name__, e,
-            )
-            return cfg, {"connected": False, "valid": False}
+        # Fail-soft per MCP (get_connect_status_safe): bond-mcps unreachable /
+        # errored reads as disconnected so the user can retry, without one bad
+        # MCP failing the whole page.
+        return cfg, await mcp_connect_client.get_connect_status_safe(
+            cfg["url"], cfg["name"], jwt_token
+        )
 
     managed_results = await asyncio.gather(*(_managed_status(c) for c in managed_configs))
 
@@ -404,8 +400,13 @@ async def list_connections(
         name = config["name"]
         if mcps_status is None:
             # MCP exposes no connect surface → not a connectable provider; omit.
+            # NOTE: /mcp/tools makes the opposite call for the same signal
+            # (reports connected — nothing to connect, server still usable).
             continue
         connected = bool(mcps_status.get("connected", False))
+        # On this screen `valid` means "not expired", so a disconnected
+        # provider reads valid=True (nothing to be expired). The tools list
+        # maps it the other way (valid gates tool selection).
         valid = bool(mcps_status.get("valid", True)) if connected else True
         connections.append(ConnectionStatusResponse(
             name=name,
@@ -764,12 +765,11 @@ async def get_connection_status(
     # --- Managed (bond-mcps-delegated) connection --------------------------
     managed = _get_managed_connection(connection_name)
     if managed is not None:
-        try:
-            # discovery-sourced name (not the request path param) → no SSRF taint.
-            mcps_status = await mcp_connect_client.get_connect_status(managed["url"], managed["name"], jwt_token)
-        except ConnectError as e:
-            LOGGER.warning("[Connections] status check failed for managed %s: %s", safe_id(connection_name), e)
-            mcps_status = {"connected": False, "valid": False}
+        # discovery-sourced name (not the request path param) → no SSRF taint.
+        # get_connect_status_safe fails soft (errors read as disconnected).
+        mcps_status = await mcp_connect_client.get_connect_status_safe(
+            managed["url"], managed["name"], jwt_token
+        )
         if mcps_status is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,

--- a/bondable/rest/routers/mcp.py
+++ b/bondable/rest/routers/mcp.py
@@ -1,3 +1,4 @@
+import asyncio
 import logging
 from typing import Annotated, List, Dict, Any, Optional, Union
 from fastapi import APIRouter, Depends, HTTPException, status, Query
@@ -114,7 +115,6 @@ async def list_mcp_tools(
         # network round-trip to bond-mcps' /connect/<name>/status; gathering them
         # avoids serializing the calls inside the per-server loop below (mirrors
         # list_connections). Internal/oauth2 servers are resolved synchronously.
-        import asyncio
         managed_names = [n for n, c in servers.items() if c.get('is_managed')]
         managed_status: Dict[str, ConnectionStatusInfo] = {}
         if managed_names:
@@ -458,7 +458,6 @@ async def _discover_user_mcp_server_tools(
                     transport = StreamableHttpTransport(server_url, headers=headers)
 
                 try:
-                    import asyncio
                     async with Client(transport) as client:
                         tools = await asyncio.wait_for(client.list_tools(), timeout=15)
                         server_tools = [
@@ -513,30 +512,31 @@ async def _get_managed_connection_status(
     """Connection status for a bond-mcps-managed (discovered) MCP.
 
     Delegates to bond-mcps' /connect/<name>/status (same as the Connections
-    screen). A None result means the MCP exposes no connect surface (e.g.
-    PAT-based databricks) — nothing to connect, so report connected. Network/
-    HTTP errors are surfaced as not-connected so the UI prompts a (re)connect.
+    screen), fail-soft: network/HTTP errors surface as not-connected so the
+    UI prompts a (re)connect instead of failing the listing.
     """
     from bondable.bond import mcp_connect_client
 
     url = server_config.get('url', '')
-    try:
-        status = await mcp_connect_client.get_connect_status(url, server_name, jwt_token)
-    except Exception as e:  # noqa: BLE001 - fail soft to "not connected"
-        LOGGER.warning("[MCP Tools] managed status check failed for '%s': %s", server_name, e)
-        return ConnectionStatusInfo(connected=False, valid=False, requires_authorization=True, expires_at=None)
+    status = await mcp_connect_client.get_connect_status_safe(url, server_name, jwt_token)
 
     if status is None:
-        # No connect surface (e.g. databricks PAT) — nothing to connect.
+        # No connect surface (e.g. databricks PAT) — nothing to connect, so the
+        # server renders as usable. NOTE: the Connections screen makes the
+        # opposite call for the same signal (omits the tile entirely).
         return ConnectionStatusInfo(connected=True, valid=True, requires_authorization=False, expires_at=None)
 
     connected = bool(status.get("connected", False))
+    # `valid` gates tool selection in the agent editor, so a disconnected
+    # server reads invalid here — unlike the Connections screen, where
+    # valid=True on a disconnected provider just means "not expired".
     valid = bool(status.get("valid", True)) if connected else False
     return ConnectionStatusInfo(
         connected=connected,
         valid=valid,
         requires_authorization=not connected,
         expires_at=status.get("expires_at"),
+        has_refresh_token=bool(status.get("has_refresh_token", False)),
     )
 
 

--- a/bondable/rest/routers/mcp.py
+++ b/bondable/rest/routers/mcp.py
@@ -110,6 +110,19 @@ async def list_mcp_tools(
         # Get token cache for checking connection status
         token_cache = get_mcp_token_cache()
 
+        # Pre-fetch managed-server connection status concurrently. Each is a
+        # network round-trip to bond-mcps' /connect/<name>/status; gathering them
+        # avoids serializing the calls inside the per-server loop below (mirrors
+        # list_connections). Internal/oauth2 servers are resolved synchronously.
+        import asyncio
+        managed_names = [n for n, c in servers.items() if c.get('is_managed')]
+        managed_status: Dict[str, ConnectionStatusInfo] = {}
+        if managed_names:
+            results = await asyncio.gather(
+                *(_get_managed_connection_status(n, servers[n], jwt_token) for n in managed_names)
+            )
+            managed_status = dict(zip(managed_names, results))
+
         # Collect tools from all servers (grouped by server)
         all_tools = []
         server_tools_list: List[MCPServerWithTools] = []
@@ -120,10 +133,16 @@ async def list_mcp_tools(
             description = server_config.get('description')
             icon_url = server_config.get('icon_url')
 
-            # Determine connection status
-            connection_status = _get_connection_status_for_server(
-                server_name, server_config, current_user.user_id, token_cache
-            )
+            # Determine connection status. Managed (bond-mcps-discovered) servers
+            # are bond_jwt but DO require a per-user provider connection, so their
+            # status is delegated to bond-mcps — not the "non-oauth = always
+            # connected" shortcut used for internal bond_jwt servers.
+            if server_config.get('is_managed'):
+                connection_status = managed_status[server_name]
+            else:
+                connection_status = _get_connection_status_for_server(
+                    server_name, server_config, current_user.user_id, token_cache
+                )
 
             server_tools: List[MCPToolResponse] = []
 
@@ -484,6 +503,41 @@ async def _discover_user_mcp_server_tools(
         LOGGER.info(f"[MCP Tools] Discovered {len(result['servers'])} user-defined servers with {len(result['tools'])} tools")
 
     return result
+
+
+async def _get_managed_connection_status(
+    server_name: str,
+    server_config: Dict[str, Any],
+    jwt_token: Optional[str],
+) -> ConnectionStatusInfo:
+    """Connection status for a bond-mcps-managed (discovered) MCP.
+
+    Delegates to bond-mcps' /connect/<name>/status (same as the Connections
+    screen). A None result means the MCP exposes no connect surface (e.g.
+    PAT-based databricks) — nothing to connect, so report connected. Network/
+    HTTP errors are surfaced as not-connected so the UI prompts a (re)connect.
+    """
+    from bondable.bond import mcp_connect_client
+
+    url = server_config.get('url', '')
+    try:
+        status = await mcp_connect_client.get_connect_status(url, server_name, jwt_token)
+    except Exception as e:  # noqa: BLE001 - fail soft to "not connected"
+        LOGGER.warning("[MCP Tools] managed status check failed for '%s': %s", server_name, e)
+        return ConnectionStatusInfo(connected=False, valid=False, requires_authorization=True, expires_at=None)
+
+    if status is None:
+        # No connect surface (e.g. databricks PAT) — nothing to connect.
+        return ConnectionStatusInfo(connected=True, valid=True, requires_authorization=False, expires_at=None)
+
+    connected = bool(status.get("connected", False))
+    valid = bool(status.get("valid", True)) if connected else False
+    return ConnectionStatusInfo(
+        connected=connected,
+        valid=valid,
+        requires_authorization=not connected,
+        expires_at=status.get("expires_at"),
+    )
 
 
 def _get_connection_status_for_server(

--- a/deployment/nginx-local-combined.conf
+++ b/deployment/nginx-local-combined.conf
@@ -121,18 +121,29 @@ server {
     }
 
     # ------------------------------------------------------------------------
+    # MCP OAuth callbacks: /connections/<provider>/callback → the per-MCP port
+    # that serves that provider's connect routes. This is the canonical,
+    # already-registered provider redirect path (so connecting needs NO new
+    # console registration). Exact `=` matches win over the /connections/
+    # prefix above (which still carries /connections/discovery → :18000).
+    # ------------------------------------------------------------------------
+    location = /connections/microsoft/callback  { proxy_pass http://host.docker.internal:18001; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+    location = /connections/github/callback     { proxy_pass http://host.docker.internal:18002; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+    location = /connections/atlassian/callback  { proxy_pass http://host.docker.internal:18003; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+
+    # ------------------------------------------------------------------------
     # /connect/<provider>/* → bond-mcps per-MCP FastMCP ports (delegated OAuth
     # Connect flow). bond-ai mints the ticket server-side (direct to the MCP
     # port), but the BROWSER hits these paths at the front door, so they must be
     # routed to the MCP that serves each provider's /connect routes. Ports mirror
-    # bond-mcps combined-mode (mcp.json): ms-graph 18001, github 18002,
+    # bond-mcps combined-mode (mcp.json): microsoft 18001, github 18002,
     # atlassian 18003, databricks 18004. Requires bond-mcps to advertise
     # BOND_MCPS_PUBLIC_URL=http://localhost:8000 and run with JWT mode ON (which
     # un-dormants /connect/*). If bond-mcps later hosts /connect on the auth
     # proxy, collapse these into one `location /connect/ → :18000` block.
     # ------------------------------------------------------------------------
-    location /connect/ms-graph/   { proxy_pass http://host.docker.internal:18001; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
-    location = /connect/ms-graph   { proxy_pass http://host.docker.internal:18001; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+    location /connect/microsoft/  { proxy_pass http://host.docker.internal:18001; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+    location = /connect/microsoft  { proxy_pass http://host.docker.internal:18001; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
     location /connect/github/     { proxy_pass http://host.docker.internal:18002; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
     location = /connect/github     { proxy_pass http://host.docker.internal:18002; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
     location /connect/atlassian/  { proxy_pass http://host.docker.internal:18003; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }

--- a/deployment/nginx-local-combined.conf
+++ b/deployment/nginx-local-combined.conf
@@ -100,6 +100,20 @@ server {
     }
 
     # ------------------------------------------------------------------------
+    # /connections (exact, no trailing slash) is the SPA route the OAuth connect
+    # flow returns to (return_url=.../connections?connection_success=...). Serve
+    # index.html directly. Without this exact match, a bare /connections matches
+    # the /connections/ prefix block below and nginx 301s to add the slash using
+    # its in-container listen port (:8080) — which the browser can't reach.
+    # Mirrors deployment/nginx-combined.conf.
+    # ------------------------------------------------------------------------
+    location = /connections {
+        add_header Cache-Control "no-cache, no-store, must-revalidate";
+        root /usr/share/nginx/html;
+        try_files /index.html =404;
+    }
+
+    # ------------------------------------------------------------------------
     # /connections/* → bond-mcps auth proxy (MCP OAuth callbacks).
     # Note: bond-mcps moves to :18000 in combined mode so nginx can take :8000.
     # The friendly 503 surfaces "bond-mcps is down" instead of a generic 502.

--- a/deployment/nginx-local-combined.conf
+++ b/deployment/nginx-local-combined.conf
@@ -114,7 +114,9 @@ server {
     }
 
     # ------------------------------------------------------------------------
-    # /connections/* → bond-mcps auth proxy (MCP OAuth callbacks).
+    # /connections/* (everything not caught by an exact match below) →
+    # bond-mcps :18000. In practice this carries /connections/discovery; the
+    # per-provider OAuth callbacks are exact-matched to the MCP ports below.
     # Note: bond-mcps moves to :18000 in combined mode so nginx can take :8000.
     # The friendly 503 surfaces "bond-mcps is down" instead of a generic 502.
     # ------------------------------------------------------------------------
@@ -141,9 +143,16 @@ server {
     # console registration). Exact `=` matches win over the /connections/
     # prefix above (which still carries /connections/discovery → :18000).
     # ------------------------------------------------------------------------
-    location = /connections/microsoft/callback  { proxy_pass http://host.docker.internal:18001; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
-    location = /connections/github/callback     { proxy_pass http://host.docker.internal:18002; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
-    location = /connections/atlassian/callback  { proxy_pass http://host.docker.internal:18003; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; }
+    location = /connections/microsoft/callback  { proxy_pass http://host.docker.internal:18001; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; proxy_intercept_errors on; error_page 502 503 504 = @mcp_down; }
+    location = /connections/github/callback     { proxy_pass http://host.docker.internal:18002; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; proxy_intercept_errors on; error_page 502 503 504 = @mcp_down; }
+    location = /connections/atlassian/callback  { proxy_pass http://host.docker.internal:18003; proxy_set_header Host $http_host; proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; proxy_set_header X-Forwarded-Proto $scheme; proxy_http_version 1.1; proxy_intercept_errors on; error_page 502 503 504 = @mcp_down; }
+
+    # Friendly error when the per-MCP port behind an OAuth callback is down
+    # (the provider redirect otherwise dead-ends on a generic nginx 502).
+    location @mcp_down {
+        default_type application/json;
+        return 503 '{"error":"bond-mcps MCP not reachable on its port (18001-18004)","hint":"run \"make dev-combined-jwt\" in ../bond-mcps/ first"}';
+    }
 
     # ------------------------------------------------------------------------
     # /connect/<provider>/* → bond-mcps per-MCP FastMCP ports (delegated OAuth

--- a/docs/local-dev-combined-mode.md
+++ b/docs/local-dev-combined-mode.md
@@ -114,6 +114,13 @@ container on the bond-ai side).
 | `make dev` (split) | Active iteration on backend or frontend code. Faster startup, fewer moving parts, hot reload. Flutter dev server with live recompilation. |
 | `make dev-combined` | OAuth flow testing, MCP integration, validating production-shaped routing. Static Flutter bundle (no hot reload — re-run `make dev-combined` to rebuild). |
 
+**Caveat — bond-mcps CLI logins (`make login-atlassian` etc.):** the front door
+exact-routes `/connections/<provider>/callback` to the per-MCP ports, which only
+serve that route in JWT mode. With the combined stack up and bond-mcps in plain
+`make dev-combined` (JWT off), a CLI login's callback through `:8000` 404s.
+Run CLI logins in split mode (auth proxy directly on `:8000`, no nginx), or run
+bond-mcps with `make dev-combined-jwt`.
+
 ---
 
 ## Troubleshooting

--- a/docs/mcp-discovery-delegation-architecture.md
+++ b/docs/mcp-discovery-delegation-architecture.md
@@ -476,8 +476,30 @@ These are the non-obvious things most reviews miss. Each is real and worth a car
    route `/connect/<provider>/*` to the right pod (mirroring local nginx), or should the
    connect flow use each MCP's own ingress host (and register per-host callbacks)? This
    is the highest-risk deployment detail.
-2. **HS256 vs RS256 in production** (§11.1) — decide whether to keep the shared symmetric
-   secret or move to bond-ai-published JWKS.
+2. **Deployed JWT verification: two token populations, one verifier — this is
+   bigger than "HS256 vs RS256" (§11.1).** In EKS, an MCP pod's fastmcp
+   `JWTVerifier` has exactly **one key source** (JWKS URI *or* static key) and
+   one algorithm. But the deployed MCPs have two known caller populations with
+   incompatible contracts:
+   - **Claude Code** (today's deployed consumer, per bond-mcps
+     `docs/DEPLOYMENT.md`): RS256 tokens issued by the bond-mcps AS —
+     `iss = <AS base URL>`, `aud = <publicUrl>/mcp`.
+   - **bond-ai delegation** (this work): HS256 shared-secret tokens —
+     `iss = bond-ai`, `aud = mcp-server` (server-side mints) or
+     `["bond-ai-api","mcp-server"]` (forwarded sessions).
+
+   fastmcp accepts issuer/audience **lists**, so those claims can coexist —
+   but the key/algorithm cannot. Configuring a pod for one population 401s
+   the other. **Enabling bond-ai delegation in EKS as currently shaped breaks
+   Claude Code access to that MCP (or vice versa).** Options to decide before
+   Chapter 2 wiring:
+   (a) a composite verifier (try JWKS, fall back to HS256 — small custom
+   `TokenVerifier`); (b) bond-ai obtains tokens from the bond-mcps AS
+   (token-exchange / client-credentials — the "correct OAuth" answer, more
+   work); (c) bond-ai publishes a JWKS and both issuers go RS256 behind a
+   multi-JWKS verifier (still needs (a)-style composition); (d) separate MCP
+   deployments per consumer. The Helm chart's `values.yaml` jwt block
+   documents the same constraint from the operator's side.
 3. **`user_key` = email vs internal `user_id`** — email is the current `sub`; an internal
    stable ID would survive email changes but requires aligning `sub` (and
    `BOND_MCPS_JWT_SUB_CLAIM`) on both sides.

--- a/docs/mcp-discovery-delegation-architecture.md
+++ b/docs/mcp-discovery-delegation-architecture.md
@@ -1,0 +1,521 @@
+# MCP Discovery & OAuth Delegation — Architecture & Review Guide
+
+**Purpose:** a self-contained overview of the cross-repo effort that moves bond-ai
+from hard-configuring MCP servers (and driving their OAuth itself) to **discovering**
+them from bond-mcps and **delegating** the OAuth/Connect flow to bond-mcps. Written
+to support a complete senior review in a fresh session — it covers the goal, the
+authentication/discovery architecture, every file changed in both repos, how to run
+and test it locally, how it maps to the deployed (EKS) environment, and the
+non-obvious factors a reviewer should scrutinize.
+
+**Status at time of writing (updated 2026-07-02; originally 2026-06-22):**
+
+| Repo | Branch / state | PR | Scope |
+|------|----------------|----|-------|
+| **bond-ai** | PR #201 **merged to `main`** (`a9ad9df`); follow-up branch `fix-mcp-callback-connections-path` (5 commits, e2e-verified, pending PR) | #201 (merged) | discovery client, config overlay, connect client, delegated connections router, runtime JWT forwarding, nginx, tests. Follow-up: canonical-callback nginx routing, managed status in /mcp/tools, server-side JWT mint, discovery fast-retry, verify script |
+| **bond-mcps** | `feat-mcp-delegation-companion` (**open, not merged**) | #9 (open) | HS256 delegation mode, `return_url` callback, status/disconnect routes, deployment-aware discovery file + AS route, scopes consolidation, tests. Follow-up commits: live integration test through FastMCP auth middleware; **callback moved to canonical `/connections/<name>/callback`** (66f7bdc) |
+
+> **2026-07-02 update — canonical callback path.** After this doc was first
+> written, commit `66f7bdc` (bond-mcps) moved the provider OAuth callback from
+> `/connect/<name>/callback` to the **already-registered**
+> `/connections/<name>/callback`, so delegation needs **no new provider-console
+> registrations**. The ticket/start/status/disconnect routes stay under
+> `/connect/<name>`. Sections below have been updated; if you find a stray
+> `/connect/<name>/callback` reference, it's stale — trust this note.
+
+> **Important rollout property:** the bond-ai side is **inert until configured**. With
+> `BOND_MCPS_DISCOVERY_URL` unset, discovery is a no-op and behavior is identical to
+> before. So merging bond-ai ahead of bond-mcps is safe; nothing activates until both
+> the env var and the bond-mcps side are in place.
+
+---
+
+## Table of contents
+1. [What we're building and why](#1-what-were-building-and-why)
+2. [The three planes: Discovery, Authentication, Connect](#2-the-three-planes)
+3. [The cross-repo contract (locked)](#3-the-cross-repo-contract-locked)
+4. [End-to-end flows](#4-end-to-end-flows)
+5. [Path & port topology (local combined mode)](#5-path--port-topology-local-combined-mode)
+6. [Files changed/added — bond-ai](#6-files-changedadded--bond-ai)
+7. [Files changed/added — bond-mcps](#7-files-changedadded--bond-mcps)
+8. [How to run locally](#8-how-to-run-locally)
+9. [How to test](#9-how-to-test)
+10. [Deployed (EKS) architecture](#10-deployed-eks-architecture)
+11. [Hidden factors & risks a reviewer should scrutinize](#11-hidden-factors--risks-a-reviewer-should-scrutinize)
+12. [Open questions / decisions](#12-open-questions--decisions)
+13. [Appendix: commit & branch index](#13-appendix-commit--branch-index)
+
+---
+
+## 1. What we're building and why
+
+### The problem
+A prior cross-repo refactor moved the MCP servers and their OAuth configuration into
+**bond-mcps**, which is meant to be the single owner of "everything about an MCP" (its
+URL, tools, OAuth scopes/client, per-user tokens). bond-ai, however, still:
+
+1. **Hard-configured the full MCP list** (URLs, scopes, client IDs) in `BOND_MCP_CONFIG`
+   (env / Secrets Manager). This config *drifted* — bond-ai's Atlassian tile sent stale
+   **classic** OAuth scopes the registered app no longer supported, so Atlassian rejected
+   the authorize request. There were three independent owners of the same OAuth config.
+2. **Ran its own OAuth "Connect" flow** and stored tokens in its own `mcp_token_cache`,
+   a parallel world to bond-mcps' `tokens.db`.
+
+### The decision: full delegation (handoff-doc "Option A")
+bond-mcps shipped a discovery endpoint that lists MCPs as `{name, display_name, url}`
+only — **no OAuth metadata by design**. That made the original "overlay scopes from
+discovery" idea (Option C) impossible, so we went with **full delegation**:
+
+- bond-ai **discovers** the MCP set from bond-mcps (one env var, polled).
+- bond-ai **authenticates** MCP tool calls with its own **Bond JWT**, validated by
+  bond-mcps via a **shared secret**. bond-mcps resolves the per-user provider token
+  itself.
+- bond-ai **delegates** the OAuth Connect flow to bond-mcps' `/connect/<name>` routes;
+  the provider redirect lands on bond-mcps (which stores the token), then the user is
+  returned to bond-ai with the connection established.
+
+**Net effect:** bond-mcps becomes the single source of truth for MCP config and managed
+provider tokens; the stale-scope class of bug is structurally eliminated; the two token
+stores unify *for managed providers* (user-defined BYO-OAuth servers stay bond-ai-owned).
+
+---
+
+## 2. The three planes
+
+The integration is best understood as three orthogonal planes that share one identity
+(the Bond JWT) but otherwise solve independent problems.
+
+### 2a. Discovery plane — "which MCPs exist and where"
+- bond-ai calls `GET {BOND_MCPS_DISCOVERY_URL}` → `{"mcps":[{name, display_name, url}]}`.
+- Cached in-process with a TTL and refreshed by a background poller (so MCPs can be
+  added/removed without restarting bond-ai — *with caveats in deployment, see §11*).
+- The discovered set is overlaid onto bond-ai's effective MCP config as `bond_jwt`
+  servers; everything beyond the URL (tools) is learned via the MCP protocol itself.
+
+### 2b. Authentication plane — Bond JWT + shared secret
+- bond-ai mints **HS256** JWTs signed with `JWT_SECRET_KEY`; claims: `sub`=**email**,
+  `iss="bond-ai"`, `aud=["bond-ai-api","mcp-server"]`, `exp`, `jti`.
+- Every bond-mcps-bound call (discovery is unauthenticated; tool calls + connect calls
+  are authenticated) carries `Authorization: Bearer <BondJWT>`.
+- bond-mcps validates with the **same secret** (`BOND_MCPS_JWT_PUBLIC_KEY` = bond-ai's
+  `JWT_SECRET_KEY`, `BOND_MCPS_JWT_ALGORITHM=HS256`, `BOND_MCPS_JWT_ISSUER=bond-ai`,
+  `BOND_MCPS_JWT_AUDIENCE=mcp-server`) and derives **`user_key = sub = email`**.
+- This is the same identity at connect-time (ticket mint) and tool-call-time, so the
+  token stored during Connect is the one resolved during a later tool call.
+
+### 2c. Connect plane — delegated OAuth with a return trip
+- bond-ai never drives provider OAuth for managed MCPs. It mints a **ticket** at
+  bond-mcps, hands the browser bond-mcps' `connect_url`, and supplies a **`return_url`**.
+- bond-mcps runs the provider OAuth, stores the token in `tokens.db` keyed by `user_key`,
+  then **302s the browser back** to bond-ai's `return_url` with a success/error marker.
+- bond-ai's connections screen reads the marker, reloads, and queries
+  `GET /connect/<name>/status` per managed MCP to render Connect/Disconnect.
+
+### Identity & token ownership summary
+| | Managed MCPs (discovered) | User-defined MCPs (BYO OAuth) |
+|--|---------------------------|-------------------------------|
+| Config owner | bond-mcps | bond-ai (DB) |
+| OAuth driven by | bond-mcps `/connect/<name>` | bond-ai `connections.py` (unchanged) |
+| Tokens stored in | bond-mcps `tokens.db` (key = JWT `sub`=email) | bond-ai `mcp_token_cache` |
+| Tool-call auth | Bond JWT (bond-mcps resolves the provider token) | bond-ai attaches the provider access token |
+
+---
+
+## 3. The cross-repo contract (locked)
+
+bond-ai's client is `bondable/bond/mcp_connect_client.py`. For each managed MCP it
+derives `base = scheme://host[:port]` from the discovered URL (with the `/mcp` path
+stripped), then calls (all with `Authorization: Bearer <BondJWT>`):
+
+| Op | Method + path | Request | Success response | 404 means |
+|----|---------------|---------|------------------|-----------|
+| discovery | `GET {discovery_url}` *(unauthenticated)* | — | `{"mcps":[{name,display_name,url}]}` | — |
+| mint ticket | `POST {base}/connect/{name}/ticket` | JSON `{return_url}` | `{ticket, connect_url}` (`connect_url` required) | — |
+| status | `GET {base}/connect/{name}/status` | — | `{connected, valid, scopes}` | "no connect surface" → bond-ai omits the tile |
+| disconnect | `DELETE {base}/connect/{name}` | — | `{disconnected: bool}` | nothing to delete → `false` |
+
+Browser-facing (not called by bond-ai, hit by the user's browser / the provider):
+
+| Op | Method + path | Behavior |
+|----|---------------|----------|
+| start | `GET {connect_base}/connect/{name}?ticket=…&return_url=…` | validate ticket, PKCE, 302 → provider authorize URL |
+| callback | `GET {connect_base}/connections/{name}/callback?code&state` | exchange code, store token, **302 → `{return_url}{?\|&}connection_success={name}`** (or `connection_error={name}&error=…`); legacy "close this tab" HTML if no `return_url`. **Note the `/connections/` (plural) path** — the canonical, already-registered provider redirect (shared with the CLI flow), so delegation needs no new console registration (66f7bdc) |
+
+**Bond JWT shape** (bond-ai `rest/utils/auth.py`, `routers/auth.py`): HS256, secret =
+`JWT_SECRET_KEY`; `sub`=email, `iss="bond-ai"`, `aud=["bond-ai-api","mcp-server"]`,
+`exp`, `jti`.
+
+**Status semantics** (bond-mcps `connect_routes.py`): `connected` = a token row exists
+for `(user_key, provider)`; `valid` = (not expired) **or** a refresh token is present
+(refresh-only state still reads as connected → shows *Disconnect*); `scopes` = stored
+granted scopes.
+
+**Return-URL safety:** validated on **both** sides — bond-ai via `is_safe_redirect_url`
+(`ALLOWED_REDIRECT_DOMAINS`); bond-mcps via `_validate_return_url` against
+`BOND_MCPS_ALLOWED_RETURN_HOSTS` (CSV allowlist), re-checked at redirect time.
+
+---
+
+## 4. End-to-end flows
+
+### Discovery (background, every TTL)
+```
+bond-ai mcp_discovery ──GET {BOND_MCPS_DISCOVERY_URL}──▶ bond-mcps (AS or auth proxy)
+        ◀── {"mcps":[{name,display_name,url}]} ──
+   → overlaid into get_mcp_config() as bond_jwt / streamable-http servers
+```
+
+### Tool call (runtime)
+```
+bond-ai execute_mcp_tool ──Bearer <BondJWT>──▶ bond-mcps MCP  /mcp
+                          bond-mcps verifies JWT (shared secret) → user_key = sub = email
+                          → tokens.db lookup → calls the upstream provider
+   (no token → MissingProviderConnection → tool error carries a /connect URL →
+    bond-ai returns a structured authorization_required result)
+```
+
+### Connect (the user journey)
+```
+1. User clicks "Connect" on a tile
+   bond-ai  GET /rest/connections/<name>/authorize
+   bond-ai  ──POST {base}/connect/<name>/ticket  (Bond JWT, {return_url})──▶ bond-mcps MCP
+            ◀── { connect_url } ──
+   Browser ◀── authorization_url = connect_url ──
+2. Browser ──▶ bond-mcps  GET /connect/<name>?ticket&return_url ──▶ provider authorize
+3. provider ──▶ bond-mcps GET /connections/<name>/callback (exchange, store in tokens.db)
+   Browser ◀── 302 {return_url}?connection_success=<name> ──
+4. bond-ai connections screen reads connection_success, reloads, calls
+   GET {base}/connect/<name>/status per managed MCP → renders Disconnect
+```
+
+---
+
+## 5. Path & port topology (local combined mode)
+
+```
+Browser / OAuth provider
+        │
+        ▼
+   nginx :8000  (bond-ai front door; container listens :8080, host maps 8000→8080)
+        ├── /                          → static Flutter build (flutterui/build/web)
+        ├── /rest/<api>                → bond-ai backend :8002  (strips /rest)
+        │     incl. /rest/connections/* (bond-ai's OWN connections REST API)
+        ├── /auth/* , /login/*         → bond-ai backend :8002  (user login)
+        ├── /connections/discovery     → bond-mcps :18000       (discovery)
+        ├── /connections/<p>/callback  → bond-mcps per-MCP ports (provider OAuth
+        │                                 redirect; exact-matched per provider:
+        │                                 microsoft :18001, github :18002,
+        │                                 atlassian :18003)
+        ├── /connections (exact)       → SPA index.html          (OAuth return trip)
+        └── /connect/<provider>/*      → bond-mcps per-MCP ports (ticket/start/
+                                          status/disconnect)
+                                          microsoft :18001, github :18002,
+                                          atlassian :18003, databricks :18004
+```
+
+### Path ownership table (the conflict the design had to resolve)
+| External path | Owner |
+|---------------|-------|
+| `/rest/connections/*` | **bond-ai** backend (the UI's connections API; nginx strips `/rest`) |
+| `/connections/discovery` | **bond-mcps** AS/proxy (:18000) |
+| `/connections/<p>/callback` | **bond-mcps** per-MCP FastMCP ports (:18001–18003) — the canonical, already-registered provider redirect |
+| `/connections` (exact, no slash) | **bond-ai** SPA (the connect flow's `return_url`) |
+| `/connect/<provider>/*` | **bond-mcps** per-MCP FastMCP ports (:18001–18004) |
+| `/auth/*`, `/login/*` | **bond-ai** user login |
+
+The key non-collision: bond-ai's connections **API** is under `/rest/connections/*`,
+while bond-mcps owns bare `/connections/*` and `/connect/*`. The provider redirect
+IS the bare `/connections/<name>/callback` — deliberately, since that URI is already
+registered in every provider console — and nginx exact-matches each one to the MCP
+port that serves it (66f7bdc). The bare `/connections` SPA route (the `return_url`
+target) is exact-matched to index.html so it never falls into the proxy prefix.
+Caveat: in plain combined mode (JWT off, `make dev-combined` in bond-mcps) the MCP
+ports don't serve the callback route, so the CLI relay flow through the front door
+404s — use split mode or `dev-combined-jwt` for CLI logins (see §8).
+
+---
+
+## 6. Files changed/added — bond-ai
+
+Merged in **PR #201** (`170ced0` feat + `daef8f7` SSRF fix → merge `a9ad9df`).
+16 files, +1649/−21.
+
+| File | Change |
+|------|--------|
+| `bondable/bond/mcp_discovery.py` | **new** — `get_discovered_mcps()`; TTL cache + background poller (`start/stop_background_poller`); SSRF-guards both the discovery URL **and each discovered MCP URL**; fail-soft to last-good/empty. Env: `BOND_MCPS_DISCOVERY_URL` / `_TTL_SECONDS` / `_TIMEOUT_SECONDS`. **Poller is the sole fetcher** — when it's alive, request threads only read cache (no blocking HTTP on the event loop). |
+| `bondable/bond/mcp_connect_client.py` | **new** — **async** (`httpx.AsyncClient`) client for `mint_connect_ticket` / `get_connect_status` / `delete_connection`. `connect_base_url()` strips the discovered path to an origin. `_safe_name()` strips URL-control chars from the name (SSRF defense + CodeQL taint break). |
+| `bondable/bond/config.py` | `get_mcp_config()` now overlays discovered MCPs onto the static config as `bond_jwt` / `streamable-http`, dropping any stale inline `oauth_config`, preserving annotations, leaving `command`/user-defined servers untouched. No-op when discovery is disabled. |
+| `bondable/rest/routers/connections.py` | Managed (delegated) track added alongside the preserved user-defined OAuth2 path. `authorize`→mint ticket; `list`/`status`→bond-mcps status (concurrent via `asyncio.gather`, **per-MCP fail-soft**); `disconnect`→bond-mcps delete. Passes the **discovery-sourced `managed["name"]`** (not the request path param) into the client → no SSRF taint. |
+| `bondable/bond/providers/bedrock/BedrockMCP.py` | `bond_jwt` branch forwards the user's JWT to discovered servers (mechanism already existed). New `_extract_connect_url()` turns a `MissingProviderConnection` tool error into a structured `{authorization_required, connect_url}` result. |
+| `bondable/rest/main.py` | Starts/stops the discovery poller in the app `lifespan` (no-op when discovery unset). |
+| `deployment/nginx-local-combined.conf` | Routes `/connect/<provider>/*` AND the canonical `/connections/<provider>/callback` (exact matches) to the per-MCP ports (18001–18004); bare `/connections` (the `return_url` target) serves the SPA. |
+| `.env.example`, `.env.combined.example` | Document `BOND_MCPS_DISCOVERY_URL` + the shared-secret mapping. |
+| `docs/combined-mode-status.md` | Updated §3 to describe delegation + the bond-mcps prerequisites. |
+| `tests/test_mcp_discovery.py` | parse/cache/TTL/SSRF/fail-soft + poller-sole-fetcher + overlay. |
+| `tests/test_mcp_connect_client.py` | async client; URL construction; `_safe_name`; malicious-name-can't-escape-path. |
+| `tests/test_jwt_mcps_trust.py` | HS256 accept/reject contract (wrong secret/aud/iss/expired). |
+| `tests/test_mcp_managed_runtime.py` | JWT forwarding + connect_url surfacing. |
+| `tests/test_connections_delegation.py` | full Connect choreography vs a stubbed bond-mcps. |
+| `tests/test_local_nginx_config.py` | `/connect/*` routing invariants. |
+
+---
+
+## 7. Files changed/added — bond-mcps
+
+On **PR #9** (`feat-mcp-delegation-companion`, **open**): commits `ca71586` (discovery
+file + AS route), `e8c3615` (connect: return_url/status/disconnect), `9cfe650`
+(`dev-combined-jwt`). 16 files, +1072/−122. Plan: `lets-make-a-plan-dynamic-pretzel.md`.
+
+| File | Change |
+|------|--------|
+| `auth/auth/connect_routes.py` | `register_connect_routes` now registers **5** routes: `POST /connect/<name>/ticket`, `GET /connect/<name>`, `GET /connections/<name>/callback` (canonical registered redirect path, per 66f7bdc), **`GET /connect/<name>/status`**, **`DELETE /connect/<name>`**. `return_url` flows mint→stash (`oauth_pending_auth.client_state`)→callback **302**. `_validate_return_url` (env `BOND_MCPS_ALLOWED_RETURN_HOSTS`). `_public_base` honors `BOND_MCPS_CONNECT_PUBLIC_URL` (front door) for `connect_url` + provider `redirect_uri`. user_key via `get_sub_claim`. **Scope storage fix**: persist provider `scope` under the `scopes` key. |
+| `auth/auth/jwt_identity.py` | **No code change** — HS256 was already supported via `BOND_MCPS_JWT_PUBLIC_KEY` + `BOND_MCPS_JWT_ALGORITHM=HS256`. `_resolve_audience()` auto-accepts `<PUBLIC_URL>/mcp` and merges the configured `BOND_MCPS_JWT_AUDIENCE`. Setting `PUBLIC_KEY` also un-dormants the connect routes (gate = JWKS-or-PUBLIC_KEY). |
+| `auth/auth/discovery.py` | Source precedence: **`BOND_MCPS_DISCOVERY_FILE`** (deploy-time JSON) → local `mcps/*/mcp.json` scan → `[]`. Entry accepts absolute **`url`** (deployment) or **`port`+`path`** (→ `localhost`, local). Accepts `{"mcps":[…]}` or a bare list; malformed entries skipped (fail-soft). |
+| `auth/auth/auth_server/endpoints.py` | Registers **`GET /connections/discovery`** (unauthenticated) on the **Authorization Server** — the always-on component in JWT-mode deployments (the auth proxy is typically off there). Same `discover_mcps()`. |
+| `Makefile` | `dev-combined-jwt` + `_start-mcp-deleg`: injects `BOND_MCPS_JWT_PUBLIC_KEY=$(BOND_MCPS_JWT_SECRET)`, `…_ALGORITHM=HS256`, `…_ISSUER=bond-ai`, `…_AUDIENCE=mcp-server`, `…_AS_BASE_URL`/`…_CONNECT_PUBLIC_URL`=front door, `…_PUBLIC_URL=http://localhost:<port>`, `…_ALLOWED_RETURN_HOSTS=localhost`. Requires `BOND_MCPS_JWT_SECRET` (= bond-ai `JWT_SECRET_KEY`). AS :18000, MCPs :18001–18004. |
+| `deployment/terraform-existing-vpc/locals.tf`, `services.tf`, `modules/service/*` | Renders `discovery_json` from enabled MCP services + `base_domain` (`url: https://<prefix>.<base_domain>/mcp`); passes it to **only** the AS service. |
+| `deployment/helm/mcp-service/templates/discovery-configmap.yaml` (+ `deployment.yaml`, `values.yaml`, `configmap.yaml`) | Renders a ConfigMap from `discovery.json`, mounts it read-only at `/etc/bond-mcps`, sets `BOND_MCPS_DISCOVERY_FILE` on the AS pod. |
+| `mcps/atlassian/atlassian_mcp.py` | **Scopes consolidation** — `ATLASSIAN_CONNECT_CONFIG.scopes = " ".join(atlassian.local_auth.SCOPES)`, a single canonical source. |
+| `auth/tests/test_connect_routes.py` (new), `test_jwt_hs256.py` (new), `test_discovery.py` (extended) | return_url round-trip + allowlist; status/disconnect states; HS256 accept/reject + audience merge; discovery file precedence + shapes + AS route. |
+
+---
+
+## 8. How to run locally
+
+Combined mode runs the whole stack behind nginx on `http://localhost:8000`, so the
+OAuth callbacks registered with providers at `:8000` keep working. To exercise
+**delegation** you must run bond-mcps in **JWT mode** (which un-dormants `/connect/*`).
+
+```bash
+# --- NO new provider-console registrations needed (66f7bdc) ---
+# The delegated callback is the canonical /connections/<provider>/callback,
+# already registered for every provider at http://localhost:8000/... —
+# nginx exact-routes each one to the MCP port that serves it.
+
+# Terminal 1 — bond-mcps in HS256 delegation mode.
+# BOND_MCPS_JWT_SECRET MUST equal bond-ai's JWT_SECRET_KEY.
+cd ../bond-mcps
+export BOND_MCPS_JWT_SECRET="$(grep -E '^JWT_SECRET_KEY=' ../bond-ai/.env | cut -d= -f2- | tr -d '"')"
+#   plus provider creds in each mcps/<svc> env: ATLASSIAN_CLIENT_ID/SECRET, GITHUB_CLIENT_ID/SECRET, …
+make dev-combined-jwt          # AS :18000, MCPs :18001–18004
+
+# Terminal 2 — bond-ai combined stack (front door :8000 + backend :8002).
+cd ../bond-ai
+#   set in .env.combined (or .env): BOND_MCPS_DISCOVERY_URL=http://localhost:8000/connections/discovery
+make dev-combined
+
+# Open http://localhost:8000/  → Connections → Connect on a tile.
+```
+
+Sanity checks:
+```bash
+curl -s http://localhost:8000/connections/discovery | jq        # MCP list (via nginx → :18000)
+# Connect on the Atlassian tile → consent → returns to bond-ai → tile shows Connected
+# Run an Atlassian tool in chat → succeeds using the token in bond-mcps tokens.db
+```
+
+---
+
+## 9. How to test
+
+### Automated — bond-ai (all green on `main`)
+```bash
+cd bond-ai
+poetry run python -m pytest tests/test_mcp_discovery.py tests/test_mcp_connect_client.py \
+  tests/test_jwt_mcps_trust.py tests/test_mcp_managed_runtime.py \
+  tests/test_connections_delegation.py -q
+# Full suite at last run: 1429 passed, 434 skipped, 0 failed.
+```
+Notable: `test_connections_delegation.py` drives the **entire Connect choreography**
+(authorize → ticket → status shows connected → disconnect) against a stubbed bond-mcps;
+`test_jwt_mcps_trust.py` pins the HS256 token shape to bond-mcps' verifier config.
+
+### Automated — bond-mcps
+```bash
+cd bond-mcps/auth && poetry run pytest -q
+# Covers: HS256 accept/reject + audience merge (test_jwt_hs256.py); return_url
+# round-trip + allowlist + status/disconnect states (test_connect_routes.py);
+# discovery file precedence + shapes + AS route (test_discovery.py).
+```
+
+### Manual end-to-end (the real proof)
+Run the local recipe in §8, then verify the round trip: discovery lists MCPs → Connect
+on a tile → provider consent → **302 back to bond-ai showing Connected** → an MCP tool
+call works → Disconnect clears it. This is the path that no single-repo test can cover
+(the two contract test suites emulate each other; only the live run spans both).
+
+---
+
+## 10. Deployed (EKS) architecture
+
+The deployed topology differs from local in three load-bearing ways. A reviewer should
+trace each carefully.
+
+1. **Discovery source is a deploy-time file, served by the Authorization Server.**
+   In deployment the auth proxy is typically off, so discovery moved to the **always-on
+   AS**. Terraform renders `discovery.json` (`{name, display_name, url: https://<prefix>.<base_domain>/mcp}`)
+   from the enabled MCP services, mounts it as a ConfigMap at `/etc/bond-mcps`, and sets
+   `BOND_MCPS_DISCOVERY_FILE` on the AS pod. bond-ai points
+   `BOND_MCPS_DISCOVERY_URL` → `https://auth.<base_domain>/connections/discovery`.
+   *This file is static per deploy — see §11.2.*
+
+2. **JWT validation.** Each MCP runs with the JWT env (HS256 + shared secret, or RS256
+   via `BOND_MCPS_JWT_JWKS_URI` — both supported by `build_verifier()`), `iss=bond-ai`,
+   `aud=mcp-server`. The MCPs validate the Bond JWT and resolve `user_key=sub=email`.
+
+3. **Connect routing.** `connect_url` + the provider `redirect_uri` use
+   `BOND_MCPS_CONNECT_PUBLIC_URL` (the front-door origin). The deployed front door must
+   route `/connect/<provider>/*` to the correct per-MCP pod — the same per-provider
+   routing nginx does locally. *Whether this is the front-door host or each MCP's own
+   ingress host is an open question — see §12.*
+
+In-cluster addressing for bond-ai → bond-mcps uses the shared ALB ingress hosts
+(`auth.<domain>`, `github.<domain>`, …) or in-cluster service DNS
+(`<svc>.<ns>.svc.cluster.local:8000`).
+
+---
+
+## 11. Hidden factors & risks a reviewer should scrutinize
+
+These are the non-obvious things most reviews miss. Each is real and worth a careful look.
+
+1. **The shared HS256 secret is a single symmetric key across two services.** Anyone who
+   holds `JWT_SECRET_KEY` can mint a token bond-mcps accepts **as any user** (it's the
+   verification key *and* the signing key). Rotation must be coordinated atomically
+   (rotate bond-ai `JWT_SECRET_KEY` **and** `BOND_MCPS_JWT_PUBLIC_KEY` on every MCP at
+   once, or accept a window of 401s). `jwt_identity.py` already supports **RS256/JWKS**;
+   for production, asymmetric keys (bond-ai publishes a JWKS, MCPs verify with the public
+   key) avoid sharing a signing secret entirely. The HS256 choice is for simplicity —
+   the prod posture deserves an explicit decision.
+
+2. **"Add an MCP without restart" is only true locally.** Locally, discovery scans the
+   filesystem, so dropping in `mcps/foo/mcp.json` makes `foo` appear on the next poll. In
+   **deployment**, discovery reads a static ConfigMap file rendered at `terraform apply`
+   time; adding/removing an MCP requires re-rendering `discovery.json` and the AS pod
+   picking up the new ConfigMap. bond-ai polls, but the *source* is static per-deploy.
+   This asymmetry is the single easiest thing to misread in the whole design.
+
+3. **Two token stores remain — by design, but with sharp edges.** Managed providers live
+   only in bond-mcps `tokens.db` (key = email); user-defined BYO-OAuth lives only in
+   bond-ai `mcp_token_cache`. They never unify. A managed Disconnect clears only
+   bond-mcps. bond-ai has *no* visibility into whether a managed token exists except via
+   the live `/connect/<name>/status` call.
+
+4. **Identity is the email in `sub`.** If a user's email changes (SSO rename), their
+   stored tokens orphan (keyed by the old email). Also, **CLI/laptop single-tenant
+   tokens** (from `make login-*`) are keyed by local username — a *separate identity
+   domain* invisible in JWT mode. A developer who connected Atlassian via the CLI won't
+   see it via the UI delegation path. Expected, but surprising.
+
+5. **Per-MCP connect routes couple the front door to the MCP port/host map.** `/connect`
+   lives on each MCP's FastMCP server (so bond-ai can derive the origin by stripping
+   `/mcp` from the discovered URL). Locally that means nginx hardcodes
+   `/connect/atlassian → :18003`, etc.; adding an MCP needs an nginx block. In deployment
+   the same per-provider routing must exist at the front door (see §12).
+
+6. **No new provider-console registrations are required** *(resolved by 66f7bdc — this
+   was originally a risk)*. The delegated callback reuses the canonical, already-
+   registered `/connections/<provider>/callback` at the front-door origin; nginx
+   exact-routes each provider's callback to its MCP port. It remains distinct from
+   `/auth/<provider>/callback` (bond-ai user login) — still easy to conflate. The
+   flip side: in plain combined mode (JWT off) the MCP ports don't serve the
+   callback, so CLI-relay logins through the front door 404 — use split mode or
+   `dev-combined-jwt` for CLI logins.
+
+7. **`return_url` is an open-redirect surface, guarded on both sides.** bond-ai validates
+   via `is_safe_redirect_url` (`ALLOWED_REDIRECT_DOMAINS`); bond-mcps via
+   `BOND_MCPS_ALLOWED_RETURN_HOSTS`. **Both** allowlists must include the prod host. Too
+   loose → open redirect; too strict → the callback falls back to "close this tab" HTML
+   and the user never returns to bond-ai.
+
+8. **Audience / issuer / sub must align exactly across repos, and nothing tests the live
+   seam.** bond-ai's `aud` includes `mcp-server`; bond-mcps `AUDIENCE=mcp-server` (and
+   also auto-accepts `<PUBLIC_URL>/mcp`); `iss=bond-ai`; `sub=email` — both sides. A drift
+   (e.g., someone flips `JWT_ISSUER` in bond-ai) yields a **silent 401 on every tool
+   call**. The contract tests on each side *emulate* the other; no automated test spans
+   both at runtime. The manual e2e in §9 is the only thing that exercises the real seam.
+
+9. **SSRF was a real finding and is mitigated, not eliminated.** bond-ai dials discovered
+   URLs server-side *with the user's JWT attached*. Mitigations: discovered URLs are
+   SSRF-validated at the discovery boundary (metadata/link-local blocked; localhost +
+   private cluster IPs intentionally allowed); the path-segment `name` is sanitized and
+   sourced from discovery (not the request). **Not** mitigated: a hostname that resolves
+   to a private IP (DNS rebinding) — consistent with the existing
+   `user_mcp_servers._validate_url_ssrf` posture and required so in-cluster private IPs
+   work. CodeQL flagged the three connect calls (`py/partial-ssrf`); fixed in `daef8f7`.
+
+10. **Event-loop blocking was the headline bug, fixed in two passes.** The connect client
+    is fully async (`httpx.AsyncClient`); the discovery *fetch* is synchronous but the
+    background **poller is the sole fetcher**, so request threads never block on a
+    discovery HTTP call. Note: the poller is per-process — multiple uvicorn workers means
+    N pollers and N× discovery traffic (each worker needs its own cache; acceptable).
+
+11. **Two Connect entry points, only one fully wired to UI.** (a) The connections-screen
+    tile uses the proactive `authorize → ticket` flow and is fully wired. (b) The
+    chat/tool-time path surfaces `MissingProviderConnection`'s `connect_url` as a
+    structured result, but **no Flutter affordance consumes it yet** — it reaches the
+    user only as LLM-relayed text. Building a tool-time "Connect" button is a documented
+    follow-up.
+
+12. **A subtle token-storage bug was fixed in passing.** Providers return granted scopes
+    under the key `scope`; bond-mcps now persists them under `scopes` (the key
+    `TokenRepository` reads and `/status` returns). Without this fix, `/status` would
+    report `scopes: null` even when connected.
+
+13. **The AS-vs-proxy split is a deployment assumption worth confirming.** Discovery was
+    duplicated onto the AS because the auth proxy is "usually off" in JWT-mode deploys.
+    Confirm the AS is genuinely the always-on component in the target topology, and that
+    nothing else relied on the proxy serving discovery in deployment.
+
+---
+
+## 12. Open questions / decisions
+
+1. **Deployed `/connect` routing.** `BOND_MCPS_CONNECT_PUBLIC_URL` is the front door, but
+   `/connect/<provider>` lives on per-MCP pods. Does the deployed front-door ingress
+   route `/connect/<provider>/*` to the right pod (mirroring local nginx), or should the
+   connect flow use each MCP's own ingress host (and register per-host callbacks)? This
+   is the highest-risk deployment detail.
+2. **HS256 vs RS256 in production** (§11.1) — decide whether to keep the shared symmetric
+   secret or move to bond-ai-published JWKS.
+3. **`user_key` = email vs internal `user_id`** — email is the current `sub`; an internal
+   stable ID would survive email changes but requires aligning `sub` (and
+   `BOND_MCPS_JWT_SUB_CLAIM`) on both sides.
+4. **Tool-time Connect affordance** (§11.11) — build the Flutter UI that consumes the
+   surfaced `connect_url`, or leave it as text.
+5. **Discovery refresh in deployment** (§11.2) — accept static-per-deploy, or add a
+   live/dynamic deployment source later.
+
+---
+
+## 13. Appendix: commit & branch index
+
+**bond-ai** — merged to `main` via PR #201:
+- `170ced0` feat(mcp): discover MCPs from bond-mcps and delegate OAuth connect
+- `daef8f7` fix(mcp): resolve CodeQL partial-SSRF in connect client
+- `a9ad9df` Merge pull request #201
+
+**bond-ai** — follow-up branch `fix-mcp-callback-connections-path` (pending PR):
+- `9735f75` fix(nginx): route MCP OAuth callbacks via /connections/<provider>/callback
+- `6fed1cd` feat(dev): add combined-stack verification recipe (script + doc)
+- `5e72c77` fix(mcp): fast-retry discovery until first successful fetch
+- `c111988` fix(mcp): delegate managed-MCP status in tools list, mint Bond JWT server-side
+- `b4ffce9` fix(dev): robust make stop; serve bare /connections from the SPA
+
+**bond-mcps** — open PR #9, branch `feat-mcp-delegation-companion` (off `main`):
+- `ca71586` feat(discovery): deployment-aware source (JSON file) + serve on Auth Server
+- `e8c3615` feat(connect): delegate MCP OAuth to bond-mcps (return_url, status, disconnect)
+- `9cfe650` feat(make): dev-combined-jwt — run MCPs in HS256 delegation mode
+- `90ca9be` test(connect): live integration through FastMCP auth middleware (proof point)
+- `66f7bdc` fix(connect): use canonical /connections/<provider>/callback (no re-registration)
+- (prior, merged) `91a8503` feat(discovery): dynamic `/connections/discovery` on auth proxy;
+  `ab943c1` dev-combined binds auth proxy to :18000 (frees :8000 for nginx)
+
+**Plans & related docs:**
+- bond-mcps plan: `~/.claude/plans/lets-make-a-plan-dynamic-pretzel.md` (titled "bond-mcps
+  companion work for full MCP-OAuth delegation" — filename is an auto-generated artifact,
+  not descriptive).
+- bond-ai diagnosis/handoff: `docs/oauth-config-discovery-handoff.md` (superseded — see its
+  "Update" banner).
+- bond-ai combined-mode status: `docs/combined-mode-status.md` §3.
+- bond-mcps discovery endpoint: `bond-mcps/docs/discovery.md`.

--- a/docs/verify-combined-stack.md
+++ b/docs/verify-combined-stack.md
@@ -29,7 +29,8 @@ output.
 | 5 | `GET :8000/connections/discovery` → `{"mcps":[…]}` | **bond-ai ↔ bond-mcps discovery plane is live** |
 | 6 | `GET :8000/connections` → 200 | the OAuth return-trip SPA route works (no broken 301 to the in-container port) |
 | 7a | status endpoint without a token → 401 | bond-mcps is in **JWT mode** (auth actually enforced) |
-| 7b | status endpoint with a freshly minted Bond JWT → 200/404 | **the HS256 trust seam is live**: shared secret, `iss=bond-ai`, `aud=mcp-server`, `sub=email` all align across repos |
+| 7b | status endpoint with a session-shape Bond JWT (`aud=["bond-ai-api","mcp-server"]`) → 200/404 | **the HS256 trust seam is live**: shared secret, `iss=bond-ai`, audience, `sub=email` all align across repos |
+| 7c | status endpoint with a narrow server-mint Bond JWT (`aud=["mcp-server"]` only) → 200/404 | the shape bond-ai's server-side mint sends (agent tool-def fetch) is accepted — requires `BOND_MCPS_JWT_AUDIENCE=mcp-server` on the MCPs |
 
 Check 7 is the one no automated test in either repo covers (each side only
 emulates the other) — it exercises the real cross-repo contract at runtime by

--- a/docs/verify-combined-stack.md
+++ b/docs/verify-combined-stack.md
@@ -1,0 +1,77 @@
+# Verifying the Combined Stack (bond-ai + bond-mcps)
+
+A repeatable recipe to confirm bond-ai and bond-mcps are both running on this
+machine and actually talking to each other in **local combined mode** (nginx
+front door on `http://localhost:8000`). Companion to
+[local-dev-combined-mode.md](local-dev-combined-mode.md) (how to start the
+stack) and
+[mcp-discovery-delegation-architecture.md](mcp-discovery-delegation-architecture.md)
+(why it's shaped this way).
+
+## TL;DR
+
+```bash
+./scripts/verify-combined-stack.sh
+```
+
+Exit 0 with all `PASS` lines → the stack is up and the two repos are talking.
+Any `FAIL` prints a targeted hint; the restart recipe is at the bottom of the
+output.
+
+## What the script proves, layer by layer
+
+| # | Check | What a pass means |
+|---|-------|-------------------|
+| 1 | Docker + `bond-ai-nginx-local` container | the front door exists |
+| 2 | Ports 8000 / 8002 / 18000–18004 listening | nginx, bond-ai backend, bond-mcps AS + 4 MCPs are all up |
+| 3 | `GET :8000/health` → 200 | nginx reaches the bond-ai backend |
+| 4 | `GET :8000/rest/providers` → JSON | the `/rest` strip-proxy works (HTML here = SPA fallthrough bug) |
+| 5 | `GET :8000/connections/discovery` → `{"mcps":[…]}` | **bond-ai ↔ bond-mcps discovery plane is live** |
+| 6 | `GET :8000/connections` → 200 | the OAuth return-trip SPA route works (no broken 301 to the in-container port) |
+| 7a | status endpoint without a token → 401 | bond-mcps is in **JWT mode** (auth actually enforced) |
+| 7b | status endpoint with a freshly minted Bond JWT → 200/404 | **the HS256 trust seam is live**: shared secret, `iss=bond-ai`, `aud=mcp-server`, `sub=email` all align across repos |
+
+Check 7 is the one no automated test in either repo covers (each side only
+emulates the other) — it exercises the real cross-repo contract at runtime by
+minting a token exactly the way bond-ai does and calling bond-mcps with it.
+
+## Starting the stack (if verification fails)
+
+```bash
+# Terminal 1 — bond-mcps in HS256 delegation mode
+cd ../bond-mcps
+make dev-combined-jwt        # AS :18000, MCPs :18001–18004
+                             # requires BOND_MCPS_JWT_SECRET = bond-ai's JWT_SECRET_KEY
+
+# Terminal 2 — bond-ai combined stack
+cd ../bond-ai
+make stop && make dev-combined   # nginx :8000 + backend :8002 + static Flutter build
+
+./scripts/verify-combined-stack.sh
+```
+
+## The manual step the script can't do
+
+The script proves the plumbing; the full OAuth round trip needs a browser and
+your consent (this is the "real proof" — see the architecture doc §9):
+
+1. Open `http://localhost:8000/` and log in.
+2. Go to **Connections** → click **Connect** on a tile (e.g. Atlassian).
+3. Complete the provider consent screen.
+4. You should land back on the Connections screen with the tile showing
+   **Connected** (this exercises `/connections/<provider>/callback` routing
+   and the SPA return route).
+5. In chat, run a tool from that MCP — it should succeed using the token
+   stored in bond-mcps' `tokens.db`.
+6. **Disconnect** on the tile should clear it.
+
+## Notes
+
+- The JWT seam check reads `JWT_SECRET_KEY` from `.env` by default; override
+  with `BOND_AI_ENV_FILE=.env.combined ./scripts/verify-combined-stack.sh`.
+- The seam check's identity is a throwaway email
+  (`verify-stack@example.com`) and the status call is read-only — it creates
+  no state in bond-mcps.
+- A long-running stack (days) can drift — stale Flutter build, expired login
+  sessions. When in doubt, restart with the recipe above; `make stop` kills
+  all listeners on both ports reliably.

--- a/docs/verify-combined-stack.md
+++ b/docs/verify-combined-stack.md
@@ -65,6 +65,23 @@ your consent (this is the "real proof" — see the architecture doc §9):
    stored in bond-mcps' `tokens.db`.
 6. **Disconnect** on the tile should clear it.
 
+## Known gotcha: managed tiles missing right after a restart
+
+`make dev-combined` starts the backend **before** nginx, and
+`BOND_MCPS_DISCOVERY_URL` points through nginx (`:8000/connections/discovery`),
+so the backend's first discovery fetch gets connection-refused and fails soft
+to an empty list — the Connections screen then shows only static tiles (no
+Atlassian/GitHub/Microsoft/Databricks). Symptom in `tmp/logs/backend.log`:
+
+```
+WARNING - bondable.bond.mcp_discovery - MCP discovery fetch failed (ConnectError: ...); failing soft
+```
+
+The discovery poller now fast-retries every 10s until its first successful
+fetch (`STARTUP_RETRY_SECONDS` in `mcp_discovery.py`), so the tiles appear
+within seconds of nginx coming up — just refresh the page. (Before that fix
+the retry waited a full TTL: up to 5 minutes of missing tiles.)
+
 ## Notes
 
 - The JWT seam check reads `JWT_SECRET_KEY` from `.env` by default; override

--- a/scripts/verify-combined-stack.sh
+++ b/scripts/verify-combined-stack.sh
@@ -13,9 +13,11 @@
 #   4. /rest/providers returns JSON            (nginx /rest proxy → backend)
 #   5. MCP discovery through nginx             (:8000/connections/discovery)
 #   6. Bare /connections serves the SPA        (OAuth return-trip route, no broken 301)
-#   7. JWT trust seam: mint a Bond JWT with JWT_SECRET_KEY and call a bond-mcps
-#      /connect/<name>/status directly — 401 without token AND 200/404 with token
-#      proves the HS256 shared-secret contract (iss/aud/sub) is live end-to-end.
+#   7. JWT trust seam: mint Bond JWTs with JWT_SECRET_KEY and call a bond-mcps
+#      /connect/<name>/status directly — 401 without a token, 200/404 with the
+#      session shape (aud=["bond-ai-api","mcp-server"]) AND with the narrow
+#      server-mint shape (aud=["mcp-server"]) proves the HS256 shared-secret
+#      contract (iss/aud/sub) is live end-to-end for both shapes bond-ai sends.
 #
 # Exit code 0 = all checks passed. Any failure prints a hint and exits 1.
 #
@@ -141,22 +143,37 @@ else
   else
     PY="poetry run python"
   fi
-  token=$(cd "$REPO_ROOT" && JWT_SEAM_SECRET="$secret" $PY -c "
+  # Two token shapes, both real at runtime: forwarded user sessions carry
+  # aud=["bond-ai-api","mcp-server"]; bond-ai's server-side mint (agent
+  # tool-def fetch) carries aud=["mcp-server"] only. Test both.
+  tokens=$(cd "$REPO_ROOT" && JWT_SEAM_SECRET="$secret" $PY -c "
 import os, time, uuid, jwt
-print(jwt.encode(
-    {'sub': 'verify-stack@example.com', 'iss': 'bond-ai',
-     'aud': ['bond-ai-api', 'mcp-server'],
-     'exp': int(time.time()) + 300, 'jti': str(uuid.uuid4())},
-    os.environ['JWT_SEAM_SECRET'], algorithm='HS256'))
+base = {'sub': 'verify-stack@example.com', 'iss': 'bond-ai',
+        'exp': int(time.time()) + 300}
+secret = os.environ['JWT_SEAM_SECRET']
+print(jwt.encode({**base, 'aud': ['bond-ai-api', 'mcp-server'],
+                  'jti': str(uuid.uuid4())}, secret, algorithm='HS256'))
+print(jwt.encode({**base, 'aud': ['mcp-server'],
+                  'jti': str(uuid.uuid4())}, secret, algorithm='HS256'))
 " 2>/dev/null)
-  if [ -z "$token" ]; then
-    bad "could not mint a Bond JWT" "run from the bond-ai repo root (needs 'poetry run python' + pyjwt)"
+  token=$(echo "$tokens" | sed -n 1p)
+  narrow=$(echo "$tokens" | sed -n 2p)
+  if [ -z "$token" ] || [ -z "$narrow" ]; then
+    bad "could not mint Bond JWTs" "run from the bond-ai repo root (needs 'poetry run python' + pyjwt)"
   else
     code=$($CURL -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $token" "$status_url" 2>/dev/null)
     if [ "$code" = "200" ] || [ "$code" = "404" ]; then
-      ok "bond-mcps accepts minted Bond JWT ($status_url → $code) — HS256 trust seam live"
+      ok "bond-mcps accepts session-shape Bond JWT ($status_url → $code) — HS256 trust seam live"
     else
-      bad "minted Bond JWT rejected ($status_url → $code)" "BOND_MCPS_JWT_SECRET in bond-mcps must equal JWT_SECRET_KEY in bond-ai's .env; iss=bond-ai, aud=mcp-server"
+      bad "session-shape Bond JWT rejected ($status_url → $code)" "BOND_MCPS_JWT_SECRET in bond-mcps must equal JWT_SECRET_KEY in bond-ai's .env; iss=bond-ai, aud=mcp-server"
+    fi
+    # 7c. narrow mint shape (aud=["mcp-server"] only — what the server-side
+    # mint sends). Requires BOND_MCPS_JWT_AUDIENCE=mcp-server on the MCPs.
+    code=$($CURL -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $narrow" "$status_url" 2>/dev/null)
+    if [ "$code" = "200" ] || [ "$code" = "404" ]; then
+      ok "bond-mcps accepts narrow (server-mint) Bond JWT ($status_url → $code)"
+    else
+      bad "narrow (server-mint) Bond JWT rejected ($status_url → $code)" "BOND_MCPS_JWT_AUDIENCE=mcp-server must be set on the MCPs (dev-combined-jwt sets it)"
     fi
   fi
 fi

--- a/scripts/verify-combined-stack.sh
+++ b/scripts/verify-combined-stack.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# verify-combined-stack.sh — verify bond-ai + bond-mcps are running and talking
+# in local combined mode (nginx front door on :8000).
+#
+# Usage:
+#   ./scripts/verify-combined-stack.sh          # run all checks
+#   BOND_AI_ENV_FILE=.env.combined ./scripts/verify-combined-stack.sh
+#
+# Checks, shallowest to deepest:
+#   1. Docker daemon + bond-ai-nginx-local container up
+#   2. All expected ports listening (8000 nginx, 8002 backend, 18000-18004 bond-mcps)
+#   3. Backend health through nginx           (:8000/health)
+#   4. /rest/providers returns JSON            (nginx /rest proxy → backend)
+#   5. MCP discovery through nginx             (:8000/connections/discovery)
+#   6. Bare /connections serves the SPA        (OAuth return-trip route, no broken 301)
+#   7. JWT trust seam: mint a Bond JWT with JWT_SECRET_KEY and call a bond-mcps
+#      /connect/<name>/status directly — 401 without token AND 200/404 with token
+#      proves the HS256 shared-secret contract (iss/aud/sub) is live end-to-end.
+#
+# Exit code 0 = all checks passed. Any failure prints a hint and exits 1.
+#
+# If checks fail, restart the stack:
+#   bond-mcps:  cd ../bond-mcps && make dev-combined-jwt
+#   bond-ai:    make stop && make dev-combined
+# Full recipe: docs/verify-combined-stack.md and docs/local-dev-combined-mode.md §8.
+
+set -u
+
+REPO_ROOT="${BOND_AI_ROOT:-$(cd "$(dirname "$0")/.." && pwd)}"
+ENV_FILE="${BOND_AI_ENV_FILE:-$REPO_ROOT/.env}"
+FRONT_DOOR="${FRONT_DOOR:-http://localhost:8000}"
+NGINX_CONTAINER="${NGINX_CONTAINER:-bond-ai-nginx-local}"
+CURL="curl -s --max-time 5"
+
+PASS=0
+FAIL=0
+
+ok()   { PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
+bad()  { FAIL=$((FAIL+1)); printf '  \033[31mFAIL\033[0m  %s\n' "$1"; [ -n "${2:-}" ] && printf '        hint: %s\n' "$2"; }
+
+echo "== bond-ai + bond-mcps combined-stack verification =="
+echo
+
+# --- 1. Docker + nginx container -------------------------------------------
+if docker info >/dev/null 2>&1; then
+  ok "Docker daemon running"
+  status=$(docker ps --filter "name=$NGINX_CONTAINER" --format '{{.Status}}')
+  if [ -n "$status" ]; then
+    ok "nginx container '$NGINX_CONTAINER' up ($status)"
+  else
+    bad "nginx container '$NGINX_CONTAINER' not running" "run 'make dev-combined' (or 'make nginx')"
+  fi
+else
+  bad "Docker daemon not running" "start Docker Desktop, then 'make dev-combined'"
+fi
+
+# --- 2. Ports ---------------------------------------------------------------
+for entry in "8000:nginx front door" "8002:bond-ai backend" \
+             "18000:bond-mcps auth server" "18001:microsoft MCP" \
+             "18002:github MCP" "18003:atlassian MCP" "18004:databricks MCP"; do
+  port=${entry%%:*}; name=${entry#*:}
+  if lsof -nP -iTCP:"$port" -sTCP:LISTEN -t >/dev/null 2>&1; then
+    ok "port :$port listening ($name)"
+  else
+    case $port in
+      18*) hint="cd ../bond-mcps && make dev-combined-jwt" ;;
+      *)   hint="make dev-combined" ;;
+    esac
+    bad "port :$port not listening ($name)" "$hint"
+  fi
+done
+
+# --- 3. Backend health through nginx ----------------------------------------
+code=$($CURL -o /dev/null -w '%{http_code}' "$FRONT_DOOR/health" 2>/dev/null)
+if [ "$code" = "200" ]; then
+  ok "backend health via nginx ($FRONT_DOOR/health → 200)"
+else
+  bad "backend health via nginx returned '$code'" "check tmp/logs/backend.log and 'make nginx-logs'"
+fi
+
+# --- 4. /rest/providers (nginx proxy sanity) ---------------------------------
+out=$($CURL "$FRONT_DOOR/rest/providers" 2>/dev/null)
+case "$out" in
+  '{'*) ok "/rest/providers returns JSON (nginx /rest proxy → backend OK)" ;;
+  '<'*) bad "/rest/providers returned HTML (SPA fallthrough)" "nginx /rest proxy isn't reaching the backend — see docs/local-dev-combined-mode.md" ;;
+  '')   bad "/rest/providers returned nothing" "backend may still be starting; check tmp/logs/backend.log" ;;
+  *)    bad "/rest/providers returned unexpected response: $(echo "$out" | head -c 60)" ;;
+esac
+
+# --- 5. MCP discovery through nginx ------------------------------------------
+disco=$($CURL "$FRONT_DOOR/connections/discovery" 2>/dev/null)
+case "$disco" in
+  *'"mcps"'*)
+    n=$(echo "$disco" | tr ',' '\n' | grep -c '"name"' || true)
+    ok "MCP discovery via nginx ($n MCPs listed)" ;;
+  *) bad "MCP discovery failed (got: $(echo "$disco" | head -c 60))" "is bond-mcps up? cd ../bond-mcps && make dev-combined-jwt" ;;
+esac
+
+# --- 6. Bare /connections serves the SPA (OAuth return trip) -----------------
+code=$($CURL -o /dev/null -w '%{http_code}' "$FRONT_DOOR/connections" 2>/dev/null)
+if [ "$code" = "200" ]; then
+  ok "bare /connections serves SPA (OAuth return trip won't 301 to :8080)"
+else
+  bad "bare /connections returned '$code' (expected 200)" "nginx missing 'location = /connections' block — reload nginx: make nginx-reload"
+fi
+
+# --- 7. JWT trust seam (the real cross-repo proof) ---------------------------
+# Mint a Bond JWT exactly as bond-ai does (HS256, sub=email, iss=bond-ai,
+# aud includes mcp-server) and hit a bond-mcps connect status endpoint on its
+# own port — the same call bond-ai's backend makes server-side. Accepted token
+# (200, or 404 = "no connect surface") proves the shared-secret contract.
+seam_target=""
+if [ -n "$disco" ]; then
+  # first discovered MCP: derive "name" and "base" (url with /mcp stripped)
+  seam_target=$(echo "$disco" | tr '{' '\n' | grep '"url"' | head -1)
+fi
+if [ ! -f "$ENV_FILE" ]; then
+  bad "env file '$ENV_FILE' not found — cannot run JWT seam check" "set BOND_AI_ENV_FILE or run from the repo root"
+elif ! grep -q '^JWT_SECRET_KEY=' "$ENV_FILE"; then
+  bad "JWT_SECRET_KEY not set in $ENV_FILE — cannot run JWT seam check"
+elif [ -z "$seam_target" ]; then
+  bad "no discovered MCP to run the JWT seam check against"
+else
+  name=$(echo "$seam_target" | sed -n 's/.*"name": *"\([^"]*\)".*/\1/p')
+  base=$(echo "$seam_target" | sed -n 's/.*"url": *"\([^"]*\)\/mcp".*/\1/p')
+  status_url="$base/connect/$name/status"
+
+  # 7a. without a token the endpoint must reject (auth is actually enforced)
+  code=$($CURL -o /dev/null -w '%{http_code}' "$status_url" 2>/dev/null)
+  if [ "$code" = "401" ] || [ "$code" = "403" ]; then
+    ok "bond-mcps rejects unauthenticated status call ($code)"
+  else
+    bad "unauthenticated $status_url returned '$code' (expected 401)" "is bond-mcps running in JWT mode? use 'make dev-combined-jwt', not 'make dev-combined'"
+  fi
+
+  # 7b. with a minted Bond JWT it must accept (shared secret + iss/aud align)
+  secret=$(grep -E '^JWT_SECRET_KEY=' "$ENV_FILE" | head -1 | cut -d= -f2- | tr -d '"')
+  # prefer the project venv's python (has pyjwt); fall back to poetry run
+  if [ -x "$REPO_ROOT/.venv/bin/python" ]; then
+    PY="$REPO_ROOT/.venv/bin/python"
+  else
+    PY="poetry run python"
+  fi
+  token=$(cd "$REPO_ROOT" && JWT_SEAM_SECRET="$secret" $PY -c "
+import os, time, uuid, jwt
+print(jwt.encode(
+    {'sub': 'verify-stack@example.com', 'iss': 'bond-ai',
+     'aud': ['bond-ai-api', 'mcp-server'],
+     'exp': int(time.time()) + 300, 'jti': str(uuid.uuid4())},
+    os.environ['JWT_SEAM_SECRET'], algorithm='HS256'))
+" 2>/dev/null)
+  if [ -z "$token" ]; then
+    bad "could not mint a Bond JWT" "run from the bond-ai repo root (needs 'poetry run python' + pyjwt)"
+  else
+    code=$($CURL -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $token" "$status_url" 2>/dev/null)
+    if [ "$code" = "200" ] || [ "$code" = "404" ]; then
+      ok "bond-mcps accepts minted Bond JWT ($status_url → $code) — HS256 trust seam live"
+    else
+      bad "minted Bond JWT rejected ($status_url → $code)" "BOND_MCPS_JWT_SECRET in bond-mcps must equal JWT_SECRET_KEY in bond-ai's .env; iss=bond-ai, aud=mcp-server"
+    fi
+  fi
+fi
+
+# --- summary ------------------------------------------------------------------
+echo
+echo "== $PASS passed, $FAIL failed =="
+if [ "$FAIL" -gt 0 ]; then
+  echo
+  echo "Restart recipe:"
+  echo "  1. cd ../bond-mcps && make dev-combined-jwt     # AS :18000, MCPs :18001-18004"
+  echo "  2. cd -            && make stop && make dev-combined"
+  echo "  3. re-run this script"
+  exit 1
+fi
+echo "Stack verified. Manual OAuth round-trip test: open $FRONT_DOOR/ → Connections → Connect a tile."

--- a/tests/test_connections_delegation.py
+++ b/tests/test_connections_delegation.py
@@ -68,7 +68,7 @@ class _StubMcps:
         self.tickets.append({"name": name, "return_url": return_url, "url": mcp_url})
         return f"http://localhost:8000/connect/{name}?ticket=TKT&return_url={return_url}"
 
-    async def get_connect_status(self, mcp_url, name, jwt_token):
+    async def get_connect_status(self, mcp_url, name, jwt_token, timeout=None):
         if name in self.no_surface:
             return None
         connected = name in self.connected

--- a/tests/test_local_nginx_config.py
+++ b/tests/test_local_nginx_config.py
@@ -139,11 +139,28 @@ def test_nginx_local_combined_conf_routes_connect_to_mcp_ports():
     expected = {
         "/connect/atlassian/": "host.docker.internal:18003",
         "/connect/github/": "host.docker.internal:18002",
-        "/connect/ms-graph/": "host.docker.internal:18001",
+        "/connect/microsoft/": "host.docker.internal:18001",
         "/connect/databricks/": "host.docker.internal:18004",
     }
     for path, upstream in expected.items():
         assert _has_active_location_block(text, path), f"missing {path} proxy block"
+        start = text.index(f"location {path}")
+        block = text[start : start + 300]
+        assert upstream in block, f"{path} must proxy to {upstream}"
+
+
+def test_nginx_local_combined_conf_routes_connection_callbacks_to_mcp_ports():
+    """The provider OAuth redirect lands at /connections/<provider>/callback on
+    the front door (the canonical, already-registered path) and must route to
+    each provider's bond-mcps MCP port, NOT the auth proxy :18000."""
+    text = NGINX_CONF.read_text()
+    expected = {
+        "= /connections/microsoft/callback": "host.docker.internal:18001",
+        "= /connections/github/callback": "host.docker.internal:18002",
+        "= /connections/atlassian/callback": "host.docker.internal:18003",
+    }
+    for path, upstream in expected.items():
+        assert _has_active_location_block(text, path), f"missing 'location {path}' block"
         start = text.index(f"location {path}")
         block = text[start : start + 300]
         assert upstream in block, f"{path} must proxy to {upstream}"

--- a/tests/test_mcp_connect_client.py
+++ b/tests/test_mcp_connect_client.py
@@ -151,6 +151,49 @@ async def test_status_other_error_raises(fake_http):
         await cc.get_connect_status(MCP_URL, "atlassian", "JWT")
 
 
+# --- status (safe wrapper) --------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_status_safe_normalizes_expires_at_to_iso(fake_http):
+    # bond-mcps reports epoch seconds; the safe wrapper converts to ISO-8601
+    # (the shape the REST models / Flutter expect).
+    fake_http["handler"] = lambda *a, **k: FakeResp(
+        {"connected": True, "valid": True, "scopes": "s",
+         "expires_at": 1750000000.0, "has_refresh_token": True}
+    )
+    out = await cc.get_connect_status_safe(MCP_URL, "atlassian", "JWT")
+    assert out["connected"] is True
+    assert out["expires_at"] == "2025-06-15T15:06:40+00:00"
+    assert out["has_refresh_token"] is True
+
+
+@pytest.mark.asyncio
+async def test_status_safe_none_expiry_stays_none(fake_http):
+    fake_http["handler"] = lambda *a, **k: FakeResp(
+        {"connected": True, "valid": True, "scopes": None,
+         "expires_at": None, "has_refresh_token": False}
+    )
+    out = await cc.get_connect_status_safe(MCP_URL, "atlassian", "JWT")
+    assert out["expires_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_status_safe_404_passthrough(fake_http):
+    fake_http["handler"] = lambda *a, **k: FakeResp(status_code=404)
+    assert await cc.get_connect_status_safe(MCP_URL, "weather", "JWT") is None
+
+
+@pytest.mark.asyncio
+async def test_status_safe_error_reads_disconnected(fake_http):
+    def boom(*a, **k):
+        raise httpx.ConnectError("down")
+    fake_http["handler"] = boom
+    out = await cc.get_connect_status_safe(MCP_URL, "atlassian", "JWT")
+    assert out["connected"] is False
+    assert out["valid"] is False
+    assert "error" in out
+
+
 # --- disconnect -----------------------------------------------------------
 
 @pytest.mark.asyncio

--- a/tests/test_mcp_discovery.py
+++ b/tests/test_mcp_discovery.py
@@ -216,6 +216,65 @@ def test_force_refresh_fetches_even_with_poller(monkeypatch):
     assert len(calls) == 1  # still no request-path fetch
 
 
+def test_poll_interval_fast_until_first_success(monkeypatch):
+    """Before any successful fetch the poller retries every
+    STARTUP_RETRY_SECONDS (backend booted before its discovery upstream);
+    after the first success it settles to the TTL cadence."""
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_URL, DISCOVERY_URL)
+    cache = mcp_discovery._CACHE
+
+    # Never fetched (also the state after a failed startup fetch) → fast.
+    assert cache._next_poll_interval() == mcp_discovery.STARTUP_RETRY_SECONDS
+
+    def boom(*a, **k):
+        import httpx
+        raise httpx.ConnectError("down")
+    monkeypatch.setattr(mcp_discovery.httpx, "get", boom)
+    get_discovered_mcps(force_refresh=True)
+    assert cache._next_poll_interval() == mcp_discovery.STARTUP_RETRY_SECONDS
+
+    # A TTL smaller than the retry interval wins (never wait longer than TTL).
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_TTL, "1")
+    assert cache._next_poll_interval() == 1.0
+    monkeypatch.delenv(mcp_discovery.ENV_DISCOVERY_TTL)
+
+    # First success → normal TTL cadence (even for an empty-but-valid list).
+    _set_response(monkeypatch, {"mcps": []})
+    get_discovered_mcps(force_refresh=True)
+    assert cache._next_poll_interval() == mcp_discovery.DEFAULT_TTL_SECONDS
+
+
+def test_poller_recovers_quickly_from_failed_startup_fetch(monkeypatch):
+    """End-to-end: upstream down when the poller starts → comes up moments
+    later → the cache populates within the fast-retry window, not a full TTL."""
+    import threading
+    import time as _time
+
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_URL, DISCOVERY_URL)
+    monkeypatch.setattr(mcp_discovery, "STARTUP_RETRY_SECONDS", 0.05)
+    upstream_up = threading.Event()
+
+    def flaky_get(url, timeout=None):
+        if not upstream_up.is_set():
+            import httpx
+            raise httpx.ConnectError("nginx not up yet")
+        return FakeResp({"mcps": [{"name": "a", "url": "http://h/mcp"}]})
+    monkeypatch.setattr(mcp_discovery.httpx, "get", flaky_get)
+
+    mcp_discovery.start_background_poller()
+    try:
+        upstream_up.set()
+        deadline = _time.monotonic() + 5
+        while _time.monotonic() < deadline:
+            if [m["name"] for m in get_discovered_mcps()] == ["a"]:
+                break
+            _time.sleep(0.02)
+        else:
+            pytest.fail("poller did not recover within the fast-retry window")
+    finally:
+        mcp_discovery.stop_background_poller()
+
+
 # --- Fail soft ------------------------------------------------------------
 
 def test_failsoft_returns_last_good_on_error(monkeypatch):

--- a/tests/test_mcp_discovery.py
+++ b/tests/test_mcp_discovery.py
@@ -335,6 +335,13 @@ def test_overlay_merges_and_strips_oauth(monkeypatch):
     assert out["hello"] == {"command": "python", "args": ["h.py"]}  # untouched
     assert out["github"]["auth_type"] == "bond_jwt"
 
+    # Discovered servers are marked managed: bond_jwt like internal servers,
+    # but their per-user connection status is delegated to bond-mcps (the
+    # "non-oauth = always connected" shortcut must not apply to them).
+    assert atl["is_managed"] is True
+    assert out["github"]["is_managed"] is True
+    assert "is_managed" not in out["hello"]
+
 
 def test_overlay_noop_when_no_discovery(monkeypatch):
     static = {"mcpServers": {"hello": {"command": "python"}}}

--- a/tests/test_mcp_managed_runtime.py
+++ b/tests/test_mcp_managed_runtime.py
@@ -1,16 +1,26 @@
 """Runtime tests for executing tools on bond-mcps-managed (bond_jwt) MCPs.
 
-Covers: the Bond JWT is forwarded as the Bearer token to a discovered server,
-and a MissingProviderConnection-shaped tool error (carrying a /connect URL) is
-surfaced as a structured authorization_required response with the connect_url.
+Covers: the Bond JWT is forwarded as the Bearer token to a discovered server;
+a MissingProviderConnection-shaped tool error (carrying a /connect URL) is
+surfaced as a structured authorization_required response with the connect_url;
+the server-side mint fallback (no forwarded JWT) asserts a real identity with
+a narrow audience and short expiry; and /mcp/tools' managed-status delegation
+maps bond-mcps' status shape correctly.
 """
 
+import os
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
+os.environ.setdefault("JWT_SECRET_KEY", "test-secret-key-for-managed-runtime")
+
+import jwt as pyjwt
 import pytest
 
 from bondable.bond.providers.bedrock.BedrockMCP import (
     _extract_connect_url,
+    _get_auth_headers_for_server,
     execute_mcp_tool,
 )
 
@@ -90,3 +100,115 @@ async def test_missing_connection_surfaces_connect_url():
     assert out["authorization_required"] is True
     assert out["connect_url"] == "http://localhost:8000/connect/atlassian?ticket=TKT"
     assert out["server_name"] == "atlassian"
+
+
+# --- server-side Bond JWT mint (no forwarded request JWT) -------------------
+
+BOND_JWT_SERVER = {
+    "url": "http://localhost:18003/mcp",
+    "transport": "streamable-http",
+    "auth_type": "bond_jwt",
+}
+
+
+def _user(email):
+    return SimpleNamespace(user_id="u-1", email=email)
+
+
+def test_forwarded_jwt_wins_over_mint():
+    headers = _get_auth_headers_for_server(
+        "atlassian", BOND_JWT_SERVER, current_user=_user("a@example.com"), jwt_token="FORWARDED"
+    )
+    assert headers["Authorization"] == "Bearer FORWARDED"
+
+
+def test_mint_asserts_real_identity_with_narrow_scope():
+    """Server-side flows mint from the user's real email — and the token must
+    be MCP-only (aud excludes bond-ai-api) and short-lived, never a full
+    24h bond-ai API session handed to an MCP server."""
+    from bondable.rest.utils.auth import jwt_config
+
+    headers = _get_auth_headers_for_server(
+        "atlassian", BOND_JWT_SERVER, current_user=_user("a@example.com"), jwt_token=None
+    )
+    token = headers["Authorization"].removeprefix("Bearer ")
+    claims = pyjwt.decode(
+        token, jwt_config.JWT_SECRET_KEY, algorithms=["HS256"], audience="mcp-server"
+    )
+    assert claims["sub"] == "a@example.com"
+    assert claims["iss"] == "bond-ai"
+    assert claims["aud"] == ["mcp-server"]          # NOT a bond-ai API session
+    assert "bond-ai-api" not in claims["aud"]
+    lifetime = claims["exp"] - datetime.now(timezone.utc).timestamp()
+    assert 0 < lifetime <= 6 * 60                    # short-lived (~5 min)
+
+
+@pytest.mark.parametrize("email", [None, "", "unknown"])
+def test_mint_refuses_placeholder_identity(email):
+    """A placeholder email must never be signed into a JWT (bond-mcps would
+    trust it as a real user_key). No mint -> no Authorization header."""
+    headers = _get_auth_headers_for_server(
+        "atlassian", BOND_JWT_SERVER, current_user=_user(email), jwt_token=None
+    )
+    assert "Authorization" not in headers
+
+
+# --- /mcp/tools managed-status delegation ------------------------------------
+
+from bondable.rest.routers.mcp import _get_managed_connection_status  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_managed_status_maps_connected_payload(monkeypatch):
+    async def fake_status(url, name, jwt_token, timeout=None):
+        return {"connected": True, "valid": True, "scopes": "read",
+                "expires_at": 1750000000.0, "has_refresh_token": True}
+    monkeypatch.setattr("bondable.bond.mcp_connect_client.get_connect_status", fake_status)
+
+    info = await _get_managed_connection_status("atlassian", BOND_JWT_SERVER, "JWT")
+    assert info.connected is True
+    assert info.valid is True
+    assert info.requires_authorization is False
+    assert info.expires_at == "2025-06-15T15:06:40+00:00"  # epoch -> ISO
+    assert info.has_refresh_token is True
+
+
+@pytest.mark.asyncio
+async def test_managed_status_disconnected_gates_tools(monkeypatch):
+    """Disconnected reads valid=False here: `valid` gates tool selection in
+    the agent editor (unlike the Connections screen, where it means
+    'not expired')."""
+    async def fake_status(url, name, jwt_token, timeout=None):
+        return {"connected": False, "valid": True, "scopes": None,
+                "expires_at": None, "has_refresh_token": False}
+    monkeypatch.setattr("bondable.bond.mcp_connect_client.get_connect_status", fake_status)
+
+    info = await _get_managed_connection_status("atlassian", BOND_JWT_SERVER, "JWT")
+    assert info.connected is False
+    assert info.valid is False
+    assert info.requires_authorization is True
+
+
+@pytest.mark.asyncio
+async def test_managed_status_no_connect_surface_reads_connected(monkeypatch):
+    """404 (no connect surface, e.g. PAT-based databricks) -> nothing to
+    connect; the server must render as usable. (The Connections screen makes
+    the opposite call and omits the tile.)"""
+    async def fake_status(url, name, jwt_token, timeout=None):
+        return None
+    monkeypatch.setattr("bondable.bond.mcp_connect_client.get_connect_status", fake_status)
+
+    info = await _get_managed_connection_status("databricks", BOND_JWT_SERVER, "JWT")
+    assert info.connected is True
+    assert info.requires_authorization is False
+
+
+@pytest.mark.asyncio
+async def test_managed_status_fails_soft_when_mcps_down(monkeypatch):
+    async def boom(url, name, jwt_token, timeout=None):
+        raise RuntimeError("bond-mcps unreachable")
+    monkeypatch.setattr("bondable.bond.mcp_connect_client.get_connect_status", boom)
+
+    info = await _get_managed_connection_status("atlassian", BOND_JWT_SERVER, "JWT")
+    assert info.connected is False
+    assert info.requires_authorization is True


### PR DESCRIPTION
This pull request introduces several reliability, security, and user experience improvements for MCP (Managed Connection Provider) discovery, connection status handling, and authentication. The key changes ensure robust process management during development, more accurate and secure user identity handling for JWT minting, improved error handling for MCP status checks, and faster discovery polling on startup. These updates make MCP integration more reliable and secure, and improve UI responsiveness and correctness.

**MCP Discovery and Polling Improvements:**
- The MCP discovery background poller now retries every 10 seconds until the first successful fetch, instead of waiting the full TTL, ensuring managed MCPs appear quickly even if the backend starts before its upstream is available. (`bondable/bond/mcp_discovery.py`) [[1]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baR49-R57) [[2]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baR221-R237) [[3]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL234-R253)

**Connection Status Handling and Error Resilience:**
- All connection status checks for managed MCPs now use a new fail-soft `get_connect_status_safe` method, which normalizes `expires_at` to ISO-8601 and ensures that network or HTTP errors are surfaced as "disconnected" rather than failing the entire listing or endpoint. This is applied in both the Connections API and the MCP tools listing. (`bondable/bond/mcp_connect_client.py`, `bondable/rest/routers/connections.py`, `bondable/rest/routers/mcp.py`) [[1]](diffhunk://#diff-dddbd5429f39752e44a82dcd8029e276c880af6740868c967932a31d7618eeafR129-R184) [[2]](diffhunk://#diff-eda14c41e264488f6e0a28450cb8e9d39adebb02420e5b0fe817e94222ace8d3L390-R409) [[3]](diffhunk://#diff-eda14c41e264488f6e0a28450cb8e9d39adebb02420e5b0fe817e94222ace8d3L767-R772) [[4]](diffhunk://#diff-c2fb454e87dea5d2af178ac45597988cb76532da9cc47e000f8eb2271a6eaf2bR114-R125) [[5]](diffhunk://#diff-c2fb454e87dea5d2af178ac45597988cb76532da9cc47e000f8eb2271a6eaf2bL123-R142) [[6]](diffhunk://#diff-c2fb454e87dea5d2af178ac45597988cb76532da9cc47e000f8eb2271a6eaf2bR507-R542)

**User Identity and JWT Minting Security:**
- When minting Bond JWTs for agent tool definition fetches, the user's real email is resolved from the database and only used if present and valid. This prevents the creation of JWTs with placeholder or fabricated identities, improving security. (`bondable/bond/providers/bedrock/BedrockMCP.py`) [[1]](diffhunk://#diff-b830787bec02ed0b24e4fc2305e8425d54fb62b5eacb703b3dd07a0562a0ba32R933-R956) [[2]](diffhunk://#diff-b830787bec02ed0b24e4fc2305e8425d54fb62b5eacb703b3dd07a0562a0ba32L954-R988) [[3]](diffhunk://#diff-b830787bec02ed0b24e4fc2305e8425d54fb62b5eacb703b3dd07a0562a0ba32L1286-R1345)

**Process Management Reliability:**
- The `Makefile`'s `stop` target is now robust: it kills all processes listening on the backend and frontend ports (including all uvicorn reloader workers), waits for the ports to be free, and escalates to SIGKILL if necessary. This ensures reliable restarts during development. (`Makefile`)

**MCP Server Configuration Enhancements:**
- Discovered MCP servers are now marked with an `is_managed` flag, clarifying their status as bond-mcps-managed and ensuring their connection logic is handled appropriately in the UI and API. (`bondable/bond/config.py`)

These changes collectively make MCP integration more robust, secure, and user-friendly.