### PR TITLE
Feat multi source discovery

### DIFF
--- a/.env.combined.example
+++ b/.env.combined.example
@@ -39,10 +39,13 @@ CORS_ALLOWED_ORIGINS="http://localhost,http://localhost:8000,http://localhost:30
 # Production stays secure=true by default.
 COOKIE_SECURE=false
 
-# bond-ai discovers MCPs from bond-mcps through the front door (nginx :8000 →
-# bond-mcps auth proxy :18000). One URL; bond-ai polls it so MCPs can change in
-# bond-mcps without restarting bond-ai.
-BOND_MCPS_DISCOVERY_URL="http://localhost:8000/connections/discovery"
+# bond-ai discovers MCPs from a comma-separated list of discovery sources
+# (earlier wins name collisions; each fails soft independently), polled so
+# MCPs can change upstream without restarting bond-ai:
+#   - bond-mcps through the front door (nginx :8000 → auth proxy :18000)
+#   - sbel-crm's backend on :8001 (advertises the SBEL CRM MCP with
+#     requires_connection=false → always-connected tile, no Connect flow)
+BOND_MCPS_DISCOVERY_URL="http://localhost:8000/connections/discovery,http://localhost:8001/connections/discovery"
 
 # To exercise the delegated Connect flow locally, bond-mcps must run with JWT
 # mode ON (this un-dormants its /connect/* routes) using the SHARED SECRET:

--- a/.env.example
+++ b/.env.example
@@ -97,14 +97,17 @@ FIREBASE_USER_ID="test-user-id"  # Used for testing
 # ==============================================================================
 # MCP (Model Context Protocol) CONFIGURATION (Optional)
 # ==============================================================================
-# bond-ai discovers the set of bond-mcps-managed MCP servers from bond-mcps'
-# discovery endpoint instead of hard-configuring them here. Set ONE URL; bond-ai
-# polls it periodically (TTL below) so MCPs can be added/removed in bond-mcps
-# without restarting bond-ai. When unset, discovery is disabled and only the
-# static BOND_MCP_CONFIG below is used.
+# bond-ai discovers the set of externally-hosted MCP servers from discovery
+# endpoints instead of hard-configuring them here. Comma-separated list of URLs
+# (earlier sources win name collisions; each source fails soft independently);
+# bond-ai polls them periodically (TTL below) so MCPs can be added/removed
+# upstream without restarting bond-ai. When unset, discovery is disabled and
+# only the static BOND_MCP_CONFIG below is used. Entries advertised with
+# requires_connection=false (e.g. sbel-crm) need no per-user Connect flow.
 #   local dev / combined mode: http://localhost:8000/connections/discovery
+#     (append ,http://localhost:8001/connections/discovery for sbel-crm)
 #   deployed (same EKS cluster): http://auth.<namespace>.svc.cluster.local:8000/connections/discovery
-# BOND_MCPS_DISCOVERY_URL="http://localhost:8000/connections/discovery"
+# BOND_MCPS_DISCOVERY_URL="http://localhost:8000/connections/discovery,http://localhost:8001/connections/discovery"
 # BOND_MCPS_DISCOVERY_TTL_SECONDS=300       # cache/poll interval (default 300)
 # BOND_MCPS_DISCOVERY_TIMEOUT_SECONDS=5     # per-request HTTP timeout (default 5)
 #

--- a/bondable/bond/config.py
+++ b/bondable/bond/config.py
@@ -504,16 +504,21 @@ class Config:
             return {"mcpServers": {}}
 
     def _overlay_discovered_mcps(self, mcp_config):
-        """Overlay bond-mcps discovery results onto the static MCP config.
+        """Overlay discovery results onto the static MCP config.
 
-        For each discovered MCP (``{name, display_name, url}``) the merged server
-        entry uses the discovered ``url``/``display_name`` and is forced to
-        ``auth_type=bond_jwt`` + ``transport=streamable-http`` (bond-mcps owns its
-        OAuth). Any non-OAuth annotations already present in the static config for
-        that name (e.g. ``description``, ``icon_url``, ``allowed_tools``) are
-        preserved; a stale inline ``oauth_config`` is dropped. Servers not present
-        in discovery (user-defined live in the DB, not here; ``command`` servers
-        like ``hello``) are left untouched. No-op when discovery is disabled.
+        For each discovered MCP (``{name, display_name, url, requires_connection}``)
+        the merged server entry uses the discovered ``url``/``display_name`` and is
+        forced to ``auth_type=bond_jwt`` + ``transport=streamable-http``. Entries
+        with ``requires_connection=true`` (the default — all bond-mcps MCPs) are
+        marked ``is_managed``: their per-user connection status is delegated to the
+        advertising service. ``requires_connection=false`` entries (e.g. sbel-crm)
+        are internal bond_jwt servers — authorized by the Bond JWT for any
+        signed-in user, always connected. Any non-OAuth annotations already present
+        in the static config for that name (e.g. ``description``, ``icon_url``,
+        ``allowed_tools``) are preserved; a stale inline ``oauth_config`` is
+        dropped. Servers not present in discovery (user-defined live in the DB,
+        not here; ``command`` servers like ``hello``) are left untouched. No-op
+        when discovery is disabled.
         """
         try:
             from bondable.bond.mcp_discovery import get_discovered_mcps
@@ -532,19 +537,29 @@ class Config:
         for entry in discovered:
             name = entry["name"]
             existing = dict(servers.get(name, {}))
-            # Drop any stale inline OAuth config — bond-mcps owns OAuth now.
+            # Drop any stale inline OAuth config — the advertising service owns
+            # OAuth now.
             existing.pop("oauth_config", None)
             existing.update({
                 "url": entry["url"],
                 "display_name": entry.get("display_name", existing.get("display_name", name)),
                 "transport": "streamable-http",
                 "auth_type": "bond_jwt",
-                # Marks a bond-mcps-managed MCP: bond_jwt auth, but its per-user
-                # connection status is delegated (queried via bond-mcps'
+            })
+            if entry.get("requires_connection", True):
+                # Marks a managed MCP: bond_jwt auth, but its per-user
+                # connection status is delegated (queried via the advertiser's
                 # /connect/<name>/status), NOT "always connected" like internal
                 # bond_jwt servers (sbelcrm, admin, common).
-                "is_managed": True,
-            })
+                existing["is_managed"] = True
+            else:
+                # Internal bond_jwt server: authorized by the Bond JWT for any
+                # signed-in user — no per-user connect flow, always connected.
+                existing.pop("is_managed", None)
+            # Static annotation wins; discovery fills the gap for servers that
+            # have no static entry.
+            if entry.get("description") and not existing.get("description"):
+                existing["description"] = entry["description"]
             servers[name] = existing
 
         result = dict(mcp_config)

--- a/bondable/bond/mcp_discovery.py
+++ b/bondable/bond/mcp_discovery.py
@@ -207,6 +207,7 @@ class _DiscoveryCache:
     def __init__(self) -> None:
         self._lock = threading.Lock()
         self._sources: Dict[str, _SourceState] = {}
+        self._warned_collisions: set = set()
         self._poller: Optional[threading.Thread] = None
         self._poller_stop: Optional[threading.Event] = None
 
@@ -214,6 +215,7 @@ class _DiscoveryCache:
         """Clear cached state (primarily for tests)."""
         with self._lock:
             self._sources = {}
+            self._warned_collisions = set()
 
     def _merge_locked(self, urls: List[str]) -> List[Dict[str, Any]]:
         """Merge cached entries across sources in configured order.
@@ -227,10 +229,15 @@ class _DiscoveryCache:
             for entry in (state.entries if state else None) or []:
                 name = entry["name"]
                 if name in claimed:
-                    LOGGER.warning(
-                        "Discovered MCP %r from %s shadowed by earlier source %s",
-                        name, url, claimed[name],
-                    )
+                    # Merges run on every cached read — warn once per
+                    # collision, not once per request.
+                    key = (name, url)
+                    if key not in self._warned_collisions:
+                        self._warned_collisions.add(key)
+                        LOGGER.warning(
+                            "Discovered MCP %r from %s shadowed by earlier source %s",
+                            name, url, claimed[name],
+                        )
                     continue
                 claimed[name] = url
                 merged.append(dict(entry))
@@ -257,10 +264,16 @@ class _DiscoveryCache:
                     for u in urls
                 ):
                     return self._merge_locked(urls)
+            # Refresh whatever isn't fresh — under force_refresh too (the
+            # poller path). At the poller's TTL cadence every source is past
+            # its TTL by the time the tick fires, so skipping fresh sources
+            # only matters during the fast startup-retry window: there it
+            # stops a never-succeeding source from dragging the healthy ones
+            # into being refetched every STARTUP_RETRY_SECONDS.
             stale = [
                 u for u in urls
                 if not (self._sources.get(u) is not None and self._sources[u].is_fresh())
-            ] if not force_refresh else list(urls)
+            ]
 
         # Fetch outside the lock so a slow endpoint doesn't block other readers.
         for url in stale:

--- a/bondable/bond/mcp_discovery.py
+++ b/bondable/bond/mcp_discovery.py
@@ -1,26 +1,38 @@
 """MCP discovery client.
 
 bond-ai no longer hard-configures the list of MCP servers and their endpoints.
-Instead it fetches the set of available MCPs from bond-mcps' discovery endpoint
-(``GET <BOND_MCPS_DISCOVERY_URL>``), which returns::
+Instead it fetches the set of available MCPs from one or more discovery
+endpoints (``GET <url>`` for each URL in ``BOND_MCPS_DISCOVERY_URL``), each of
+which returns::
 
     {"mcps": [{"name": "atlassian", "display_name": "Atlassian",
                "url": "http://localhost:18003/mcp"}, ...]}
 
-Everything beyond the endpoint URL (tools, auth, capabilities) is learned via the
-MCP protocol itself. Discovery only answers "which MCPs exist and where".
+Entries may carry two optional fields (see docs/PLATFORM-CONTRACT.md):
 
-Results are cached in-process with a TTL and refreshed lazily on access (and
-optionally by a background poller started at app startup) so MCPs can be added or
-removed in bond-mcps **without restarting bond-ai**. On any fetch error or an
-empty response the client *fails soft*: it returns the last good result if one is
-cached, otherwise an empty list, and callers fall back to whatever static MCP
-config bond-ai still carries.
+- ``requires_connection`` (bool, default ``true``) — ``true`` means the user
+  must run a per-provider connect flow, delegated to the advertising service
+  (bond-mcps' /connect routes); ``false`` means the MCP is authorized by the
+  Bond JWT for any signed-in user (e.g. sbel-crm) and needs no connect flow.
+- ``description`` — human-readable blurb, passed through to the UI.
+
+Everything beyond that (tools, auth, capabilities) is learned via the MCP
+protocol itself. Discovery only answers "which MCPs exist and where".
+
+Results are cached in-process per source with a TTL and refreshed lazily on
+access (and optionally by a background poller started at app startup) so MCPs
+can be added or removed upstream **without restarting bond-ai**. Each source
+*fails soft* independently: on a fetch error it keeps that source's last good
+result (or contributes nothing if it never succeeded) without affecting the
+other sources, and callers fall back to whatever static MCP config bond-ai
+still carries. When two sources advertise the same ``name``, the earlier URL
+in the configured list wins and a warning is logged.
 
 Configuration (all via environment):
 
-- ``BOND_MCPS_DISCOVERY_URL`` — full discovery URL. When unset, discovery is
-  disabled and :func:`get_discovered_mcps` returns ``[]`` (pure static config).
+- ``BOND_MCPS_DISCOVERY_URL`` — comma-separated list of discovery URLs. When
+  unset, discovery is disabled and :func:`get_discovered_mcps` returns ``[]``
+  (pure static config).
 - ``BOND_MCPS_DISCOVERY_TTL_SECONDS`` — cache TTL (default 300).
 - ``BOND_MCPS_DISCOVERY_TIMEOUT_SECONDS`` — per-request HTTP timeout (default 5).
 """
@@ -71,10 +83,20 @@ class DiscoveryError(Exception):
     """Raised internally when a discovery fetch cannot be completed."""
 
 
-def get_discovery_url() -> Optional[str]:
-    """Return the configured discovery URL, or ``None`` if discovery is off."""
-    url = os.environ.get(ENV_DISCOVERY_URL, "").strip()
-    return url or None
+def get_discovery_urls() -> List[str]:
+    """Return the configured discovery URLs (possibly empty when discovery is off).
+
+    ``BOND_MCPS_DISCOVERY_URL`` is a comma-separated list; whitespace around
+    entries is ignored, empties are dropped, and duplicates are removed while
+    preserving order (order matters: earlier sources win name collisions).
+    """
+    raw = os.environ.get(ENV_DISCOVERY_URL, "")
+    urls: List[str] = []
+    for part in raw.split(","):
+        url = part.strip()
+        if url and url not in urls:
+            urls.append(url)
+    return urls
 
 
 def _get_ttl_seconds() -> float:
@@ -108,7 +130,7 @@ def _validate_url_ssrf(url: str) -> None:
         pass  # not an IP literal — exact-match check above is sufficient
 
 
-def _parse_response(payload: Any) -> List[Dict[str, str]]:
+def _parse_response(payload: Any) -> List[Dict[str, Any]]:
     """Coerce a discovery response into a clean list of MCP entries.
 
     Malformed entries (missing ``name``/``url`` or wrong types) are skipped so a
@@ -120,7 +142,7 @@ def _parse_response(payload: Any) -> List[Dict[str, str]]:
     if not isinstance(raw, list):
         raise DiscoveryError("discovery response missing 'mcps' list")
 
-    entries: List[Dict[str, str]] = []
+    entries: List[Dict[str, Any]] = []
     for item in raw:
         if not isinstance(item, dict):
             continue
@@ -143,39 +165,80 @@ def _parse_response(payload: Any) -> List[Dict[str, str]]:
         display_name = item.get("display_name")
         if not isinstance(display_name, str) or not display_name.strip():
             display_name = name
-        entries.append({
+        entry: Dict[str, Any] = {
             "name": name.strip(),
             "display_name": display_name.strip(),
             "url": url,
-        })
+            # Only a literal JSON `false` opts an MCP out of the per-user
+            # connect flow; anything else (absent, non-bool) keeps the safe
+            # default of a managed connection.
+            "requires_connection": item.get("requires_connection") is not False,
+        }
+        description = item.get("description")
+        if isinstance(description, str) and description.strip():
+            entry["description"] = description.strip()
+        entries.append(entry)
     return entries
 
 
+class _SourceState:
+    """Last-good entries and fetch time for a single discovery URL."""
+
+    __slots__ = ("entries", "fetched_at")
+
+    def __init__(self) -> None:
+        self.entries: Optional[List[Dict[str, Any]]] = None
+        self.fetched_at: float = 0.0
+
+    def is_fresh(self) -> bool:
+        return (
+            self.entries is not None
+            and (time.monotonic() - self.fetched_at) < _get_ttl_seconds()
+        )
+
+
 class _DiscoveryCache:
-    """Thread-safe TTL cache for discovered MCP entries with fail-soft refresh."""
+    """Thread-safe per-source TTL cache for discovered MCP entries.
+
+    Each configured discovery URL fails soft independently: a fetch error keeps
+    that source's last good entries without affecting the others.
+    """
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._entries: Optional[List[Dict[str, str]]] = None
-        self._fetched_at: float = 0.0
+        self._sources: Dict[str, _SourceState] = {}
         self._poller: Optional[threading.Thread] = None
         self._poller_stop: Optional[threading.Event] = None
 
     def reset(self) -> None:
         """Clear cached state (primarily for tests)."""
         with self._lock:
-            self._entries = None
-            self._fetched_at = 0.0
+            self._sources = {}
 
-    def _is_fresh(self) -> bool:
-        return (
-            self._entries is not None
-            and (time.monotonic() - self._fetched_at) < _get_ttl_seconds()
-        )
+    def _merge_locked(self, urls: List[str]) -> List[Dict[str, Any]]:
+        """Merge cached entries across sources in configured order.
 
-    def get(self, force_refresh: bool = False) -> List[Dict[str, str]]:
-        url = get_discovery_url()
-        if not url:
+        Earlier sources win name collisions (callers must hold ``self._lock``).
+        """
+        merged: List[Dict[str, Any]] = []
+        claimed: Dict[str, str] = {}
+        for url in urls:
+            state = self._sources.get(url)
+            for entry in (state.entries if state else None) or []:
+                name = entry["name"]
+                if name in claimed:
+                    LOGGER.warning(
+                        "Discovered MCP %r from %s shadowed by earlier source %s",
+                        name, url, claimed[name],
+                    )
+                    continue
+                claimed[name] = url
+                merged.append(dict(entry))
+        return merged
+
+    def get(self, force_refresh: bool = False) -> List[Dict[str, Any]]:
+        urls = get_discovery_urls()
+        if not urls:
             return []
 
         with self._lock:
@@ -189,24 +252,36 @@ class _DiscoveryCache:
                 # Without a poller (scripts/CLI, off the event loop) lazy fetch is
                 # the right behaviour, so we only short-circuit when one is alive.
                 poller_active = self._poller is not None and self._poller.is_alive()
-                if poller_active or self._is_fresh():
-                    return list(self._entries or [])
+                if poller_active or all(
+                    self._sources.get(u) is not None and self._sources[u].is_fresh()
+                    for u in urls
+                ):
+                    return self._merge_locked(urls)
+            stale = [
+                u for u in urls
+                if not (self._sources.get(u) is not None and self._sources[u].is_fresh())
+            ] if not force_refresh else list(urls)
 
         # Fetch outside the lock so a slow endpoint doesn't block other readers.
-        try:
-            entries = self._fetch(url)
-        except DiscoveryError as exc:
-            LOGGER.warning("MCP discovery fetch failed (%s); failing soft", exc)
+        for url in stale:
+            try:
+                entries = self._fetch(url)
+            except DiscoveryError as exc:
+                # Keep this source's last good entries (or nothing if it never
+                # succeeded); other sources are unaffected.
+                LOGGER.warning(
+                    "MCP discovery fetch from %s failed (%s); failing soft", url, exc
+                )
+                continue
             with self._lock:
-                # Serve the last good result if we have one, else empty.
-                return list(self._entries or [])
+                state = self._sources.setdefault(url, _SourceState())
+                state.entries = entries
+                state.fetched_at = time.monotonic()
 
         with self._lock:
-            self._entries = entries
-            self._fetched_at = time.monotonic()
-            return list(entries)
+            return self._merge_locked(urls)
 
-    def _fetch(self, url: str) -> List[Dict[str, str]]:
+    def _fetch(self, url: str) -> List[Dict[str, Any]]:
         _validate_url_ssrf(url)
         try:
             resp = httpx.get(url, timeout=_get_timeout_seconds())  # nosec B113 - timeout always set (defaults to 5s)
@@ -219,9 +294,13 @@ class _DiscoveryCache:
         return entries
 
     def _next_poll_interval(self) -> float:
-        """Poll cadence: fast retry until the first successful fetch lands."""
+        """Poll cadence: fast retry until every source's first fetch lands."""
+        urls = get_discovery_urls()
         with self._lock:
-            never_fetched = self._entries is None
+            never_fetched = any(
+                self._sources.get(u) is None or self._sources[u].entries is None
+                for u in urls
+            )
         ttl = _get_ttl_seconds()
         return min(STARTUP_RETRY_SECONDS, ttl) if never_fetched else ttl
 
@@ -236,7 +315,7 @@ class _DiscoveryCache:
         that boots before its discovery upstream recovers in seconds, not a
         full TTL.
         """
-        if not get_discovery_url():
+        if not get_discovery_urls():
             return
         with self._lock:
             if self._poller is not None and self._poller.is_alive():
@@ -269,11 +348,12 @@ class _DiscoveryCache:
 _CACHE = _DiscoveryCache()
 
 
-def get_discovered_mcps(force_refresh: bool = False) -> List[Dict[str, str]]:
-    """Return the available MCPs from bond-mcps discovery.
+def get_discovered_mcps(force_refresh: bool = False) -> List[Dict[str, Any]]:
+    """Return the available MCPs merged across all configured discovery sources.
 
-    Returns a list of ``{"name", "display_name", "url"}`` dicts (possibly empty).
-    Never raises: a discovery outage degrades to the last good result or ``[]``.
+    Returns a list of ``{"name", "display_name", "url", "requires_connection"
+    [, "description"]}`` dicts (possibly empty). Never raises: a source outage
+    degrades to that source's last good result without affecting the others.
     """
     return _CACHE.get(force_refresh=force_refresh)
 

--- a/bondable/rest/routers/connections.py
+++ b/bondable/rest/routers/connections.py
@@ -61,6 +61,9 @@ class ConnectionStatusResponse(BaseModel):
     has_refresh_token: bool = False
     is_user_defined: bool = False
     user_server_id: Optional[str] = None
+    # False for MCPs authorized by the Bond JWT for any signed-in user (e.g.
+    # sbel-crm): always connected, no Connect/Disconnect action in the UI.
+    requires_connection: bool = True
 
 
 class ConnectionsListResponse(BaseModel):
@@ -231,15 +234,22 @@ def _get_connection_config(connection_name: str, user_id: Optional[str] = None) 
 # them as connectable tiles, but authorize/status/disconnect proxy to bond-mcps.
 
 def _get_managed_connection_configs() -> List[Dict[str, Any]]:
-    """Return discovered bond-mcps-managed MCPs as connection-config dicts."""
+    """Return discovered managed MCPs as connection-config dicts.
+
+    Entries advertised with ``requires_connection: false`` are internal bond_jwt
+    servers (no per-user connect flow) — see
+    :func:`_get_internal_discovered_configs`.
+    """
     configs = []
     for entry in get_discovered_mcps():
+        if entry.get("requires_connection", True) is False:
+            continue
         name = entry["name"]
         display_name = entry.get("display_name", name.title())
         configs.append({
             "name": name,
             "display_name": display_name,
-            "description": f"Connect to {display_name}",
+            "description": entry.get("description") or f"Connect to {display_name}",
             "url": entry["url"],
             "auth_type": "bond_jwt",
             "is_managed": True,
@@ -247,6 +257,56 @@ def _get_managed_connection_configs() -> List[Dict[str, Any]]:
             "icon_url": None,
         })
     return configs
+
+
+def _get_internal_discovered_configs() -> List[Dict[str, Any]]:
+    """Return discovered internal (``requires_connection: false``) MCPs.
+
+    These are authorized by the Bond JWT for any signed-in user (e.g. sbel-crm):
+    always connected, nothing to authorize or disconnect. They get an
+    informational tile on the Connections page.
+    """
+    configs = []
+    for entry in get_discovered_mcps():
+        if entry.get("requires_connection", True) is not False:
+            continue
+        name = entry["name"]
+        display_name = entry.get("display_name", name.title())
+        configs.append({
+            "name": name,
+            "display_name": display_name,
+            "description": entry.get("description"),
+            "url": entry["url"],
+            "auth_type": "bond_jwt",
+            "is_user_defined": False,
+            "icon_url": None,
+        })
+    return configs
+
+
+def _get_internal_discovered(connection_name: str) -> Optional[Dict[str, Any]]:
+    """Get a specific internal (always-connected) discovered MCP, or None."""
+    for config in _get_internal_discovered_configs():
+        if config["name"] == connection_name:
+            return config
+    return None
+
+
+def _internal_connection_response(config: Dict[str, Any]) -> ConnectionStatusResponse:
+    """Always-connected status for an internal discovered MCP."""
+    name = config["name"]
+    return ConnectionStatusResponse(
+        name=name,
+        display_name=config.get("display_name", name.title()),
+        description=config.get("description"),
+        connected=True,
+        valid=True,
+        auth_type="bond_jwt",
+        icon_url=config.get("icon_url"),
+        requires_authorization=False,
+        is_user_defined=False,
+        requires_connection=False,
+    )
 
 
 def _get_managed_connection(connection_name: str) -> Optional[Dict[str, Any]]:
@@ -429,6 +489,12 @@ async def list_connections(
                 "expires_at": mcps_status.get("expires_at"),
             })
 
+    # --- Internal discovered connections (always connected) ----------------
+    # No per-user state to query: the Bond JWT authorizes any signed-in user,
+    # so these render as informational "Connected" tiles and never expire.
+    for config in _get_internal_discovered_configs():
+        connections.append(_internal_connection_response(config))
+
     # --- Legacy / user-defined OAuth2 connections --------------------------
     configs = _get_connection_configs(user_id=current_user.user_id)
 
@@ -493,6 +559,13 @@ async def authorize_connection(
     bond-ai builds the provider authorize URL itself (unchanged).
     """
     current_user, jwt_token = user_and_token
+
+    # --- Internal discovered connection: nothing to authorize --------------
+    if _get_internal_discovered(connection_name) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Connection '{connection_name}' does not require authorization",
+        )
 
     # --- Managed (bond-mcps-delegated) connection --------------------------
     managed = _get_managed_connection(connection_name)
@@ -762,6 +835,11 @@ async def get_connection_status(
     current_user, jwt_token = user_and_token
     LOGGER.debug(f"[Connections] Checking status of {connection_name} for user {current_user.email}")
 
+    # --- Internal discovered connection: always connected -------------------
+    internal = _get_internal_discovered(connection_name)
+    if internal is not None:
+        return _internal_connection_response(internal)
+
     # --- Managed (bond-mcps-delegated) connection --------------------------
     managed = _get_managed_connection(connection_name)
     if managed is not None:
@@ -839,6 +917,13 @@ async def disconnect(
     """
     current_user, jwt_token = user_and_token
     LOGGER.info(f"User {current_user.email} disconnecting from {connection_name}")
+
+    # --- Internal discovered connection: nothing to disconnect --------------
+    if _get_internal_discovered(connection_name) is not None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Connection '{connection_name}' cannot be disconnected",
+        )
 
     # --- Managed (bond-mcps-delegated) connection --------------------------
     managed = _get_managed_connection(connection_name)

--- a/deployment/terraform-existing-vpc/variables.tf
+++ b/deployment/terraform-existing-vpc/variables.tf
@@ -531,7 +531,7 @@ variable "eks_scheduled_jobs_enabled" {
 }
 
 variable "bond_mcps_discovery_url" {
-  description = "bond-mcps managed-MCP discovery endpoint (e.g. https://auth.mcps.example.com/connections/discovery). Empty disables discovery — managed MCP tiles and delegation stay off."
+  description = "Comma-separated MCP discovery endpoints (e.g. https://auth.mcps.example.com/connections/discovery,https://crm.example.com/connections/discovery). Earlier sources win name collisions. Empty disables discovery — managed MCP tiles and delegation stay off."
   type        = string
   default     = ""
 }

--- a/docs/PLATFORM-CONTRACT.md
+++ b/docs/PLATFORM-CONTRACT.md
@@ -1,9 +1,10 @@
-# Platform Contract: shared EKS cluster (bond-ai + bond-mcps)
+# Platform Contract: shared EKS cluster (bond-ai + bond-mcps + sbel-crm)
 
-This document is the cross-repo contract between **bond-ai** and **bond-mcps**.
-An identical copy lives in both repos (`docs/PLATFORM-CONTRACT.md`). Any change
-to a value below is a breaking change for the other repo: update both copies in
-the same change window, and coordinate applies.
+This document is the cross-repo contract between **bond-ai**, **bond-mcps**,
+and **sbel-crm**. An identical copy lives in all three repos
+(`docs/PLATFORM-CONTRACT.md`). Any change to a value below is a breaking
+change for the other repos: update all copies in the same change window, and
+coordinate applies.
 
 ## Ownership
 
@@ -11,15 +12,17 @@ the same change window, and coordinate applies.
 |---|---|
 | EKS cluster (`bond-platform-dev`), node group, KMS | **bond-mcps** Terraform (`deployment/terraform-existing-vpc/`) |
 | Cluster addons: AWS Load Balancer Controller, External Secrets Operator | **bond-mcps** Terraform |
-| Shared ALB (via IngressGroup `bond-platform`) | AWS LB Controller (reconciled from both repos' Ingresses) |
-| Namespace `bond-mcps` + its 5 services | bond-mcps |
+| Shared ALB (via IngressGroup `bond-platform`) | AWS LB Controller (reconciled from all repos' Ingresses) |
+| Namespace `bond-mcps` + its services | bond-mcps |
 | Namespace `bond-ai` + the combined container workload | **bond-ai** Terraform, in "external cluster consume mode" (`eks_existing_cluster_name`) |
+| Namespace `sbel-crm` + the combined container workload | **sbel-crm** Terraform (`deployment/terraform/`), consume mode like bond-ai |
 | Route53 `ai.southbayequity.cloud` (apex A-alias) | bond-ai |
 | Route53 `*.mcps.ai.southbayequity.cloud` | bond-mcps |
+| Route53 `crm.southbayequity.cloud` (apex A-alias) | sbel-crm |
 
-bond-ai must NOT install a second LB controller or ESO. bond-mcps must not
-rename or destroy the cluster without a coordinated window (bond-ai's
-`terraform plan` breaks silently otherwise).
+bond-ai and sbel-crm must NOT install a second LB controller or ESO. bond-mcps
+must not rename or destroy the cluster without a coordinated window (the
+consumers' `terraform plan` breaks silently otherwise).
 
 ## Pinned values
 
@@ -28,9 +31,10 @@ rename or destroy the cluster without a coordinated window (bond-ai's
 | Cluster name | `bond-platform-dev` |
 | Region / VPC | `us-west-2` / `vpc-0a10b710daf789382` |
 | IngressGroup (`alb.ingress.kubernetes.io/group.name`) | `bond-platform` |
-| group.order allocation | auth-server = `1`, per-MCP services = `10`, bond-ai = `20` |
-| Node security group | bond-mcps output `node_security_group_id`; bond-ai pins it in tfvars as `eks_external_node_security_group_id` (both repos use local tfstate — no remote-state lookup) |
-| ALB idle timeout | `300s` (set group-wide from bond-ai's Ingress; required for SSE) |
+| group.order allocation | auth-server = `1`, per-MCP services = `10`, bond-ai = `20`, sbel-crm = `30` |
+| Node security group | bond-mcps output `node_security_group_id`; bond-ai and sbel-crm pin it in tfvars as `eks_external_node_security_group_id` (all repos use their own tfstate — no remote-state lookup) |
+| ALB idle timeout | `300s` (set group-wide from bond-ai's Ingress **only** — no other member may set `alb.ingress.kubernetes.io/load-balancer-attributes`; conflicting group-wide attributes break reconciliation. Required for SSE) |
+| Aurora access | each consumer's own Aurora SG allows 5432 from the node SG (sbel-crm: inline rule in its `security.tf`; bond-mcps: rule in its `eks.tf`) |
 
 ## In-cluster service DNS (consumed by bond-ai's nginx front door)
 
@@ -54,10 +58,28 @@ breaks bond-ai's nginx upstreams — treat service keys as part of this contract
 | Exchange | RFC 8693 on `POST {AS}/oauth/token`, `client_id=bond-ai`, `resource=<mcp url>`; AS resolves email → Cognito sub (pool of client `4uog2crm587odi3pb39e7b8726`) |
 | Browser front door | `https://ai.southbayequity.cloud` — `BOND_MCPS_CONNECT_PUBLIC_URL` on every MCP pod; bond-ai nginx routes `/connect/<p>/*`, `/connections/<p>/callback`, `/connections/discovery` to the services above |
 
+## MCP discovery
+
+bond-ai learns which MCPs exist from one or more discovery endpoints
+(`BOND_MCPS_DISCOVERY_URL` is a **comma-separated list**; earlier sources win
+name collisions, and each source fails soft independently).
+
+| Key | Value |
+|---|---|
+| Endpoint contract | `GET <base>/connections/discovery` → `{"mcps": [{"name", "display_name", "url", "description"?, "requires_connection"?}]}` (unauthenticated) |
+| `requires_connection` | default `true` = managed: per-user connect flow delegated to the advertising service (`/connect/<name>/*`). `false` = authorized by the Bond JWT for any signed-in user — always connected, no connect flow (informational tile in bond-ai) |
+| Sources (deployed) | bond-mcps AS `https://auth.mcps.ai.southbayequity.cloud/connections/discovery`, sbel-crm `https://crm.southbayequity.cloud/connections/discovery` |
+| Sources (local combined mode) | `http://localhost:8000/connections/discovery` (bond-ai nginx → bond-mcps proxy :18000), `http://localhost:8001/connections/discovery` (sbel-crm backend) |
+| sbel-crm advertised URL | `MCP_PUBLIC_URL` env on the sbel-crm pod (`https://crm.southbayequity.cloud/mcp/` — trailing slash; nginx `location = /mcp` 308-redirects the bare path) |
+
+An MCP's `name` is a cross-repo identifier (bond-ai merges discovery onto its
+static config by name) — renaming an advertised MCP is a breaking change.
+
 ## Change process
 
-1. PR the change to this doc in **both** repos first.
-2. Apply bond-mcps before bond-ai when a change affects cluster/addons;
-   reverse order when it only affects bond-ai's namespace.
+1. PR the change to this doc in **all three** repos first.
+2. Apply bond-mcps before the consumers when a change affects cluster/addons;
+   consumer-namespace-only changes need no coordination.
 3. After any bond-mcps apply that could touch the node group or ALB, run
-   `terraform plan` in bond-ai and confirm it is clean before walking away.
+   `terraform plan` in bond-ai and sbel-crm and confirm both are clean before
+   walking away.

--- a/docs/mcp-discovery-delegation-architecture.md
+++ b/docs/mcp-discovery-delegation-architecture.md
@@ -86,11 +86,21 @@ The integration is best understood as three orthogonal planes that share one ide
 (the Bond JWT) but otherwise solve independent problems.
 
 ### 2a. Discovery plane — "which MCPs exist and where"
-- bond-ai calls `GET {BOND_MCPS_DISCOVERY_URL}` → `{"mcps":[{name, display_name, url}]}`.
-- Cached in-process with a TTL and refreshed by a background poller (so MCPs can be
-  added/removed without restarting bond-ai — *with caveats in deployment, see §11*).
+- `BOND_MCPS_DISCOVERY_URL` is a **comma-separated list** of discovery sources
+  (bond-mcps, sbel-crm, …). bond-ai calls `GET <url>` on each →
+  `{"mcps":[{name, display_name, url, description?, requires_connection?}]}`.
+- Merged across sources in configured order (earlier source wins a `name`
+  collision, warned once). Cached in-process per source with a TTL and refreshed
+  by a background poller (so MCPs can be added/removed without restarting
+  bond-ai — *with caveats in deployment, see §11*); each source fails soft
+  independently to its last good result.
 - The discovered set is overlaid onto bond-ai's effective MCP config as `bond_jwt`
   servers; everything beyond the URL (tools) is learned via the MCP protocol itself.
+- `requires_connection` (default `true`) = managed: per-user Connect flow
+  delegated to the advertising service. `false` (e.g. sbel-crm) = authorized by
+  the Bond JWT for any signed-in user — never `is_managed`, always connected,
+  informational Connections tile with no Connect/Disconnect. Contract:
+  `docs/PLATFORM-CONTRACT.md` §"MCP discovery".
 
 ### 2b. Authentication plane — Bond JWT + shared secret
 - bond-ai mints **HS256** JWTs signed with `JWT_SECRET_KEY`; claims: `sub`=**email**,
@@ -242,7 +252,7 @@ Merged in **PR #201** (`170ced0` feat + `daef8f7` SSRF fix → merge `a9ad9df`).
 
 | File | Change |
 |------|--------|
-| `bondable/bond/mcp_discovery.py` | **new** — `get_discovered_mcps()`; TTL cache + background poller (`start/stop_background_poller`); SSRF-guards both the discovery URL **and each discovered MCP URL**; fail-soft to last-good/empty. Env: `BOND_MCPS_DISCOVERY_URL` / `_TTL_SECONDS` / `_TIMEOUT_SECONDS`. **Poller is the sole fetcher** — when it's alive, request threads only read cache (no blocking HTTP on the event loop). |
+| `bondable/bond/mcp_discovery.py` | **new** — `get_discovered_mcps()`; per-source TTL cache + background poller (`start/stop_background_poller`); SSRF-guards each discovery URL **and each discovered MCP URL**; each source fails soft to its last-good result independently. Env: `BOND_MCPS_DISCOVERY_URL` (comma-separated list; earlier source wins name collisions) / `_TTL_SECONDS` / `_TIMEOUT_SECONDS`. Entries carry `requires_connection` (default true = managed) + optional `description`. **Poller is the sole fetcher** — when it's alive, request threads only read cache (no blocking HTTP on the event loop); refreshes skip still-fresh sources so a dead source can't drag healthy ones into the 10s startup-retry cadence. |
 | `bondable/bond/mcp_connect_client.py` | **new** — **async** (`httpx.AsyncClient`) client for `mint_connect_ticket` / `get_connect_status` / `delete_connection`. `connect_base_url()` strips the discovered path to an origin. `_safe_name()` strips URL-control chars from the name (SSRF defense + CodeQL taint break). |
 | `bondable/bond/config.py` | `get_mcp_config()` now overlays discovered MCPs onto the static config as `bond_jwt` / `streamable-http`, dropping any stale inline `oauth_config`, preserving annotations, leaving `command`/user-defined servers untouched. No-op when discovery is disabled. |
 | `bondable/rest/routers/connections.py` | Managed (delegated) track added alongside the preserved user-defined OAuth2 path. `authorize`→mint ticket; `list`/`status`→bond-mcps status (concurrent via `asyncio.gather`, **per-MCP fail-soft**); `disconnect`→bond-mcps delete. Passes the **discovery-sourced `managed["name"]`** (not the request path param) into the client → no SSRF taint. |
@@ -356,7 +366,9 @@ trace each carefully.
    AS**. Terraform renders `discovery.json` (`{name, display_name, url: https://<prefix>.<base_domain>/mcp}`)
    from the enabled MCP services, mounts it as a ConfigMap at `/etc/bond-mcps`, and sets
    `BOND_MCPS_DISCOVERY_FILE` on the AS pod. bond-ai points
-   `BOND_MCPS_DISCOVERY_URL` → `https://auth.<base_domain>/connections/discovery`.
+   `BOND_MCPS_DISCOVERY_URL` → `https://auth.<base_domain>/connections/discovery`
+   (comma-append further sources, e.g. sbel-crm's
+   `https://crm.<domain>/connections/discovery`).
    *This file is static per deploy — see §11.2.*
 
 2. **JWT validation.** Each MCP runs with the JWT env (HS256 + shared secret, or RS256

--- a/flutterui/lib/data/models/connection_model.dart
+++ b/flutterui/lib/data/models/connection_model.dart
@@ -12,6 +12,10 @@ class ConnectionStatus {
   final bool requiresAuthorization;
   final bool hasRefreshToken;
 
+  /// False for MCPs authorized by the signed-in session itself (e.g. SBEL
+  /// CRM): always connected, no Connect/Disconnect action.
+  final bool requiresConnection;
+
   ConnectionStatus({
     required this.name,
     required this.displayName,
@@ -24,6 +28,7 @@ class ConnectionStatus {
     this.expiresAt,
     this.requiresAuthorization = false,
     this.hasRefreshToken = false,
+    this.requiresConnection = true,
   });
 
   factory ConnectionStatus.fromJson(Map<String, dynamic> json) {
@@ -39,6 +44,7 @@ class ConnectionStatus {
       expiresAt: json['expires_at'] as String?,
       requiresAuthorization: json['requires_authorization'] as bool? ?? false,
       hasRefreshToken: json['has_refresh_token'] as bool? ?? false,
+      requiresConnection: json['requires_connection'] as bool? ?? true,
     );
   }
 
@@ -54,10 +60,12 @@ class ConnectionStatus {
     'expires_at': expiresAt,
     'requires_authorization': requiresAuthorization,
     'has_refresh_token': hasRefreshToken,
+    'requires_connection': requiresConnection,
   };
 
   /// Returns true if the connection needs attention (expired without refresh token, or not connected)
-  bool get needsAttention => !connected || (!valid && !hasRefreshToken);
+  bool get needsAttention =>
+      requiresConnection && (!connected || (!valid && !hasRefreshToken));
 
   /// Human-readable status string
   String get statusText {

--- a/flutterui/lib/presentation/screens/connections/connections_screen.dart
+++ b/flutterui/lib/presentation/screens/connections/connections_screen.dart
@@ -793,7 +793,16 @@ class _ConnectionRow extends StatelessWidget {
           ),
           const SizedBox(width: 8),
           // Action buttons based on connection state
-          if (connection.connected && connection.valid)
+          if (!connection.requiresConnection)
+            // Authorized by the signed-in session itself (e.g. SBEL CRM):
+            // informational tile, nothing to connect or disconnect.
+            Text(
+              'Included',
+              style: textTheme.bodySmall?.copyWith(
+                color: colorScheme.onSurfaceVariant,
+              ),
+            )
+          else if (connection.connected && connection.valid)
             // Connected and valid: show Disconnect
             OutlinedButton(
               onPressed: onDisconnect,

--- a/flutterui/test/models/connection_model_test.dart
+++ b/flutterui/test/models/connection_model_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutterui/data/models/connection_model.dart';
+
+void main() {
+  group('ConnectionStatus.requiresConnection', () {
+    test('defaults to true when absent from JSON', () {
+      final status = ConnectionStatus.fromJson(const {
+        'name': 'atlassian',
+        'display_name': 'Atlassian',
+        'connected': false,
+        'auth_type': 'bond_jwt',
+      });
+      expect(status.requiresConnection, isTrue);
+      expect(status.needsAttention, isTrue);
+    });
+
+    test('parses false and round-trips through toJson', () {
+      final status = ConnectionStatus.fromJson(const {
+        'name': 'sbelcrm',
+        'display_name': 'SBEL CRM',
+        'connected': true,
+        'valid': true,
+        'auth_type': 'bond_jwt',
+        'requires_connection': false,
+      });
+      expect(status.requiresConnection, isFalse);
+      expect(status.toJson()['requires_connection'], isFalse);
+      expect(status.statusText, 'Connected');
+    });
+
+    test('never needs attention when no connection is required', () {
+      final status = ConnectionStatus.fromJson(const {
+        'name': 'sbelcrm',
+        'display_name': 'SBEL CRM',
+        'connected': false, // even if a stale payload says disconnected
+        'auth_type': 'bond_jwt',
+        'requires_connection': false,
+      });
+      expect(status.needsAttention, isFalse);
+    });
+  });
+}

--- a/flutterui/test/widgets/connections_screen_test.dart
+++ b/flutterui/test/widgets/connections_screen_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutterui/data/models/connection_model.dart';
+import 'package:flutterui/data/models/user_mcp_server_model.dart';
+import 'package:flutterui/data/services/user_mcp_server_service.dart';
+import 'package:flutterui/providers/connections_provider.dart';
+import 'package:flutterui/providers/services/service_providers.dart';
+import 'package:flutterui/presentation/screens/connections/connections_screen.dart';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+/// Seeded notifier: loadConnections is a no-op so initState never overwrites
+/// the canned state.
+class _FakeConnectionsNotifier extends StateNotifier<ConnectionsState>
+    implements ConnectionsNotifier {
+  _FakeConnectionsNotifier(ConnectionsState seeded) : super(seeded);
+
+  @override
+  Future<void> loadConnections() async {}
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeUserMcpServerService implements UserMcpServerService {
+  @override
+  Future<UserMcpServerListResponse> listServers() async =>
+      UserMcpServerListResponse(servers: const [], total: 0);
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+ConnectionStatus _connection({
+  required String name,
+  required String displayName,
+  bool connected = false,
+  bool requiresConnection = true,
+}) {
+  return ConnectionStatus(
+    name: name,
+    displayName: displayName,
+    connected: connected,
+    valid: true,
+    authType: 'bond_jwt',
+    requiresAuthorization: !connected,
+    requiresConnection: requiresConnection,
+  );
+}
+
+Future<void> _pumpConnectionsScreen(
+  WidgetTester tester,
+  List<ConnectionStatus> connections,
+) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        connectionsNotifierProvider.overrideWith(
+          (ref) => _FakeConnectionsNotifier(
+            ConnectionsState(connections: connections),
+          ),
+        ),
+        userMcpServerServiceProvider
+            .overrideWithValue(_FakeUserMcpServerService()),
+      ],
+      child: const MaterialApp(home: ConnectionsScreen()),
+    ),
+  );
+  await tester.pumpAndSettle();
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void main() {
+  group('ConnectionsScreen row actions', () {
+    testWidgets(
+        'internal connection (requiresConnection=false) renders an '
+        'informational tile with no Connect/Disconnect action', (tester) async {
+      await _pumpConnectionsScreen(tester, [
+        _connection(
+          name: 'sbelcrm',
+          displayName: 'SBEL CRM',
+          connected: true,
+          requiresConnection: false,
+        ),
+      ]);
+
+      expect(find.text('SBEL CRM'), findsOneWidget);
+      expect(find.text('Connected'), findsOneWidget);
+      expect(find.text('Included'), findsOneWidget);
+      expect(find.text('Connect'), findsNothing);
+      expect(find.text('Disconnect'), findsNothing);
+    });
+
+    testWidgets('managed connection still gets a Connect button when '
+        'disconnected', (tester) async {
+      await _pumpConnectionsScreen(tester, [
+        _connection(name: 'github', displayName: 'GitHub'),
+      ]);
+
+      expect(find.text('GitHub'), findsOneWidget);
+      expect(find.text('Not Connected'), findsOneWidget);
+      expect(find.text('Connect'), findsOneWidget);
+      expect(find.text('Included'), findsNothing);
+    });
+
+    testWidgets('managed connection still gets a Disconnect button when '
+        'connected', (tester) async {
+      await _pumpConnectionsScreen(tester, [
+        _connection(name: 'microsoft', displayName: 'Microsoft', connected: true),
+      ]);
+
+      expect(find.text('Microsoft'), findsOneWidget);
+      expect(find.text('Disconnect'), findsOneWidget);
+      expect(find.text('Included'), findsNothing);
+    });
+  });
+}

--- a/tests/test_connections_delegation.py
+++ b/tests/test_connections_delegation.py
@@ -31,6 +31,10 @@ TEST_USER_ID = "deleg-user-1"
 DISCOVERED = [
     {"name": "atlassian", "display_name": "Atlassian", "url": "http://localhost:18003/mcp"},
     {"name": "github", "display_name": "GitHub", "url": "http://localhost:18002/mcp"},
+    # Internal (requires_connection=false): authorized by the Bond JWT for any
+    # signed-in user — always connected, no connect flow to delegate.
+    {"name": "sbelcrm", "display_name": "SBEL CRM", "url": "http://localhost:8001/mcp",
+     "requires_connection": False, "description": "Access CRM tools"},
 ]
 
 
@@ -61,6 +65,7 @@ class _StubMcps:
     def __init__(self):
         self.connected = set()
         self.tickets = []
+        self.status_calls = []
         self.no_surface = set()  # providers that 404 (no connect flow)
 
     async def mint_connect_ticket(self, mcp_url, name, jwt_token, return_url):
@@ -69,6 +74,7 @@ class _StubMcps:
         return f"http://localhost:8000/connect/{name}?ticket=TKT&return_url={return_url}"
 
     async def get_connect_status(self, mcp_url, name, jwt_token, timeout=None):
+        self.status_calls.append(name)
         if name in self.no_surface:
             return None
         connected = name in self.connected
@@ -208,3 +214,58 @@ def test_full_connect_choreography(client, headers, stub):
 def test_managed_endpoints_require_auth(client, stub):
     assert client.get("/connections/atlassian/authorize").status_code == 401
     assert client.delete("/connections/atlassian").status_code == 401
+
+
+# --- internal (requires_connection=false) discovered MCPs -------------------
+
+def test_list_includes_internal_always_connected(client, headers, stub):
+    """Internal discovered MCPs get an informational always-connected tile,
+    with no status round-trip to the advertising service."""
+    resp = client.get("/connections", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    by_name = {c["name"]: c for c in body["connections"]}
+
+    crm = by_name["sbelcrm"]
+    assert crm["connected"] is True
+    assert crm["valid"] is True
+    assert crm["auth_type"] == "bond_jwt"
+    assert crm["requires_connection"] is False
+    assert crm["requires_authorization"] is False
+    assert crm["description"] == "Access CRM tools"
+    # Never in the expired list.
+    assert all(e["name"] != "sbelcrm" for e in body["expired"])
+    # No connect-status round-trip was made for the internal MCP.
+    assert "sbelcrm" not in stub.status_calls
+
+    # Managed entries still require a connection.
+    assert by_name["atlassian"]["requires_connection"] is True
+
+
+def test_internal_status_always_connected(client, headers, stub):
+    resp = client.get("/connections/sbelcrm/status", headers=headers)
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["connected"] is True
+    assert body["requires_connection"] is False
+
+
+def test_internal_status_skips_connect_client(client, headers, monkeypatch):
+    """Status for an internal MCP must not hit the connect client at all."""
+    async def kaboom(*a, **k):
+        raise AssertionError("connect client must not be called for internal MCPs")
+    monkeypatch.setattr(conn.mcp_connect_client, "get_connect_status", kaboom)
+    assert client.get("/connections/sbelcrm/status", headers=headers).status_code == 200
+
+
+def test_internal_authorize_rejected(client, headers, stub):
+    resp = client.get("/connections/sbelcrm/authorize", headers=headers)
+    assert resp.status_code == 400
+    assert "does not require authorization" in resp.json()["detail"]
+    assert stub.tickets == []
+
+
+def test_internal_disconnect_rejected(client, headers, stub):
+    resp = client.delete("/connections/sbelcrm", headers=headers)
+    assert resp.status_code == 400
+    assert "cannot be disconnected" in resp.json()["detail"]

--- a/tests/test_mcp_discovery.py
+++ b/tests/test_mcp_discovery.py
@@ -15,11 +15,12 @@ from bondable.bond.mcp_discovery import (
     _parse_response,
     _validate_url_ssrf,
     get_discovered_mcps,
-    get_discovery_url,
+    get_discovery_urls,
 )
 
 
 DISCOVERY_URL = "http://localhost:8000/connections/discovery"
+DISCOVERY_URL_2 = "http://localhost:8001/connections/discovery"
 
 
 class FakeResp:
@@ -60,13 +61,22 @@ def _set_response(monkeypatch, payload, calls=None):
 # --- URL config -----------------------------------------------------------
 
 def test_discovery_disabled_when_url_unset():
-    assert get_discovery_url() is None
+    assert get_discovery_urls() == []
     assert get_discovered_mcps() == []
 
 
 def test_discovery_url_read_from_env(monkeypatch):
     monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_URL, DISCOVERY_URL)
-    assert get_discovery_url() == DISCOVERY_URL
+    assert get_discovery_urls() == [DISCOVERY_URL]
+
+
+def test_discovery_urls_comma_separated(monkeypatch):
+    """Whitespace trimmed, empties dropped, duplicates removed preserving order."""
+    monkeypatch.setenv(
+        mcp_discovery.ENV_DISCOVERY_URL,
+        f" {DISCOVERY_URL} , {DISCOVERY_URL_2},, {DISCOVERY_URL} ",
+    )
+    assert get_discovery_urls() == [DISCOVERY_URL, DISCOVERY_URL_2]
 
 
 # --- Parsing --------------------------------------------------------------
@@ -82,9 +92,31 @@ def test_parse_skips_malformed_entries():
     ]}
     out = _parse_response(payload)
     assert out == [
-        {"name": "atlassian", "display_name": "Atlassian", "url": "http://h:1/mcp"},
-        {"name": "github", "display_name": "github", "url": "http://h:4/mcp"},
+        {"name": "atlassian", "display_name": "Atlassian", "url": "http://h:1/mcp",
+         "requires_connection": True},
+        {"name": "github", "display_name": "github", "url": "http://h:4/mcp",
+         "requires_connection": True},
     ]
+
+
+def test_parse_requires_connection_and_description():
+    """Only a literal false opts out of the connect flow; description passes
+    through when a non-empty string and is dropped otherwise."""
+    payload = {"mcps": [
+        {"name": "sbelcrm", "url": "http://h:1/mcp", "requires_connection": False,
+         "description": " CRM tools "},
+        {"name": "absent", "url": "http://h:2/mcp"},
+        {"name": "nonbool", "url": "http://h:3/mcp", "requires_connection": "yes"},
+        {"name": "blankdesc", "url": "http://h:4/mcp", "description": "  "},
+        {"name": "baddesc", "url": "http://h:5/mcp", "description": 42},
+    ]}
+    out = {e["name"]: e for e in _parse_response(payload)}
+    assert out["sbelcrm"]["requires_connection"] is False
+    assert out["sbelcrm"]["description"] == "CRM tools"
+    assert out["absent"]["requires_connection"] is True
+    assert out["nonbool"]["requires_connection"] is True
+    assert "description" not in out["blankdesc"]
+    assert "description" not in out["baddesc"]
 
 
 def test_parse_rejects_non_object_and_missing_list():
@@ -302,6 +334,81 @@ def test_failsoft_empty_when_no_prior_success(monkeypatch):
     assert get_discovered_mcps() == []
 
 
+# --- Multiple sources -------------------------------------------------------
+
+def _set_multi_response(monkeypatch, payloads):
+    """Install a fake httpx.get dispatching per-URL from ``payloads``.
+
+    A payload value of an Exception instance is raised instead of returned.
+    """
+    def fake_get(url, timeout=None):
+        payload = payloads[url]
+        if isinstance(payload, Exception):
+            raise payload
+        return FakeResp(payload)
+    monkeypatch.setattr(mcp_discovery.httpx, "get", fake_get)
+
+
+def test_multi_source_merge_in_configured_order(monkeypatch):
+    monkeypatch.setenv(
+        mcp_discovery.ENV_DISCOVERY_URL, f"{DISCOVERY_URL},{DISCOVERY_URL_2}")
+    _set_multi_response(monkeypatch, {
+        DISCOVERY_URL: {"mcps": [{"name": "atlassian", "url": "http://h:1/mcp"}]},
+        DISCOVERY_URL_2: {"mcps": [
+            {"name": "sbelcrm", "url": "http://h:2/mcp", "requires_connection": False}]},
+    })
+    out = get_discovered_mcps()
+    assert [m["name"] for m in out] == ["atlassian", "sbelcrm"]
+    assert out[0]["requires_connection"] is True
+    assert out[1]["requires_connection"] is False
+
+
+def test_multi_source_per_source_failsoft(monkeypatch):
+    """One source down keeps its last good entries without affecting the other;
+    a source that never succeeded contributes nothing."""
+    import httpx
+
+    monkeypatch.setenv(
+        mcp_discovery.ENV_DISCOVERY_URL, f"{DISCOVERY_URL},{DISCOVERY_URL_2}")
+    monkeypatch.setenv(mcp_discovery.ENV_DISCOVERY_TTL, "0")
+
+    # B down from the start → A only.
+    _set_multi_response(monkeypatch, {
+        DISCOVERY_URL: {"mcps": [{"name": "a", "url": "http://h:1/mcp"}]},
+        DISCOVERY_URL_2: httpx.ConnectError("down"),
+    })
+    assert [m["name"] for m in get_discovered_mcps()] == ["a"]
+
+    # B comes up → merged.
+    _set_multi_response(monkeypatch, {
+        DISCOVERY_URL: {"mcps": [{"name": "a", "url": "http://h:1/mcp"}]},
+        DISCOVERY_URL_2: {"mcps": [{"name": "b", "url": "http://h:2/mcp"}]},
+    })
+    assert [m["name"] for m in get_discovered_mcps()] == ["a", "b"]
+
+    # B goes down again → A fresh + B last-good.
+    _set_multi_response(monkeypatch, {
+        DISCOVERY_URL: {"mcps": [{"name": "a2", "url": "http://h:3/mcp"}]},
+        DISCOVERY_URL_2: httpx.ConnectError("down"),
+    })
+    assert [m["name"] for m in get_discovered_mcps()] == ["a2", "b"]
+
+
+def test_multi_source_name_collision_first_wins(monkeypatch):
+    monkeypatch.setenv(
+        mcp_discovery.ENV_DISCOVERY_URL, f"{DISCOVERY_URL},{DISCOVERY_URL_2}")
+    _set_multi_response(monkeypatch, {
+        DISCOVERY_URL: {"mcps": [{"name": "github", "url": "http://first/mcp"}]},
+        DISCOVERY_URL_2: {"mcps": [
+            {"name": "github", "url": "http://second/mcp"},
+            {"name": "sbelcrm", "url": "http://second/crm/mcp"},
+        ]},
+    })
+    out = {m["name"]: m for m in get_discovered_mcps()}
+    assert set(out) == {"github", "sbelcrm"}
+    assert out["github"]["url"] == "http://first/mcp"
+
+
 # --- Config overlay -------------------------------------------------------
 
 def _overlay(monkeypatch, static, discovered):
@@ -347,3 +454,31 @@ def test_overlay_noop_when_no_discovery(monkeypatch):
     static = {"mcpServers": {"hello": {"command": "python"}}}
     out = _overlay(monkeypatch, static, [])
     assert out == static
+
+
+def test_overlay_internal_entry_not_managed(monkeypatch):
+    """requires_connection=false entries are internal bond_jwt servers: never
+    marked is_managed (the "always connected" path in /mcp/tools applies), and
+    a stale is_managed from an earlier overlay is removed."""
+    static = {"mcpServers": {
+        "sbelcrm": {"url": "http://old", "auth_type": "bond_jwt",
+                    "description": "Static description", "is_managed": True},
+    }}
+    discovered = [
+        {"name": "sbelcrm", "display_name": "SBEL CRM",
+         "url": "http://localhost:8001/mcp", "requires_connection": False,
+         "description": "Discovered description"},
+        {"name": "fresh", "url": "http://localhost:9999/mcp",
+         "requires_connection": False, "description": "From discovery"},
+    ]
+    out = _overlay(monkeypatch, static, discovered)["mcpServers"]
+
+    crm = out["sbelcrm"]
+    assert crm["url"] == "http://localhost:8001/mcp"
+    assert crm["auth_type"] == "bond_jwt"
+    assert "is_managed" not in crm
+    assert crm["description"] == "Static description"   # static annotation wins
+
+    fresh = out["fresh"]
+    assert "is_managed" not in fresh
+    assert fresh["description"] == "From discovery"     # discovery fills the gap

--- a/tests/test_mcp_discovery.py
+++ b/tests/test_mcp_discovery.py
@@ -394,6 +394,49 @@ def test_multi_source_per_source_failsoft(monkeypatch):
     assert [m["name"] for m in get_discovered_mcps()] == ["a2", "b"]
 
 
+def test_refresh_skips_fresh_sources(monkeypatch):
+    """During the fast startup-retry window only the never-fetched source is
+    refetched — a dead source must not drag the healthy one into being
+    hammered every STARTUP_RETRY_SECONDS."""
+    import httpx
+
+    monkeypatch.setenv(
+        mcp_discovery.ENV_DISCOVERY_URL, f"{DISCOVERY_URL},{DISCOVERY_URL_2}")
+    calls = []
+
+    def fake_get(url, timeout=None):
+        calls.append(url)
+        if url == DISCOVERY_URL_2:
+            raise httpx.ConnectError("still down")
+        return FakeResp({"mcps": [{"name": "a", "url": "http://h:1/mcp"}]})
+    monkeypatch.setattr(mcp_discovery.httpx, "get", fake_get)
+
+    # First poll: both fetched (A succeeds, B fails).
+    get_discovered_mcps(force_refresh=True)
+    assert calls == [DISCOVERY_URL, DISCOVERY_URL_2]
+    # Fast retry: A is fresh (default TTL) → only B is retried.
+    get_discovered_mcps(force_refresh=True)
+    assert calls == [DISCOVERY_URL, DISCOVERY_URL_2, DISCOVERY_URL_2]
+
+
+def test_collision_warns_once(monkeypatch):
+    """A persistent name collision logs one warning, not one per read."""
+    monkeypatch.setenv(
+        mcp_discovery.ENV_DISCOVERY_URL, f"{DISCOVERY_URL},{DISCOVERY_URL_2}")
+    _set_multi_response(monkeypatch, {
+        DISCOVERY_URL: {"mcps": [{"name": "github", "url": "http://first/mcp"}]},
+        DISCOVERY_URL_2: {"mcps": [{"name": "github", "url": "http://second/mcp"}]},
+    })
+    warnings = []
+    monkeypatch.setattr(
+        mcp_discovery.LOGGER, "warning",
+        lambda msg, *args: warnings.append(msg % args if args else msg),
+    )
+    for _ in range(3):
+        get_discovered_mcps()
+    assert len([w for w in warnings if "shadowed" in w]) == 1
+
+
 def test_multi_source_name_collision_first_wins(monkeypatch):
     monkeypatch.setenv(
         mcp_discovery.ENV_DISCOVERY_URL, f"{DISCOVERY_URL},{DISCOVERY_URL_2}")


### PR DESCRIPTION
This pull request updates MCP (Model Context Protocol) discovery to support multiple discovery sources, improves fail-soft handling, and adds support for new fields in the MCP discovery protocol. The changes make MCP discovery more robust and flexible, allowing bond-ai to merge MCPs from several sources, handle outages independently, and expose richer metadata to clients.

**MCP Discovery Enhancements:**

* MCP discovery now supports a comma-separated list of discovery URLs via the `BOND_MCPS_DISCOVERY_URL` environment variable. Earlier sources in the list win name collisions, and each source fails soft independently. (`.env.combined.example` [[1]](diffhunk://#diff-61b40490c52b4a17b865bc2c445b2b3817f538e474efc4a897c77d3600266b2dL42-R48) `.env.example` [[2]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL100-R110) `bondable/bond/mcp_discovery.py` [[3]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL4-R35) [[4]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL74-R99)
* The discovery client and cache were refactored to handle per-source caching, merging, and independent fail-soft behavior. If one source fails, others continue to contribute their MCPs. (`bondable/bond/mcp_discovery.py` [[1]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL146-R248) [[2]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL192-R297) [[3]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL222-R316) [[4]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL239-R331)
* When multiple sources advertise the same MCP name, the earlier source's entry is used, and a warning is logged. (`bondable/bond/mcp_discovery.py` [bondable/bond/mcp_discovery.pyL146-R248](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL146-R248))

**Protocol and Field Support:**

* MCP discovery entries now support the `requires_connection` (bool) and `description` (str) fields. The `requires_connection` field allows certain MCPs (e.g., sbel-crm) to be always connected without a per-user connect flow; the `description` is passed through to the UI. (`bondable/bond/mcp_discovery.py` [[1]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL4-R35) [[2]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL111-R133) [[3]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL123-R145) [[4]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL146-R248) [[5]](diffhunk://#diff-4ca8dedc0c5fc9653073eec967e460690ddafe99c8f3f8a7e12390f8dd1404baL272-R369)
* The code for overlaying discovered MCPs onto the static config was updated to handle these new fields, setting `is_managed` only for MCPs that require a connection and passing through descriptions when available. (`bondable/bond/config.py` [[1]](diffhunk://#diff-c82781044f49b85b99552576e94304202c42fd60fcd49a2a3f899ffebdbaf0c3L507-R521) [[2]](diffhunk://#diff-c82781044f49b85b99552576e94304202c42fd60fcd49a2a3f899ffebdbaf0c3L535-R562)

**API and UI Integration:**

* The connection config and status APIs now expose the `requires_connection` field, ensuring that MCPs which do not require a connect flow are correctly represented as always connected in the UI. (`bondable/rest/routers/connections.py` [[1]](diffhunk://#diff-eda14c41e264488f6e0a28450cb8e9d39adebb02420e5b0fe817e94222ace8d3R64-R66) [[2]](diffhunk://#diff-eda14c41e264488f6e0a28450cb8e9d39adebb02420e5b0fe817e94222ace8d3L234-R252)

These changes collectively make MCP discovery more flexible, resilient, and informative for both backend and frontend consumers.