### PR TITLE
feat(mcp): AS token-exchange (RFC 8693) client for managed MCPs

### DIFF
--- a/bondable/bond/mcp_connect_client.py
+++ b/bondable/bond/mcp_connect_client.py
@@ -25,6 +25,8 @@ from urllib.parse import urlparse
 
 import httpx
 
+from bondable.bond import mcp_token_exchange
+
 LOGGER = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_SECONDS = 10.0
@@ -65,6 +67,23 @@ def _auth_headers(jwt_token: Optional[str]) -> Dict[str, str]:
     return {"Authorization": f"Bearer {jwt_token}", "Accept": "application/json"}
 
 
+async def _bearer_for(mcp_url: str, jwt_token: str) -> str:
+    """Resolve the Bearer credential for a bond-mcps connect call.
+
+    These connect endpoints only ever front bond-mcps-managed MCPs, which sit
+    behind the bond-mcps Authorization Server. When token exchange is enabled
+    (``BOND_MCPS_AS_BASE_URL`` set) the caller's Bond JWT must be exchanged
+    (RFC 8693) for an AS-issued token scoped to this MCP; when disabled, the
+    Bond JWT is presented directly (local dev-combined-jwt), unchanged.
+    """
+    if not mcp_token_exchange.is_exchange_enabled():
+        return jwt_token
+    try:
+        return await mcp_token_exchange.exchange_token(jwt_token, mcp_url)
+    except mcp_token_exchange.TokenExchangeError as exc:
+        raise ConnectError(f"AS token exchange failed: {exc}") from exc
+
+
 async def mint_connect_ticket(
     mcp_url: str,
     name: str,
@@ -77,6 +96,7 @@ async def mint_connect_ticket(
     bond-mcps binds the ticket to the JWT's ``sub`` and (per the contract) carries
     ``return_url`` through to the callback so the user is sent back to bond-ai.
     """
+    bearer = await _bearer_for(mcp_url, jwt_token)
     base = connect_base_url(mcp_url)
     url = f"{base}/connect/{_safe_name(name)}/ticket"
     try:
@@ -84,7 +104,7 @@ async def mint_connect_ticket(
             resp = await client.post(
                 url,
                 json={"return_url": return_url},
-                headers=_auth_headers(jwt_token),
+                headers=_auth_headers(bearer),
             )
             resp.raise_for_status()
             payload = resp.json()
@@ -109,11 +129,12 @@ async def get_connect_status(
     no provider connection and should not be shown as connectable. On any other
     error this raises :class:`ConnectError` (callers decide how to fail soft).
     """
+    bearer = await _bearer_for(mcp_url, jwt_token)
     base = connect_base_url(mcp_url)
     url = f"{base}/connect/{_safe_name(name)}/status"
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.get(url, headers=_auth_headers(jwt_token))
+            resp = await client.get(url, headers=_auth_headers(bearer))
             if resp.status_code == 404:
                 return None
             resp.raise_for_status()
@@ -189,11 +210,12 @@ async def delete_connection(
     timeout: float = DEFAULT_TIMEOUT_SECONDS,
 ) -> bool:
     """Delete the user's stored provider token for an MCP via bond-mcps."""
+    bearer = await _bearer_for(mcp_url, jwt_token)
     base = connect_base_url(mcp_url)
     url = f"{base}/connect/{_safe_name(name)}"
     try:
         async with httpx.AsyncClient(timeout=timeout) as client:
-            resp = await client.request("DELETE", url, headers=_auth_headers(jwt_token))
+            resp = await client.request("DELETE", url, headers=_auth_headers(bearer))
             if resp.status_code == 404:
                 return False
             resp.raise_for_status()

--- a/bondable/bond/mcp_token_exchange.py
+++ b/bondable/bond/mcp_token_exchange.py
@@ -1,0 +1,188 @@
+"""RFC 8693 token-exchange client for the bond-mcps Authorization Server.
+
+For bond-mcps-*managed* MCPs, bond-ai must not present its HS256 Bond JWT to
+the MCP pod directly. Instead it exchanges that JWT at the bond-mcps
+Authorization Server (RFC 8693, ``POST {AS}/oauth/token``) for a short-lived
+access token scoped to the target MCP (``resource``) and presents that token.
+
+This module is INERT unless ``BOND_MCPS_AS_BASE_URL`` is set:
+:func:`is_exchange_enabled` returns ``False`` and callers keep sending the Bond
+JWT directly (the local dev-combined-jwt flow), byte-for-byte unchanged.
+
+Exchanged tokens are cached (thread-safe, shared across the sync and async
+fetchers) keyed by ``(subject "sub", resource)`` and reused until 30 s before
+expiry.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Dict, Optional, Tuple
+
+import httpx
+import jwt
+
+LOGGER = logging.getLogger(__name__)
+
+ENV_AS_BASE_URL = "BOND_MCPS_AS_BASE_URL"
+ENV_TIMEOUT = "BOND_MCPS_TOKEN_EXCHANGE_TIMEOUT_SECONDS"
+
+DEFAULT_TIMEOUT_SECONDS = 10.0
+
+GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+SUBJECT_TOKEN_TYPE = "urn:ietf:params:oauth:token-type:jwt"  # nosec B105 - RFC 8693 URN, not a secret
+CLIENT_ID = "bond-ai"
+
+# Refresh a cached token this many seconds before its reported expiry, so an
+# in-flight MCP call never rides a token that lapses mid-request.
+_EXPIRY_SKEW_SECONDS = 30
+
+
+class TokenExchangeError(Exception):
+    """Raised when the AS token exchange fails (config/network/HTTP/parse)."""
+
+
+# key: (subject "sub", resource) -> value: (access_token, monotonic expiry)
+_cache: Dict[Tuple[str, str], Tuple[str, float]] = {}
+_cache_lock = threading.Lock()
+
+
+def is_exchange_enabled() -> bool:
+    """True when ``BOND_MCPS_AS_BASE_URL`` is set (and non-empty)."""
+    return bool(os.getenv(ENV_AS_BASE_URL, "").strip())
+
+
+def reset_cache() -> None:
+    """Clear the shared token cache (tests)."""
+    with _cache_lock:
+        _cache.clear()
+
+
+def _base_url() -> str:
+    base = os.getenv(ENV_AS_BASE_URL, "").strip()
+    if not base:
+        raise TokenExchangeError(f"{ENV_AS_BASE_URL} is not set; token exchange is disabled")
+    return base.rstrip("/")
+
+
+def _timeout(timeout: Optional[float]) -> float:
+    if timeout is not None:
+        return timeout
+    raw = os.getenv(ENV_TIMEOUT, "").strip()
+    if raw:
+        try:
+            return float(raw)
+        except ValueError:
+            LOGGER.warning("invalid %s=%r; using %ss", ENV_TIMEOUT, raw, DEFAULT_TIMEOUT_SECONDS)
+    return DEFAULT_TIMEOUT_SECONDS
+
+
+def _subject_sub(subject_token: str) -> str:
+    """Extract the ``sub`` claim without verifying the signature (cache key only)."""
+    try:
+        claims = jwt.decode(subject_token, options={"verify_signature": False})
+    except jwt.PyJWTError as exc:
+        raise TokenExchangeError(f"subject token is not a valid JWT: {exc}") from exc
+    sub = claims.get("sub")
+    if not sub:
+        raise TokenExchangeError("subject token has no 'sub' claim")
+    return str(sub)
+
+
+def _cache_key(subject_token: str, resource: str) -> Tuple[str, str]:
+    return (_subject_sub(subject_token), resource)
+
+
+def _cached(key: Tuple[str, str]) -> Optional[str]:
+    with _cache_lock:
+        entry = _cache.get(key)
+        if entry is None:
+            return None
+        token, expiry = entry
+        if time.monotonic() >= expiry:
+            _cache.pop(key, None)
+            return None
+        return token
+
+
+def _store(key: Tuple[str, str], token: str, expires_in: object) -> None:
+    # Only cache when the AS reports an expiry long enough to be worth reusing.
+    if not isinstance(expires_in, (int, float)) or isinstance(expires_in, bool):
+        return
+    if expires_in <= _EXPIRY_SKEW_SECONDS:
+        return
+    with _cache_lock:
+        _cache[key] = (token, time.monotonic() + float(expires_in) - _EXPIRY_SKEW_SECONDS)
+
+
+def _form(subject_token: str, resource: str) -> Dict[str, str]:
+    return {
+        "grant_type": GRANT_TYPE,
+        "subject_token": subject_token,
+        "subject_token_type": SUBJECT_TOKEN_TYPE,
+        "resource": resource,
+        "client_id": CLIENT_ID,
+    }
+
+
+def _parse(status_code: int, text: str, payload_json) -> Tuple[str, object]:
+    if status_code != 200:
+        raise TokenExchangeError(f"AS token exchange returned HTTP {status_code}: {text[:500]}")
+    if not isinstance(payload_json, dict):
+        raise TokenExchangeError("AS token exchange response was not a JSON object")
+    token = payload_json.get("access_token")
+    if not isinstance(token, str) or not token.strip():
+        raise TokenExchangeError("AS token exchange response missing access_token")
+    return token.strip(), payload_json.get("expires_in")
+
+
+def exchange_token_sync(subject_token: str, resource: str, timeout: Optional[float] = None) -> str:
+    """Exchange ``subject_token`` for an AS access token scoped to ``resource``.
+
+    Returns a cached token when one is still valid. Raises
+    :class:`TokenExchangeError` on config/network/HTTP/parse failure.
+    """
+    key = _cache_key(subject_token, resource)
+    cached = _cached(key)
+    if cached is not None:
+        return cached
+
+    url = f"{_base_url()}/oauth/token"
+    try:
+        with httpx.Client(timeout=_timeout(timeout)) as client:  # nosec B113 - timeout always set
+            resp = client.post(url, data=_form(subject_token, resource))
+            token, expires_in = _parse(resp.status_code, resp.text, _safe_json(resp))
+    except httpx.HTTPError as exc:
+        raise TokenExchangeError(f"AS token exchange request failed: {type(exc).__name__}: {exc}") from exc
+
+    _store(key, token, expires_in)
+    return token
+
+
+async def exchange_token(subject_token: str, resource: str, timeout: Optional[float] = None) -> str:
+    """Async variant of :func:`exchange_token_sync` (shares the same cache)."""
+    key = _cache_key(subject_token, resource)
+    cached = _cached(key)
+    if cached is not None:
+        return cached
+
+    url = f"{_base_url()}/oauth/token"
+    try:
+        async with httpx.AsyncClient(timeout=_timeout(timeout)) as client:  # nosec B113 - timeout always set
+            resp = await client.post(url, data=_form(subject_token, resource))
+            token, expires_in = _parse(resp.status_code, resp.text, _safe_json(resp))
+    except httpx.HTTPError as exc:
+        raise TokenExchangeError(f"AS token exchange request failed: {type(exc).__name__}: {exc}") from exc
+
+    _store(key, token, expires_in)
+    return token
+
+
+def _safe_json(resp: httpx.Response):
+    try:
+        return resp.json()
+    except ValueError:
+        return None

--- a/bondable/bond/providers/bedrock/BedrockMCP.py
+++ b/bondable/bond/providers/bedrock/BedrockMCP.py
@@ -21,6 +21,7 @@ from fastmcp.client.transports import StreamableHttpTransport  # Use fastmcp's t
 from fastmcp.client.transports import SSETransport
 import asyncio
 from bondable.bond.config import Config
+from bondable.bond import mcp_token_exchange
 from bondable.bond.auth.mcp_token_cache import (
     get_mcp_token_cache,
     AuthorizationRequiredError,
@@ -1113,7 +1114,11 @@ async def _get_mcp_tool_definitions(mcp_config: Dict[str, Any], tool_names: List
         try:
             # Get authentication headers (handles oauth2, bond_jwt, static)
             try:
-                headers = _get_auth_headers_for_server(server_name, server_config, current_user)
+                # to_thread: the managed-MCP branch may make a blocking token-exchange
+                # HTTP call — keep it off the event loop.
+                headers = await asyncio.to_thread(
+                    _get_auth_headers_for_server, server_name, server_config, current_user
+                )
                 headers['User-Agent'] = 'Bond-AI-MCP-Client/1.0'
                 LOGGER.debug("[MCP Tool Defs] Server '%s': authenticated successfully", safe_id(server_name))
             except (AuthorizationRequiredError, TokenExpiredError) as e:
@@ -1338,6 +1343,20 @@ def _get_auth_headers_for_server(
                     LOGGER.warning("Failed to mint Bond JWT for server %s: %s", safe_id(server_name), e)
             else:
                 LOGGER.debug("No real email for bond_jwt mint on server %s; skipping", safe_id(server_name))
+
+        # bond-mcps-managed MCPs sit behind the Authorization Server: when token
+        # exchange is enabled we must NOT present the HS256 Bond JWT to the MCP
+        # pod. Exchange it (RFC 8693) for an AS token scoped to this MCP. On
+        # failure, send NO Authorization header rather than leak the HS256 to a
+        # managed pod. Non-managed servers and disabled mode are unaffected.
+        if token and server_config.get('is_managed') and mcp_token_exchange.is_exchange_enabled():
+            try:
+                token = mcp_token_exchange.exchange_token_sync(token, server_config['url'])
+                LOGGER.debug("Exchanged Bond JWT for AS token on managed server %s", safe_id(server_name))
+            except mcp_token_exchange.TokenExchangeError as e:
+                LOGGER.warning("AS token exchange failed for managed server %s; sending no Authorization: %s", safe_id(server_name), e)
+                token = None
+
         if token:
             headers['Authorization'] = f'Bearer {token}'
             LOGGER.debug("Using Bond JWT for MCP server %s", safe_id(server_name))
@@ -1428,12 +1447,15 @@ async def execute_mcp_tool(
 
         for attempt in range(max_attempts):
             try:
-                # Get authentication headers based on auth_type
-                headers = _get_auth_headers_for_server(
+                # Get authentication headers based on auth_type.
+                # to_thread: the managed-MCP branch may make a blocking
+                # token-exchange HTTP call — keep it off the event loop.
+                headers = await asyncio.to_thread(
+                    _get_auth_headers_for_server,
                     server_name=server_name,
                     server_config=server_config,
                     current_user=current_user,
-                    jwt_token=jwt_token
+                    jwt_token=jwt_token,
                 )
                 headers['User-Agent'] = 'Bond-AI-MCP-Client/1.0'
 

--- a/scripts/verify-combined-stack.sh
+++ b/scripts/verify-combined-stack.sh
@@ -18,6 +18,9 @@
 #      session shape (aud=["bond-ai-api","mcp-server"]) AND with the narrow
 #      server-mint shape (aud=["mcp-server"]) proves the HS256 shared-secret
 #      contract (iss/aud/sub) is live end-to-end for both shapes bond-ai sends.
+#   8. RFC 8693 token exchange (only when BOND_MCPS_AS_BASE_URL is set): exchange
+#      a minted Bond JWT at the AS for a scoped access token, then use that token
+#      on the connect status probe. Unset -> SKIP (HS256-direct mode).
 #
 # Exit code 0 = all checks passed. Any failure prints a hint and exits 1.
 #
@@ -39,6 +42,7 @@ FAIL=0
 
 ok()   { PASS=$((PASS+1)); printf '  \033[32mPASS\033[0m  %s\n' "$1"; }
 bad()  { FAIL=$((FAIL+1)); printf '  \033[31mFAIL\033[0m  %s\n' "$1"; [ -n "${2:-}" ] && printf '        hint: %s\n' "$2"; }
+skip() { printf '  \033[33mSKIP\033[0m  %s\n' "$1"; }
 
 echo "== bond-ai + bond-mcps combined-stack verification =="
 echo
@@ -175,6 +179,49 @@ print(jwt.encode({**base, 'aud': ['mcp-server'],
     else
       bad "narrow (server-mint) Bond JWT rejected ($status_url → $code)" "BOND_MCPS_JWT_AUDIENCE=mcp-server must be set on the MCPs (dev-combined-jwt sets it)"
     fi
+  fi
+fi
+
+# --- 8. RFC 8693 token exchange (only when AS delegation mode is on) ----------
+# When BOND_MCPS_AS_BASE_URL is set, bond-ai exchanges its Bond JWT at the AS
+# for a scoped access token instead of presenting the HS256 JWT directly. Prove
+# that round-trip: exchange the narrow minted subject JWT (from check 7), assert
+# HTTP 200 + access_token, then use the result on the connect status probe.
+# Unset -> nothing to exchange (HS256-direct mode); SKIP.
+as_base="${BOND_MCPS_AS_BASE_URL:-}"
+if [ -z "$as_base" ] && [ -f "$ENV_FILE" ]; then
+  as_base=$(grep -E '^BOND_MCPS_AS_BASE_URL=' "$ENV_FILE" | head -1 | cut -d= -f2- | tr -d '"')
+fi
+as_base=${as_base%/}
+if [ -z "$as_base" ]; then
+  skip "RFC 8693 token exchange (BOND_MCPS_AS_BASE_URL unset — HS256-direct mode)"
+elif [ -z "${narrow:-}" ]; then
+  bad "token exchange: no minted subject JWT available" "check 7 must run first (needs env file + discovered MCP)"
+elif [ -z "${status_url:-}" ] || [ -z "${base:-}" ]; then
+  bad "token exchange: no connect status URL available" "no discovered MCP to exchange against"
+else
+  # resource = the MCP's discovered /mcp URL, exactly what bond-ai sends.
+  mcp_resource="$base/mcp"
+  ex_resp=$($CURL -w '\n%{http_code}' \
+    -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+    -d "subject_token=$narrow" \
+    -d "subject_token_type=urn:ietf:params:oauth:token-type:jwt" \
+    -d "resource=$mcp_resource" \
+    -d "client_id=bond-ai" \
+    "$as_base/oauth/token" 2>/dev/null)
+  ex_code=$(echo "$ex_resp" | tail -1)
+  ex_body=$(echo "$ex_resp" | sed '$d')
+  access=$(echo "$ex_body" | sed -n 's/.*"access_token" *: *"\([^"]*\)".*/\1/p')
+  if [ "$ex_code" = "200" ] && [ -n "$access" ]; then
+    ok "AS token exchange ($as_base/oauth/token → 200, access_token present)"
+    code=$($CURL -o /dev/null -w '%{http_code}' -H "Authorization: Bearer $access" "$status_url" 2>/dev/null)
+    if [ "$code" = "200" ] || [ "$code" = "404" ]; then
+      ok "exchanged token accepted by MCP ($status_url → $code)"
+    else
+      bad "exchanged token rejected ($status_url → $code)" "AS-issued token not accepted by the MCP — check AS signing keys / MCP verification config"
+    fi
+  else
+    bad "AS token exchange failed ($as_base/oauth/token → $ex_code)" "is the bond-mcps AS running with the RFC 8693 grant? body: $(echo "$ex_body" | head -c 120)"
   fi
 fi
 

--- a/tests/test_mcp_connect_client.py
+++ b/tests/test_mcp_connect_client.py
@@ -206,3 +206,63 @@ async def test_delete_returns_flag(fake_http):
 async def test_delete_404_returns_false(fake_http):
     fake_http["handler"] = lambda *a, **k: FakeResp(status_code=404, content=b"")
     assert await cc.delete_connection(MCP_URL, "atlassian", "JWT") is False
+
+
+# --- AS token exchange (managed MCP delegation) ----------------------------
+
+@pytest.fixture
+def exchange_enabled(monkeypatch):
+    """Enable RFC 8693 exchange; exchange_token returns 'AS-<resource>'."""
+    monkeypatch.setattr(cc.mcp_token_exchange, "is_exchange_enabled", lambda: True)
+
+    async def fake_exchange(subject, resource, timeout=None):
+        return f"AS-{resource}"
+
+    monkeypatch.setattr(cc.mcp_token_exchange, "exchange_token", fake_exchange)
+
+
+@pytest.mark.asyncio
+async def test_ticket_sends_exchanged_bearer(fake_http, exchange_enabled):
+    fake_http["handler"] = lambda *a, **k: FakeResp({"connect_url": "http://x/connect/a?ticket=t"})
+    await cc.mint_connect_ticket(MCP_URL, "atlassian", "JWT123", "http://x/connections")
+    assert fake_http["calls"][0]["headers"]["Authorization"] == f"Bearer AS-{MCP_URL}"
+
+
+@pytest.mark.asyncio
+async def test_status_sends_exchanged_bearer(fake_http, exchange_enabled):
+    fake_http["handler"] = lambda *a, **k: FakeResp({"connected": True})
+    await cc.get_connect_status(MCP_URL, "atlassian", "JWT123")
+    assert fake_http["calls"][0]["headers"]["Authorization"] == f"Bearer AS-{MCP_URL}"
+
+
+@pytest.mark.asyncio
+async def test_delete_sends_exchanged_bearer(fake_http, exchange_enabled):
+    fake_http["handler"] = lambda *a, **k: FakeResp({"disconnected": True})
+    await cc.delete_connection(MCP_URL, "atlassian", "JWT123")
+    assert fake_http["calls"][0]["headers"]["Authorization"] == f"Bearer AS-{MCP_URL}"
+
+
+@pytest.mark.asyncio
+async def test_exchange_failure_raises_connect_error(fake_http, monkeypatch):
+    monkeypatch.setattr(cc.mcp_token_exchange, "is_exchange_enabled", lambda: True)
+
+    async def boom(subject, resource, timeout=None):
+        raise cc.mcp_token_exchange.TokenExchangeError("nope")
+
+    monkeypatch.setattr(cc.mcp_token_exchange, "exchange_token", boom)
+    with pytest.raises(ConnectError):
+        await cc.get_connect_status(MCP_URL, "atlassian", "JWT123")
+
+
+@pytest.mark.asyncio
+async def test_status_safe_degrades_on_exchange_failure(fake_http, monkeypatch):
+    monkeypatch.setattr(cc.mcp_token_exchange, "is_exchange_enabled", lambda: True)
+
+    async def boom(subject, resource, timeout=None):
+        raise cc.mcp_token_exchange.TokenExchangeError("nope")
+
+    monkeypatch.setattr(cc.mcp_token_exchange, "exchange_token", boom)
+    out = await cc.get_connect_status_safe(MCP_URL, "atlassian", "JWT123")
+    assert out["connected"] is False
+    assert out["valid"] is False
+    assert "error" in out

--- a/tests/test_mcp_managed_runtime.py
+++ b/tests/test_mcp_managed_runtime.py
@@ -153,6 +153,98 @@ def test_mint_refuses_placeholder_identity(email):
     assert "Authorization" not in headers
 
 
+# --- AS token exchange for managed MCPs --------------------------------------
+
+from bondable.bond.providers.bedrock import BedrockMCP as bm  # noqa: E402
+
+MANAGED_SERVER = {
+    "url": "http://localhost:18003/mcp",
+    "transport": "streamable-http",
+    "auth_type": "bond_jwt",
+    "is_managed": True,
+}
+
+
+def test_managed_enabled_exchanges_forwarded_token(monkeypatch):
+    """Managed MCP + exchange on: the forwarded Bond JWT is exchanged at the
+    AS and the AS-issued token (not the HS256) is presented."""
+    monkeypatch.setattr(bm.mcp_token_exchange, "is_exchange_enabled", lambda: True)
+    captured = {}
+
+    def fake_exchange(subject, resource, timeout=None):
+        captured["subject"] = subject
+        captured["resource"] = resource
+        return "ASTOKEN"
+
+    monkeypatch.setattr(bm.mcp_token_exchange, "exchange_token_sync", fake_exchange)
+    headers = _get_auth_headers_for_server(
+        "atlassian", MANAGED_SERVER, current_user=_user("a@example.com"), jwt_token="FWD"
+    )
+    assert headers["Authorization"] == "Bearer ASTOKEN"
+    assert captured["subject"] == "FWD"                       # exchanges what it would have sent
+    assert captured["resource"] == "http://localhost:18003/mcp"
+
+
+def test_managed_enabled_mints_then_exchanges(monkeypatch):
+    """Server-side flow (no forwarded JWT): mint a subject from the real email,
+    then exchange it — the presented token is the AS token."""
+    monkeypatch.setattr(bm.mcp_token_exchange, "is_exchange_enabled", lambda: True)
+    captured = {}
+
+    def fake_exchange(subject, resource, timeout=None):
+        captured["subject"] = subject
+        return "ASTOKEN"
+
+    monkeypatch.setattr(bm.mcp_token_exchange, "exchange_token_sync", fake_exchange)
+    headers = _get_auth_headers_for_server(
+        "atlassian", MANAGED_SERVER, current_user=_user("a@example.com"), jwt_token=None
+    )
+    assert headers["Authorization"] == "Bearer ASTOKEN"
+    # subject is a minted HS256 Bond JWT for the real identity
+    claims = pyjwt.decode(captured["subject"], options={"verify_signature": False})
+    assert claims["sub"] == "a@example.com"
+
+
+def test_managed_exchange_failure_sends_no_auth(monkeypatch):
+    """Exchange failure must NOT leak the HS256 to a managed pod — no header."""
+    monkeypatch.setattr(bm.mcp_token_exchange, "is_exchange_enabled", lambda: True)
+
+    def boom(subject, resource, timeout=None):
+        raise bm.mcp_token_exchange.TokenExchangeError("AS down")
+
+    monkeypatch.setattr(bm.mcp_token_exchange, "exchange_token_sync", boom)
+    headers = _get_auth_headers_for_server(
+        "atlassian", MANAGED_SERVER, current_user=_user("a@example.com"), jwt_token="FWD"
+    )
+    assert "Authorization" not in headers
+
+
+def test_managed_disabled_sends_hs256(monkeypatch):
+    """Managed MCP + exchange off (local dev): HS256 Bond JWT sent directly."""
+    monkeypatch.setattr(bm.mcp_token_exchange, "is_exchange_enabled", lambda: False)
+    headers = _get_auth_headers_for_server(
+        "atlassian", MANAGED_SERVER, current_user=_user("a@example.com"), jwt_token="FWD"
+    )
+    assert headers["Authorization"] == "Bearer FWD"
+
+
+def test_non_managed_never_exchanges(monkeypatch):
+    """A non-managed bond_jwt server always sends HS256, even when exchange is on."""
+    monkeypatch.setattr(bm.mcp_token_exchange, "is_exchange_enabled", lambda: True)
+    calls = {"n": 0}
+
+    def fake_exchange(*a, **k):
+        calls["n"] += 1
+        return "ASTOKEN"
+
+    monkeypatch.setattr(bm.mcp_token_exchange, "exchange_token_sync", fake_exchange)
+    headers = _get_auth_headers_for_server(
+        "atlassian", BOND_JWT_SERVER, current_user=_user("a@example.com"), jwt_token="FWD"
+    )
+    assert headers["Authorization"] == "Bearer FWD"
+    assert calls["n"] == 0
+
+
 # --- /mcp/tools managed-status delegation ------------------------------------
 
 from bondable.rest.routers.mcp import _get_managed_connection_status  # noqa: E402

--- a/tests/test_mcp_token_exchange.py
+++ b/tests/test_mcp_token_exchange.py
@@ -1,0 +1,219 @@
+"""Unit tests for the bond-mcps RFC 8693 token-exchange client."""
+
+import httpx
+import jwt
+import pytest
+
+from bondable.bond import mcp_token_exchange as tx
+
+
+AS_BASE = "https://as.example.com"
+_NO_JSON = object()
+
+
+def _subject(sub="alice@example.com"):
+    return jwt.encode({"sub": sub}, "x" * 32, algorithm="HS256")
+
+
+class FakeResp:
+    def __init__(self, status_code=200, payload=None, text=""):
+        self.status_code = status_code
+        self._payload = {"access_token": "AS_TOKEN", "expires_in": 300} if payload is None else payload
+        self.text = text
+
+    def json(self):
+        if self._payload is _NO_JSON:
+            raise ValueError("not json")
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache():
+    tx.reset_cache()
+    yield
+    tx.reset_cache()
+
+
+@pytest.fixture
+def enabled(monkeypatch):
+    monkeypatch.setenv(tx.ENV_AS_BASE_URL, AS_BASE)
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    """Patch httpx.Client/AsyncClient; set `handler`, inspect `sync_calls`/`async_calls`."""
+    state = {"handler": lambda url, data: FakeResp(), "sync_calls": [], "async_calls": []}
+
+    class FakeSyncClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def post(self, url, data=None):
+            state["sync_calls"].append({"url": url, "data": data})
+            return state["handler"](url, data)
+
+    class FakeAsyncClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, data=None):
+            state["async_calls"].append({"url": url, "data": data})
+            return state["handler"](url, data)
+
+    monkeypatch.setattr(tx.httpx, "Client", FakeSyncClient)
+    monkeypatch.setattr(tx.httpx, "AsyncClient", FakeAsyncClient)
+    return state
+
+
+# --- enabled / disabled ------------------------------------------------------
+
+def test_disabled_when_env_unset(monkeypatch):
+    monkeypatch.delenv(tx.ENV_AS_BASE_URL, raising=False)
+    assert tx.is_exchange_enabled() is False
+
+
+def test_enabled_when_env_set(enabled):
+    assert tx.is_exchange_enabled() is True
+
+
+def test_exchange_disabled_raises(monkeypatch):
+    monkeypatch.delenv(tx.ENV_AS_BASE_URL, raising=False)
+    with pytest.raises(tx.TokenExchangeError):
+        tx.exchange_token_sync(_subject(), "res")
+
+
+# --- request shape -----------------------------------------------------------
+
+def test_form_fields_and_url(enabled, fake_http):
+    sub = _subject()
+    out = tx.exchange_token_sync(sub, "https://mcp.example.com/mcp")
+    assert out == "AS_TOKEN"
+    call = fake_http["sync_calls"][0]
+    assert call["url"] == f"{AS_BASE}/oauth/token"
+    assert call["data"] == {
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": sub,
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "resource": "https://mcp.example.com/mcp",
+        "client_id": "bond-ai",
+    }
+
+
+def test_base_url_trailing_slash_stripped(monkeypatch, fake_http):
+    monkeypatch.setenv(tx.ENV_AS_BASE_URL, AS_BASE + "/")
+    tx.exchange_token_sync(_subject(), "res")
+    assert fake_http["sync_calls"][0]["url"] == f"{AS_BASE}/oauth/token"
+
+
+# --- cache -------------------------------------------------------------------
+
+def test_cache_per_sub_and_resource(enabled, fake_http):
+    alice = _subject("alice@x")
+    bob = _subject("bob@x")
+
+    tx.exchange_token_sync(alice, "res-a")
+    tx.exchange_token_sync(alice, "res-a")  # cached — no new call
+    assert len(fake_http["sync_calls"]) == 1
+
+    tx.exchange_token_sync(alice, "res-b")  # different resource
+    assert len(fake_http["sync_calls"]) == 2
+
+    tx.exchange_token_sync(bob, "res-a")    # different subject
+    assert len(fake_http["sync_calls"]) == 3
+
+
+def test_cache_expiry_refresh(enabled, fake_http, monkeypatch):
+    clock = {"t": 1000.0}
+    monkeypatch.setattr(tx.time, "monotonic", lambda: clock["t"])
+    sub = _subject()
+    fake_http["handler"] = lambda url, data: FakeResp(payload={"access_token": "AS_TOKEN", "expires_in": 300})
+
+    tx.exchange_token_sync(sub, "res")             # stores expiry at 1000+300-30 = 1270
+    assert len(fake_http["sync_calls"]) == 1
+
+    clock["t"] = 1269.0                             # still valid
+    tx.exchange_token_sync(sub, "res")
+    assert len(fake_http["sync_calls"]) == 1
+
+    clock["t"] = 1271.0                             # past skew-adjusted expiry
+    tx.exchange_token_sync(sub, "res")
+    assert len(fake_http["sync_calls"]) == 2
+
+
+def test_no_expiry_is_not_cached(enabled, fake_http):
+    sub = _subject()
+    fake_http["handler"] = lambda url, data: FakeResp(payload={"access_token": "AS_TOKEN"})
+    tx.exchange_token_sync(sub, "res")
+    tx.exchange_token_sync(sub, "res")
+    assert len(fake_http["sync_calls"]) == 2  # no expires_in -> not cached, refetched
+
+
+# --- error mapping -----------------------------------------------------------
+
+def test_non_200_raises(enabled, fake_http):
+    fake_http["handler"] = lambda url, data: FakeResp(status_code=400, payload={}, text="invalid_grant")
+    with pytest.raises(tx.TokenExchangeError) as ei:
+        tx.exchange_token_sync(_subject(), "res")
+    assert "400" in str(ei.value)
+
+
+def test_missing_access_token_raises(enabled, fake_http):
+    fake_http["handler"] = lambda url, data: FakeResp(payload={"token_type": "Bearer"})
+    with pytest.raises(tx.TokenExchangeError):
+        tx.exchange_token_sync(_subject(), "res")
+
+
+def test_non_json_body_raises(enabled, fake_http):
+    fake_http["handler"] = lambda url, data: FakeResp(payload=_NO_JSON)
+    with pytest.raises(tx.TokenExchangeError):
+        tx.exchange_token_sync(_subject(), "res")
+
+
+def test_network_error_raises(enabled, fake_http):
+    def boom(url, data):
+        raise httpx.ConnectError("down")
+    fake_http["handler"] = boom
+    with pytest.raises(tx.TokenExchangeError):
+        tx.exchange_token_sync(_subject(), "res")
+
+
+def test_bad_subject_token_raises(enabled, fake_http):
+    with pytest.raises(tx.TokenExchangeError):
+        tx.exchange_token_sync("not-a-jwt", "res")
+
+
+def test_subject_without_sub_raises(enabled, fake_http):
+    token = jwt.encode({"foo": "bar"}, "x" * 32, algorithm="HS256")
+    with pytest.raises(tx.TokenExchangeError):
+        tx.exchange_token_sync(token, "res")
+
+
+# --- sync / async parity + shared cache --------------------------------------
+
+@pytest.mark.asyncio
+async def test_async_exchange_returns_token(enabled, fake_http):
+    out = await tx.exchange_token(_subject(), "res")
+    assert out == "AS_TOKEN"
+    assert len(fake_http["async_calls"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_cache_shared_across_sync_and_async(enabled, fake_http):
+    sub = _subject()
+    await tx.exchange_token(sub, "res")          # fills cache via async
+    assert len(fake_http["async_calls"]) == 1
+
+    tx.exchange_token_sync(sub, "res")           # served from the same cache
+    assert len(fake_http["sync_calls"]) == 0


### PR DESCRIPTION
For bond-mcps-managed MCPs, bond-ai now exchanges its HS256 Bond JWT at the bond-mcps Authorization Server for a scoped access token instead of presenting the HS256 JWT directly. Fully inert unless BOND_MCPS_AS_BASE_URL is set — the local dev-combined-jwt (HS256-direct) flow is unchanged.

- New bondable/bond/mcp_token_exchange.py: sync + async POST {AS}/oauth/token token-exchange with a thread-safe cache keyed by (subject sub, resource), reused until 30s before expiry; is_exchange_enabled()/reset_cache() helpers.
- mcp_connect_client: _bearer_for() exchanges the JWT (when enabled) before ticket/status/delete; exchange failure maps to ConnectError.
- BedrockMCP: managed bond_jwt servers exchange the token they'd otherwise send; on exchange failure send NO Authorization header (never leak HS256 to a managed pod). Non-managed/disabled unchanged. Blocking exchange moved off the event loop via asyncio.to_thread at both async call sites.
- verify-combined-stack.sh: check 8 exercises the exchange round-trip when BOND_MCPS_AS_BASE_URL is set, else SKIPs (HS256-direct mode).
- Tests: new test_mcp_token_exchange.py; extended connect-client and managed-runtime tests.