### PR TITLE
feat(deploy): B4 — delegation env vars for discovery + token exchange

### DIFF
--- a/deployment/terraform-existing-vpc/backend.tf
+++ b/deployment/terraform-existing-vpc/backend.tf
@@ -69,6 +69,11 @@ locals {
     # Bedrock Guardrails
     BEDROCK_GUARDRAIL_ID      = var.enable_guardrails ? aws_bedrock_guardrail.main[0].guardrail_id : ""
     BEDROCK_GUARDRAIL_VERSION = var.enable_guardrails ? (var.bedrock_guardrail_version != "" ? var.bedrock_guardrail_version : aws_bedrock_guardrail_version.main[0].version) : ""
+
+    # bond-mcps managed-MCP discovery + RFC 8693 token exchange (empty = both
+    # features disabled; see docs/PLATFORM-CONTRACT.md "Auth seam")
+    BOND_MCPS_DISCOVERY_URL = var.bond_mcps_discovery_url
+    BOND_MCPS_AS_BASE_URL   = var.bond_mcps_as_base_url
   }
 }
 

--- a/deployment/terraform-existing-vpc/eks-kubernetes.tf
+++ b/deployment/terraform-existing-vpc/eks-kubernetes.tf
@@ -111,6 +111,14 @@ resource "kubernetes_config_map" "backend" {
     # Bedrock Guardrails
     BEDROCK_GUARDRAIL_ID      = var.enable_guardrails ? aws_bedrock_guardrail.main[0].guardrail_id : ""
     BEDROCK_GUARDRAIL_VERSION = var.enable_guardrails ? (var.bedrock_guardrail_version != "" ? var.bedrock_guardrail_version : aws_bedrock_guardrail_version.main[0].version) : ""
+
+    # bond-mcps managed-MCP discovery + RFC 8693 token exchange (empty = off).
+    # The in-container nginx front-door upstreams (BOND_MCPS_*_UPSTREAM) are
+    # deliberately NOT overridden here — the image defaults target the public
+    # *.mcps hostnames, which work from any platform. Switching to
+    # cluster-internal service DNS is a later optimization.
+    BOND_MCPS_DISCOVERY_URL = var.bond_mcps_discovery_url
+    BOND_MCPS_AS_BASE_URL   = var.bond_mcps_as_base_url
   }
 
   depends_on = [kubernetes_namespace.bond_ai]

--- a/deployment/terraform-existing-vpc/variables.tf
+++ b/deployment/terraform-existing-vpc/variables.tf
@@ -529,3 +529,15 @@ variable "eks_scheduled_jobs_enabled" {
   type        = bool
   default     = false
 }
+
+variable "bond_mcps_discovery_url" {
+  description = "bond-mcps managed-MCP discovery endpoint (e.g. https://auth.mcps.example.com/connections/discovery). Empty disables discovery — managed MCP tiles and delegation stay off."
+  type        = string
+  default     = ""
+}
+
+variable "bond_mcps_as_base_url" {
+  description = "bond-mcps Authorization Server origin for RFC 8693 token exchange (e.g. https://auth.mcps.example.com). Empty disables the exchange — bond-ai sends HS256 bond JWTs directly (local/dev behavior)."
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
New vars bond_mcps_discovery_url / bond_mcps_as_base_url wired into both the shared backend env map (App Runner/ECS) and the EKS ConfigMap; empty disables both features. Consume-mode/tfvars values documented in PLATFORM-CONTRACT.