### PR TITLE
Feat crm22 crm33 tool depth cards

### DIFF
--- a/bondable/bond/providers/bedrock/BedrockAgent.py
+++ b/bondable/bond/providers/bedrock/BedrockAgent.py
@@ -1246,6 +1246,10 @@ Please integrate any relevant insights from the documents with your analysis of 
         """
         invocation_inputs = return_control.get('invocationInputs', [])
         results = []
+        # Side channel for structured cards from MCP tool results (CRM-33).
+        # Cards must NOT go into the Bedrock tool results (INVARIANT above);
+        # the caller (_handle_continuation_response) drains this list.
+        self._pending_tool_cards = []
 
         for inv_input in invocation_inputs:
             # Top-level safety net: guarantee a response is appended for every invocation
@@ -1428,6 +1432,11 @@ Please integrate any relevant insights from the documents with your analysis of 
                                 LOGGER.warning(f"MCP tool {tool_name} returned an error, result preview: {result_preview}")
 
                             raw_result = result.get('result', result.get('error', 'Unknown error'))
+                            card = result.get('card')
+                            if isinstance(card, dict):
+                                # Structured card envelope (CRM-33) - surfaced to
+                                # the client via the side channel, never to Bedrock
+                                self._pending_tool_cards.append(card)
                             tool_response = self._make_tool_response(action_input, inv_input, api_path, raw_result, tool_name)
                             LOGGER.debug(f"Returning tool response to Bedrock: \n{json.dumps(tool_response, indent=2)}")
                             results.append(tool_response)
@@ -1545,6 +1554,84 @@ Please integrate any relevant insights from the documents with your analysis of 
         yield from self._handle_file_event(file_info=file_info,
                                          thread_id=thread_id,
                                          user_id=user_id)
+
+        # Start a new text message
+        new_response_id = str(uuid.uuid4())
+        yield self._create_bond_message_tag(
+            message_id=new_response_id,
+            thread_id=thread_id,
+            agent_id=self.agent_id,
+            message_type="text",
+            role="assistant"
+        )
+
+        return new_response_id
+
+    # Message type for structured cards surfaced from MCP tool results (CRM-33)
+    CARD_MESSAGE_TYPE = "resource_card"
+
+    def _handle_card_event_streaming(self, card: Dict[str, Any], thread_id: str,
+                                     user_id: str, current_response_id: str,
+                                     full_content: str,
+                                     attachments: Optional[List] = None) -> Generator[str, None, str]:
+        """
+        Persist and stream a structured card from an MCP tool result (CRM-33).
+
+        Mirrors _handle_file_event_streaming: saves accumulated text under the
+        current response id, closes the open text message, persists + streams a
+        resource_card message whose content is the raw envelope JSON, then
+        opens a new text message.
+
+        Returns:
+            New response ID for continuation
+        """
+        # Save any accumulated text content
+        if full_content and len(full_content) > 0:
+            self.bond_provider.threads.add_message(
+                message_id=current_response_id,
+                thread_id=thread_id,
+                user_id=user_id,
+                role="assistant",
+                message_type="text",
+                content=xml_unescape(full_content),
+                attachments=attachments,
+                metadata={
+                    'agent_id': self.agent_id,
+                    'model': self.model,
+                    'bedrock_agent_id': self.bedrock_agent_id
+                }
+            )
+
+        # Close current text message
+        yield '</_bondmessage>'
+
+        # Persist the card message (generic envelope JSON; unescaped in the DB)
+        card_content = json.dumps(card)
+        card_message_id = self.bond_provider.threads.add_message(
+            thread_id=thread_id,
+            user_id=user_id,
+            role="assistant",
+            message_type=self.CARD_MESSAGE_TYPE,
+            content=card_content,
+            metadata={
+                'agent_id': self.agent_id,
+                'model': self.model,
+                'bedrock_agent_id': self.bedrock_agent_id
+            }
+        )
+
+        # Stream the card message. Escape for XML transport: card fields may
+        # contain & or < which would break the client's XML parsing; the
+        # client's entity handling restores the raw JSON.
+        yield self._create_bond_message_tag(
+            message_id=card_message_id,
+            thread_id=thread_id,
+            agent_id=self.agent_id,
+            message_type=self.CARD_MESSAGE_TYPE,
+            role="assistant"
+        )
+        yield xml_escape(card_content)
+        yield '</_bondmessage>'
 
         # Start a new text message
         new_response_id = str(uuid.uuid4())
@@ -1898,6 +1985,19 @@ Please integrate any relevant insights from the documents with your analysis of 
                                         if new_response_id != response_id:
                                             response_id = new_response_id
                                             full_content = ''
+                            elif isinstance(cont_item, dict) and 'card_event' in cont_item:
+                                # Structured card from an MCP tool result (CRM-33)
+                                new_response_id = yield from self._handle_card_event_streaming(
+                                    card=cont_item['card_event'],
+                                    thread_id=thread_id,
+                                    user_id=user_id,
+                                    current_response_id=response_id,
+                                    full_content=full_content,
+                                    attachments=attachments if not phase_metadata else None
+                                )
+                                if new_response_id != response_id:
+                                    response_id = new_response_id
+                                    full_content = ''
                             elif isinstance(cont_item, dict):
                                 # Handle session_state from continuation response
                                 # (files_event is already handled by the condition at line 1040)
@@ -2254,7 +2354,9 @@ Please integrate any relevant insights from the documents with your analysis of 
 
         Yields:
             str: Response text chunks
-            dict: Files events (with 'files_event' key) or session state (with 'session_state' key)
+            dict: Files events (with 'files_event' key), structured cards from MCP
+                tool results (with 'card_event' key), or session state (with
+                'session_state' key)
         """
         # Graceful stop: the agent has used its tool-call budget for this turn.
         # Expected, handled path (WARNING, not ERROR). The message is plain
@@ -2275,6 +2377,11 @@ Please integrate any relevant insights from the documents with your analysis of 
 
         continuation_start_time = time.monotonic()
         tool_results = self._handle_return_control(return_control)
+        # Drain structured cards captured during tool execution (CRM-33).
+        # Drained synchronously before any recursion can re-enter
+        # _handle_return_control, so cards can never leak across rounds.
+        pending_cards = getattr(self, '_pending_tool_cards', None) or []
+        self._pending_tool_cards = []
         tool_exec_elapsed = time.monotonic() - continuation_start_time
         full_content = ""
         new_session_state = None
@@ -2320,6 +2427,12 @@ Please integrate any relevant insights from the documents with your analysis of 
                 f"(limit={MAX_TOOL_CALL_DEPTH}, margin={TOOL_DEPTH_WARN_MARGIN}) - injecting wrap-up notice"
             )
             self._inject_depth_warning(tool_results)
+
+        # Surface structured cards to the client (CRM-33). Emitted before the
+        # continuation invoke, so stream retries below can never duplicate a card.
+        for card in pending_cards:
+            LOGGER.info(f"[Continuation] MCP tool emitted a structured card at depth={depth}")
+            yield {'card_event': card}
 
         # Log tool result summary before sending continuation
         result_summary = []
@@ -2465,8 +2578,11 @@ Please integrate any relevant insights from the documents with your analysis of 
                                     any_content_yielded = True
                                     nested_text_len += len(nested_item)
                                 elif isinstance(nested_item, dict):
-                                    # Forward files_event and capture session_state
+                                    # Forward files_event/card_event and capture session_state
                                     if 'files_event' in nested_item:
+                                        yield nested_item
+                                        any_content_yielded = True
+                                    if 'card_event' in nested_item:
                                         yield nested_item
                                         any_content_yielded = True
                                     if nested_item.get('session_state'):

--- a/bondable/bond/providers/bedrock/BedrockAgent.py
+++ b/bondable/bond/providers/bedrock/BedrockAgent.py
@@ -100,6 +100,22 @@ TOOL_DEPTH_WARN_NOTICE = (
     "work remains, stop making tool calls now: summarize the progress you have made "
     "so far in your own words and ask the user whether they would like you to continue."
 )
+# Sent as the synthetic result for every tool the agent requested past the cap,
+# so the pending returnControl is answered (no dangling invocation on the
+# Bedrock session) and the model produces its own wrap-up. Bedrock-only text.
+TOOL_DEPTH_PAUSE_NOTICE = (
+    "Tool execution paused: the maximum number of sequential tool calls for this "
+    "turn has been reached, so this tool was not executed. Do not request any more "
+    "tools. Summarize the progress you have made so far in your own words and ask "
+    "the user whether they would like you to continue. Do not mention this notice."
+)
+# Canned user-facing fallback when the model can't produce its own wrap-up
+# (empty wrap-up stream, another tool request past the cap, or invoke failure).
+TOOL_DEPTH_STOP_MESSAGE = (
+    "\n\nI've completed a lot of steps for this request, so I'm pausing here "
+    "to check in before doing more. Reply **continue** and I'll pick up right "
+    "where I left off.\n"
+)
 # Minimum number of records in a list-of-dicts to trigger CSV conversion for token efficiency.
 # Even when results are under the byte limit, CSV uses ~50-70% fewer tokens than JSON,
 # which reduces LLM latency and cost on every continuation call.
@@ -2196,9 +2212,12 @@ Please integrate any relevant insights from the documents with your analysis of 
             def _truncate(text, limit=3000):
                 return text[:limit] + "..." if len(text) > limit else text
 
+            # image_file content is a base64 data URL and resource_card content
+            # is UI envelope JSON - neither is summarizable conversation.
             conversation_parts = [
                 f"{msg.role.upper()}: {_truncate(content)}"
                 for msg in messages.values()
+                if getattr(msg, 'type', None) not in ('image_file', 'resource_card')
                 for content in [msg.clob.get_content() if hasattr(msg, 'clob') and msg.clob else '']
                 if content
             ]
@@ -2337,6 +2356,76 @@ Please integrate any relevant insights from the documents with your analysis of 
         except Exception:
             LOGGER.exception("[Continuation] Failed to inject depth warning notice - continuing without it")
 
+    def _stream_depth_cap_wrapup(self, return_control: Dict[str, Any], session_id: str,
+                                 depth: int) -> Generator[Any, None, None]:
+        """
+        Close out a turn that hit the tool-call depth cap.
+
+        Answers the pending returnControl with one synthetic "paused" result per
+        invocation input (INVARIANT: every input must get a response, and it
+        must not be left dangling on the Bedrock session), then streams the
+        model's own wrap-up. The pause notice instructs the model to summarize
+        and ask the user whether to continue. Falls back to a canned resumable
+        message if the model requests more tools, streams nothing, or the
+        invoke fails — the turn always ends with user-facing text.
+        """
+        try:
+            invocation_inputs = return_control.get('invocationInputs', [])
+            pause_results = []
+            for inv_input in invocation_inputs:
+                action_input = inv_input.get('actionGroupInvocationInput',
+                                             inv_input.get('apiInvocationInput', {}))
+                api_path = action_input.get('apiPath')
+                pause_results.append(self._make_error_response(
+                    action_input, inv_input, api_path, TOOL_DEPTH_PAUSE_NOTICE))
+            if not pause_results:
+                raise ValueError("returnControl carried no invocation inputs")
+
+            wrapup_request = {
+                'agentId': self.bedrock_agent_id,
+                'agentAliasId': self.bedrock_agent_alias_id,
+                'sessionId': session_id,
+                'sessionState': {
+                    'invocationId': return_control.get('invocationId'),
+                    'returnControlInvocationResults': pause_results
+                },
+                'enableTrace': True,
+                'streamingConfigurations': {
+                    'streamFinalResponse': True
+                }
+            }
+            LOGGER.info(
+                f"[Continuation] Answering capped returnControl with {len(pause_results)} "
+                f"pause result(s) at depth={depth}"
+            )
+            response = self.bond_provider.bedrock_agent_runtime_client.invoke_agent(**wrapup_request)
+
+            any_text = False
+            for event in response.get('completion', []):
+                if 'chunk' in event:
+                    text = self._handle_chunk_event(event['chunk'])
+                    if text:
+                        any_text = True
+                        yield text
+                elif 'returnControl' in event:
+                    # The model ignored the pause notice and asked for more
+                    # tools; hard-stop without recursing. This does leave a
+                    # dangling invocation, matching pre-cap legacy behavior.
+                    LOGGER.warning(
+                        f"[Continuation] Model requested more tools past the depth cap "
+                        f"(depth={depth}) - stopping with canned message"
+                    )
+                    yield TOOL_DEPTH_STOP_MESSAGE
+                    return
+                elif 'sessionState' in event:
+                    yield {'session_state': event['sessionState']}
+
+            if not any_text:
+                yield TOOL_DEPTH_STOP_MESSAGE
+        except Exception:
+            LOGGER.exception("[Continuation] Depth-cap wrap-up failed - falling back to canned pause message")
+            yield TOOL_DEPTH_STOP_MESSAGE
+
     def _handle_continuation_response(self, return_control: Dict[str, Any], session_id: str,
                                     thread_id: str, seen_file_hashes: set,
                                     attachments: Optional[List] = None,
@@ -2359,20 +2448,18 @@ Please integrate any relevant insights from the documents with your analysis of 
                 'session_state' key)
         """
         # Graceful stop: the agent has used its tool-call budget for this turn.
-        # Expected, handled path (WARNING, not ERROR). The message is plain
-        # assistant text inside the already-open <_bondmessage>, so the UI renders
-        # a normal bubble; the Bedrock session_id persists across turns, so a
-        # follow-up "continue" resumes at depth=0 with full context.
+        # Expected, handled path (WARNING, not ERROR). The requested tools are
+        # NOT executed; instead the pending returnControl is answered with
+        # synthetic "paused" results so the Bedrock session has no dangling
+        # invocation, and the model streams its own wrap-up (plain assistant
+        # text inside the already-open <_bondmessage>). The session persists,
+        # so a follow-up "continue" resumes at depth=0 with full context.
         if depth >= MAX_TOOL_CALL_DEPTH:
             LOGGER.warning(
                 f"[Continuation] Tool call depth limit reached "
                 f"(depth={depth}, limit={MAX_TOOL_CALL_DEPTH}) - pausing gracefully"
             )
-            yield (
-                "\n\nI've completed a lot of steps for this request, so I'm pausing here "
-                "to check in before doing more. Reply **continue** and I'll pick up right "
-                "where I left off.\n"
-            )
+            yield from self._stream_depth_cap_wrapup(return_control, session_id, depth)
             return
 
         continuation_start_time = time.monotonic()

--- a/bondable/bond/providers/bedrock/BedrockAgent.py
+++ b/bondable/bond/providers/bedrock/BedrockAgent.py
@@ -1188,12 +1188,15 @@ Please integrate any relevant insights from the documents with your analysis of 
         return None
 
     def _make_error_response(self, action_input: Optional[Dict], inv_input: Dict,
-                             api_path: Optional[str], error_message: str) -> Dict[str, Any]:
+                             api_path: Optional[str], error_message: str,
+                             body_key: str = 'error') -> Dict[str, Any]:
         """
         Create a standardized error response for Bedrock (always HTTP 200).
 
         Every tool invocation MUST produce a response back to Bedrock.
         Non-200 codes cause dependencyFailedException which aborts the conversation.
+        body_key lets non-error synthetic responses (e.g. the depth-cap pause
+        notice) avoid the 'error' framing, which models tend to narrate.
         """
         tool_response = {
             "actionGroup": (action_input or {}).get('actionGroup') or (action_input or {}).get('actionGroupName', 'Unknown'),
@@ -1202,7 +1205,7 @@ Please integrate any relevant insights from the documents with your analysis of 
             "httpStatusCode": 200,
             "responseBody": {
                 "application/json": {
-                    "body": json.dumps({"error": error_message})
+                    "body": json.dumps({body_key: error_message})
                 }
             }
         }
@@ -1546,8 +1549,9 @@ Please integrate any relevant insights from the documents with your analysis of 
                     return current_response_id
                 seen_file_hashes.add(file_hash)
 
-        # Save any accumulated text content
-        if full_content and len(full_content) > 0:
+        # Save any accumulated text content (whitespace-only is not persisted,
+        # matching the top-level persist gate and the client parser's skip)
+        if full_content and full_content.strip():
             self.bond_provider.threads.add_message(
                 message_id=current_response_id,
                 thread_id=thread_id,
@@ -1601,8 +1605,9 @@ Please integrate any relevant insights from the documents with your analysis of 
         Returns:
             New response ID for continuation
         """
-        # Save any accumulated text content
-        if full_content and len(full_content) > 0:
+        # Save any accumulated text content (whitespace-only is not persisted,
+        # matching the top-level persist gate and the client parser's skip)
+        if full_content and full_content.strip():
             self.bond_provider.threads.add_message(
                 message_id=current_response_id,
                 thread_id=thread_id,
@@ -2070,9 +2075,12 @@ Please integrate any relevant insights from the documents with your analysis of 
         # Close bond message
         yield '</_bondmessage>'
 
-        # Save response if we have content
+        # Save response if we have content. Whitespace-only content is not
+        # persisted: the client parser skips empty text messages and the REST
+        # layer treats whitespace-only turns as no-content, so persisting it
+        # would make a thread reload disagree with the live view.
         compaction_performed = False
-        if full_content:
+        if full_content and full_content.strip():
             # Unescape XML entities before persisting — the stream escapes
             # <, >, & for safe XML transport, but the DB should store raw text.
             db_content = xml_unescape(full_content)
@@ -2377,7 +2385,8 @@ Please integrate any relevant insights from the documents with your analysis of 
                                              inv_input.get('apiInvocationInput', {}))
                 api_path = action_input.get('apiPath')
                 pause_results.append(self._make_error_response(
-                    action_input, inv_input, api_path, TOOL_DEPTH_PAUSE_NOTICE))
+                    action_input, inv_input, api_path, TOOL_DEPTH_PAUSE_NOTICE,
+                    body_key='system_notice'))
             if not pause_results:
                 raise ValueError("returnControl carried no invocation inputs")
 
@@ -2398,10 +2407,32 @@ Please integrate any relevant insights from the documents with your analysis of 
                 f"[Continuation] Answering capped returnControl with {len(pause_results)} "
                 f"pause result(s) at depth={depth}"
             )
-            response = self.bond_provider.bedrock_agent_runtime_client.invoke_agent(**wrapup_request)
+            # Retry transient connection errors (mirrors the normal continuation
+            # invoke): an unanswered failure here would leave the invocation
+            # dangling - the exact state this wrap-up exists to prevent.
+            response = None
+            for attempt in range(MAX_INVOKE_RETRIES + 1):
+                try:
+                    if attempt > 0:
+                        delay = INVOKE_RETRY_BASE_DELAY * (2 ** (attempt - 1))
+                        LOGGER.warning(
+                            f"[Continuation] Wrap-up retry {attempt}/{MAX_INVOKE_RETRIES} "
+                            f"after {delay}s delay (depth={depth})"
+                        )
+                        time.sleep(delay)
+                    response = self.bond_provider.bedrock_agent_runtime_client.invoke_agent(**wrapup_request)
+                    break
+                except (RemoteDisconnected, ConnectionClosedError, ConnectionError, OSError) as e:
+                    LOGGER.warning(
+                        f"[Continuation] Wrap-up connection error on attempt "
+                        f"{attempt + 1}/{MAX_INVOKE_RETRIES + 1}: {type(e).__name__}: {e}"
+                    )
+                    if attempt == MAX_INVOKE_RETRIES:
+                        raise
 
             any_text = False
-            for event in response.get('completion', []):
+            completion = response.get('completion') or []
+            for event in completion:
                 if 'chunk' in event:
                     text = self._handle_chunk_event(event['chunk'])
                     if text:
@@ -2415,10 +2446,15 @@ Please integrate any relevant insights from the documents with your analysis of 
                         f"[Continuation] Model requested more tools past the depth cap "
                         f"(depth={depth}) - stopping with canned message"
                     )
+                    try:
+                        completion.close()  # return the half-consumed stream's connection
+                    except Exception as close_err:
+                        LOGGER.debug(f"[Continuation] Wrap-up stream close failed: {close_err}")
                     yield TOOL_DEPTH_STOP_MESSAGE
                     return
-                elif 'sessionState' in event:
-                    yield {'session_state': event['sessionState']}
+                # 'files' and 'trace' events are deliberately dropped: the
+                # wrap-up prompt requests a text summary only, and there is no
+                # message bookkeeping open for file attachments on this path.
 
             if not any_text:
                 yield TOOL_DEPTH_STOP_MESSAGE

--- a/bondable/bond/providers/bedrock/BedrockAgent.py
+++ b/bondable/bond/providers/bedrock/BedrockAgent.py
@@ -2326,8 +2326,8 @@ Please integrate any relevant insights from the documents with your analysis of 
         """
         if not tool_results:
             return
-        inner = tool_results[-1].get('apiResult', tool_results[-1])
         try:
+            inner = tool_results[-1].get('apiResult', tool_results[-1])
             content = inner['responseBody']['application/json']
             body = json.loads(content.get('body') or '{}')
             if not isinstance(body, dict):

--- a/bondable/bond/providers/bedrock/BedrockAgent.py
+++ b/bondable/bond/providers/bedrock/BedrockAgent.py
@@ -2378,8 +2378,9 @@ Please integrate any relevant insights from the documents with your analysis of 
         continuation_start_time = time.monotonic()
         tool_results = self._handle_return_control(return_control)
         # Drain structured cards captured during tool execution (CRM-33).
-        # Drained synchronously before any recursion can re-enter
-        # _handle_return_control, so cards can never leak across rounds.
+        # _handle_return_control resets the list on entry, so this reset is
+        # defensive; the getattr covers agents built without __init__ (tests)
+        # and mocked _handle_return_control implementations.
         pending_cards = getattr(self, '_pending_tool_cards', None) or []
         self._pending_tool_cards = []
         tool_exec_elapsed = time.monotonic() - continuation_start_time
@@ -2419,8 +2420,9 @@ Please integrate any relevant insights from the documents with your analysis of 
             tool_results = [fallback_error]
 
         # Near-limit nudge: tell the agent to wrap up and ask the user (CRM-22).
-        # Fires exactly once per recursion chain (depth equality; recursion always
-        # passes depth + 1). MARGIN <= 0 disables.
+        # Fires at most once per recursion chain (depth equality; recursion always
+        # passes depth + 1); sibling chains in the same turn can each hit the
+        # band and inject again, which is harmless. MARGIN <= 0 disables.
         if TOOL_DEPTH_WARN_MARGIN > 0 and depth == MAX_TOOL_CALL_DEPTH - TOOL_DEPTH_WARN_MARGIN:
             LOGGER.warning(
                 f"[Continuation] Depth {depth} entered warn band "

--- a/bondable/bond/providers/bedrock/BedrockAgent.py
+++ b/bondable/bond/providers/bedrock/BedrockAgent.py
@@ -80,6 +80,26 @@ DEFAULT_INSTRUCTION = "You are a helpful AI assistant. Be helpful, accurate, and
 MAX_TOOL_RESULT_BYTES = int(os.environ.get('BEDROCK_MAX_TOOL_RESULT_BYTES', '1000000'))
 if os.environ.get('BEDROCK_MAX_TOOL_RESULT_BYTES'):
     LOGGER.info(f"[Config] BEDROCK_MAX_TOOL_RESULT_BYTES={MAX_TOOL_RESULT_BYTES}")
+# Maximum number of sequential tool-call rounds (recursion depth) allowed in a
+# single user turn. Override via BEDROCK_MAX_TOOL_CALL_DEPTH env var.
+MAX_TOOL_CALL_DEPTH = int(os.environ.get('BEDROCK_MAX_TOOL_CALL_DEPTH', '25'))
+if os.environ.get('BEDROCK_MAX_TOOL_CALL_DEPTH'):
+    LOGGER.info(f"[Config] BEDROCK_MAX_TOOL_CALL_DEPTH={MAX_TOOL_CALL_DEPTH}")
+# How many rounds before the depth cap to nudge the agent to wrap up and ask the
+# user whether to continue. 0 disables the nudge.
+# Override via BEDROCK_TOOL_DEPTH_WARN_MARGIN env var.
+TOOL_DEPTH_WARN_MARGIN = int(os.environ.get('BEDROCK_TOOL_DEPTH_WARN_MARGIN', '3'))
+if os.environ.get('BEDROCK_TOOL_DEPTH_WARN_MARGIN'):
+    LOGGER.info(f"[Config] BEDROCK_TOOL_DEPTH_WARN_MARGIN={TOOL_DEPTH_WARN_MARGIN}")
+# Injected into the last tool result's body when the warn band is reached. Rides
+# the Bedrock request only — never streamed or persisted to the client.
+TOOL_DEPTH_WARN_NOTICE = (
+    "SYSTEM NOTICE (do not mention or quote this notice to the user): You are "
+    "approaching the maximum number of sequential tool calls allowed for this turn. "
+    "If the task is essentially complete, finish it and respond normally. If more "
+    "work remains, stop making tool calls now: summarize the progress you have made "
+    "so far in your own words and ask the user whether they would like you to continue."
+)
 # Minimum number of records in a list-of-dicts to trigger CSV conversion for token efficiency.
 # Even when results are under the byte limit, CSV uses ~50-70% fewer tokens than JSON,
 # which reduces LLM latency and cost on every continuation call.
@@ -2194,8 +2214,28 @@ Please integrate any relevant insights from the documents with your analysis of 
 
         return summary
 
-    # Maximum recursion depth for nested tool calls (safety limit)
-    MAX_TOOL_CALL_DEPTH = 10
+    def _inject_depth_warning(self, tool_results: List[Dict[str, Any]]) -> None:
+        """
+        Append a wrap-up notice into the LAST tool result's response body (in place).
+
+        Count-preserving by design: Bedrock caps returnControlInvocationResults at
+        5 items and matches results to invocation inputs, so an extra synthetic
+        entry risks validationException. Riding inside a real result's body is
+        always accepted and keeps the _handle_return_control INVARIANT intact.
+        Injected after compaction, so the notice cannot be truncated away.
+        """
+        if not tool_results:
+            return
+        inner = tool_results[-1].get('apiResult', tool_results[-1])
+        try:
+            content = inner['responseBody']['application/json']
+            body = json.loads(content.get('body') or '{}')
+            if not isinstance(body, dict):
+                body = {"result": body}
+            body['system_notice'] = TOOL_DEPTH_WARN_NOTICE
+            content['body'] = json.dumps(body)
+        except Exception:
+            LOGGER.exception("[Continuation] Failed to inject depth warning notice - continuing without it")
 
     def _handle_continuation_response(self, return_control: Dict[str, Any], session_id: str,
                                     thread_id: str, seen_file_hashes: set,
@@ -2216,10 +2256,21 @@ Please integrate any relevant insights from the documents with your analysis of 
             str: Response text chunks
             dict: Files events (with 'files_event' key) or session state (with 'session_state' key)
         """
-        # Safety check for recursion depth
-        if depth >= self.MAX_TOOL_CALL_DEPTH:
-            LOGGER.error(f"Maximum tool call depth ({self.MAX_TOOL_CALL_DEPTH}) exceeded - stopping recursion")
-            yield f"\n\n[Error: Maximum tool call depth exceeded. The agent attempted too many sequential tool calls.]\n"
+        # Graceful stop: the agent has used its tool-call budget for this turn.
+        # Expected, handled path (WARNING, not ERROR). The message is plain
+        # assistant text inside the already-open <_bondmessage>, so the UI renders
+        # a normal bubble; the Bedrock session_id persists across turns, so a
+        # follow-up "continue" resumes at depth=0 with full context.
+        if depth >= MAX_TOOL_CALL_DEPTH:
+            LOGGER.warning(
+                f"[Continuation] Tool call depth limit reached "
+                f"(depth={depth}, limit={MAX_TOOL_CALL_DEPTH}) - pausing gracefully"
+            )
+            yield (
+                "\n\nI've completed a lot of steps for this request, so I'm pausing here "
+                "to check in before doing more. Reply **continue** and I'll pick up right "
+                "where I left off.\n"
+            )
             return
 
         continuation_start_time = time.monotonic()
@@ -2259,6 +2310,16 @@ Please integrate any relevant insights from the documents with your analysis of 
                 fallback_error = {"apiResult": fallback_error}
 
             tool_results = [fallback_error]
+
+        # Near-limit nudge: tell the agent to wrap up and ask the user (CRM-22).
+        # Fires exactly once per recursion chain (depth equality; recursion always
+        # passes depth + 1). MARGIN <= 0 disables.
+        if TOOL_DEPTH_WARN_MARGIN > 0 and depth == MAX_TOOL_CALL_DEPTH - TOOL_DEPTH_WARN_MARGIN:
+            LOGGER.warning(
+                f"[Continuation] Depth {depth} entered warn band "
+                f"(limit={MAX_TOOL_CALL_DEPTH}, margin={TOOL_DEPTH_WARN_MARGIN}) - injecting wrap-up notice"
+            )
+            self._inject_depth_warning(tool_results)
 
         # Log tool result summary before sending continuation
         result_summary = []

--- a/bondable/bond/providers/bedrock/BedrockMCP.py
+++ b/bondable/bond/providers/bedrock/BedrockMCP.py
@@ -1373,6 +1373,33 @@ def _get_auth_headers_for_server(
     return headers
 
 
+def _extract_bond_card(result: Any, text: str) -> Optional[Dict[str, Any]]:
+    """Extract a _bond_card envelope from an MCP tool result (CRM-33).
+
+    A tool can surface a structured card in chat by including a "_bond_card"
+    object in its result. Primary transport: MCP structuredContent (fastmcp
+    CallToolResult.structured_content). fastmcp wraps non-object returns under
+    {"result": ...}, so check one level down too. Fallback: a top-level
+    "_bond_card" key in the text JSON.
+    """
+    structured = getattr(result, 'structured_content', None)
+    if isinstance(structured, dict):
+        card = structured.get('_bond_card')
+        if isinstance(card, dict):
+            return card
+        inner = structured.get('result')
+        if isinstance(inner, dict) and isinstance(inner.get('_bond_card'), dict):
+            return inner['_bond_card']
+    if text:
+        try:
+            parsed = json.loads(text)
+        except (json.JSONDecodeError, ValueError):
+            return None
+        if isinstance(parsed, dict) and isinstance(parsed.get('_bond_card'), dict):
+            return parsed['_bond_card']
+    return None
+
+
 async def execute_mcp_tool(
     mcp_config: Dict[str, Any],
     tool_name: str,
@@ -1521,7 +1548,13 @@ async def execute_mcp_tool(
                                 text_parts.append(content_item.text)
                             elif hasattr(content_item, 'type') and content_item.type == 'text':
                                 text_parts.append(str(content_item))
-                        return {"success": True, "result": " ".join(text_parts)}
+                        text_result = " ".join(text_parts)
+                        response = {"success": True, "result": text_result}
+                        card = _extract_bond_card(result, text_result)
+                        if card:
+                            # Side channel for the agent loop; never sent to Bedrock
+                            response["card"] = card
+                        return response
                     elif hasattr(result, 'text'):
                         return {"success": True, "result": result.text}
                     else:

--- a/bondable/bond/providers/bedrock/BedrockMCP.py
+++ b/bondable/bond/providers/bedrock/BedrockMCP.py
@@ -1390,7 +1390,9 @@ def _extract_bond_card(result: Any, text: str) -> Optional[Dict[str, Any]]:
         inner = structured.get('result')
         if isinstance(inner, dict) and isinstance(inner.get('_bond_card'), dict):
             return inner['_bond_card']
-    if text:
+    # Substring guard: skips a potentially large json.loads for the vast
+    # majority of tool results that never carry a card.
+    if text and '_bond_card' in text:
         try:
             parsed = json.loads(text)
         except (json.JSONDecodeError, ValueError):
@@ -1398,6 +1400,26 @@ def _extract_bond_card(result: Any, text: str) -> Optional[Dict[str, Any]]:
         if isinstance(parsed, dict) and isinstance(parsed.get('_bond_card'), dict):
             return parsed['_bond_card']
     return None
+
+
+def _strip_bond_card_text(text: str) -> str:
+    """Remove the _bond_card envelope from a tool-result text JSON.
+
+    The envelope is UI plumbing, not model input: leaving it in the text wastes
+    tokens and invites the model to narrate raw card JSON next to the rendered
+    card. All other keys are preserved for agents that parse them. Returns the
+    text unchanged if it isn't a JSON object carrying the key.
+    """
+    if not text or '_bond_card' not in text:
+        return text
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, ValueError):
+        return text
+    if isinstance(parsed, dict) and '_bond_card' in parsed:
+        parsed.pop('_bond_card')
+        return json.dumps(parsed)
+    return text
 
 
 async def execute_mcp_tool(
@@ -1549,11 +1571,18 @@ async def execute_mcp_tool(
                             elif hasattr(content_item, 'type') and content_item.type == 'text':
                                 text_parts.append(str(content_item))
                         text_result = " ".join(text_parts)
-                        response = {"success": True, "result": text_result}
                         card = _extract_bond_card(result, text_result)
                         if card:
-                            # Side channel for the agent loop; never sent to Bedrock
-                            response["card"] = card
+                            # The card rides a side channel to the client; strip
+                            # the envelope from the model-facing text so Bedrock
+                            # never sees it (other keys are preserved).
+                            response = {
+                                "success": True,
+                                "result": _strip_bond_card_text(text_result),
+                                "card": card,
+                            }
+                        else:
+                            response = {"success": True, "result": text_result}
                         return response
                     elif hasattr(result, 'text'):
                         return {"success": True, "result": result.text}

--- a/bondable/bond/providers/bedrock/BedrockThreads.py
+++ b/bondable/bond/providers/bedrock/BedrockThreads.py
@@ -539,7 +539,7 @@ class BedrockThreadsProvider(ThreadsProvider):
                     msg_meta = msg.message_metadata or {}
                     if msg_meta.get('hidden') in (True, 'true') or msg_meta.get('override_role') == 'system':
                         continue
-                    if msg.type in ('system', 'error', 'file_link', 'image_file'):
+                    if msg.type in ('system', 'error', 'file_link', 'image_file', 'resource_card'):
                         continue
 
                     # Extract text content

--- a/flutterui/pubspec.lock
+++ b/flutterui/pubspec.lock
@@ -79,7 +79,7 @@ packages:
       path: "../packages/bond_chat_ui"
       relative: true
     source: path
-    version: "0.1.0"
+    version: "0.2.0"
   boolean_selector:
     dependency: transitive
     description:

--- a/packages/bond_chat_ui/CHANGELOG.md
+++ b/packages/bond_chat_ui/CHANGELOG.md
@@ -1,0 +1,19 @@
+# Changelog
+
+## 0.2.0 (2026-07-07)
+
+- `parseAllBondMessages` now skips empty assistant `type="text"` messages —
+  the bookend pair the server emits when a tool round produces a file or
+  card before any text. These messages are never persisted server-side, so
+  the live view now matches a thread reload.
+- **Behavioral notes for consumers with their own stream handlers:**
+  - The first parsed assistant message can now be a non-`text` type
+    (`image_file`, `file_link`, `resource_card`) — a placeholder-replacement
+    pattern must not assume the first message is text.
+  - A turn whose only assistant output was empty/whitespace text now parses
+    to zero assistant messages; handlers should surface the server's trailing
+    `role="system"` error message in that case (the bond-ai router always
+    appends one).
+- New server message type `resource_card` (structured card envelope JSON from
+  MCP tool results) passes through the parser as a normal typed message;
+  renderers without a card widget fall through to plain text.

--- a/packages/bond_chat_ui/lib/src/utils/bond_message_parser.dart
+++ b/packages/bond_chat_ui/lib/src/utils/bond_message_parser.dart
@@ -87,6 +87,23 @@ class BondMessageParser {
         String? imageData;
 
         final messageType = element.getAttribute('type') ?? '';
+        final role = element.getAttribute('role') ?? '';
+        final isErrorAttribute =
+            element.getAttribute('is_error')?.toLowerCase() == 'true';
+
+        // Skip empty assistant text messages. The server emits an empty
+        // text-message pair when a tool round produces a file or card before
+        // any text (the open message is closed to make room, then a fresh one
+        // is opened). These are never persisted server-side, so skipping them
+        // keeps the live view consistent with a thread reload and avoids
+        // rendering an empty bubble.
+        if (role == 'assistant' &&
+            (messageType == 'text' || messageType.isEmpty) &&
+            content.isEmpty &&
+            !isErrorAttribute) {
+          continue;
+        }
+
         if (messageType == 'image_file' || messageType == 'image') {
           if (content.startsWith('data:image/')) {
             final commaIndex = content.indexOf(',');
@@ -102,10 +119,10 @@ class BondMessageParser {
           threadId: element.getAttribute('thread_id') ?? '',
           agentId: element.getAttribute('agent_id'),
           type: messageType,
-          role: element.getAttribute('role') ?? '',
+          role: role,
           content: content,
           imageData: imageData,
-          isErrorAttribute: element.getAttribute('is_error')?.toLowerCase() == 'true',
+          isErrorAttribute: isErrorAttribute,
           parsingHadError: false,
         ));
       }

--- a/packages/bond_chat_ui/lib/src/utils/bond_message_parser.dart
+++ b/packages/bond_chat_ui/lib/src/utils/bond_message_parser.dart
@@ -96,9 +96,10 @@ class BondMessageParser {
         // any text (the open message is closed to make room, then a fresh one
         // is opened). These are never persisted server-side, so skipping them
         // keeps the live view consistent with a thread reload and avoids
-        // rendering an empty bubble.
+        // rendering an empty bubble. Deliberately narrow: only type="text"
+        // (the server always sets a type), only assistant, never errors.
         if (role == 'assistant' &&
-            (messageType == 'text' || messageType.isEmpty) &&
+            messageType == 'text' &&
             content.isEmpty &&
             !isErrorAttribute) {
           continue;

--- a/packages/bond_chat_ui/pubspec.yaml
+++ b/packages/bond_chat_ui/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bond_chat_ui
 description: Reusable chat message rendering widgets for Bond AI
-version: 0.1.0
+version: 0.2.0
 publish_to: 'none'
 
 environment:

--- a/packages/bond_chat_ui/test/utils/bond_message_parser_test.dart
+++ b/packages/bond_chat_ui/test/utils/bond_message_parser_test.dart
@@ -109,6 +109,43 @@ void main() {
       expect(messages[0].content, '[Image]');
     });
 
+    test('skips empty assistant text messages (card/file-before-text pair)', () {
+      // Stream shape when a tool round emits a card before any text: the
+      // just-opened empty text message is closed, the card streams, and a
+      // fresh text message carries the reply.
+      final xml = '<_bondmessage id="1" thread_id="t" type="text" role="assistant" is_error="false"></_bondmessage>'
+          '<_bondmessage id="2" thread_id="t" type="resource_card" role="assistant" is_error="false">'
+          '{&quot;type&quot;: &quot;proposal&quot;, &quot;proposal_id&quot;: &quot;p-1&quot;}'
+          '</_bondmessage>'
+          '<_bondmessage id="3" thread_id="t" type="text" role="assistant" is_error="false">Here is your proposal.</_bondmessage>';
+
+      final messages = BondMessageParser.parseAllBondMessages(xml);
+      expect(messages.length, 2);
+      expect(messages[0].type, 'resource_card');
+      expect(messages[0].content, '{"type": "proposal", "proposal_id": "p-1"}');
+      expect(messages[1].content, 'Here is your proposal.');
+    });
+
+    test('keeps empty non-text and non-assistant messages', () {
+      final xml = '<_bondmessage id="1" thread_id="t" type="text" role="user"></_bondmessage>'
+          '<_bondmessage id="2" thread_id="t" type="error" role="assistant" is_error="true"></_bondmessage>';
+
+      final messages = BondMessageParser.parseAllBondMessages(xml);
+      expect(messages.length, 2);
+      expect(messages[0].role, 'user');
+      expect(messages[1].isErrorAttribute, true);
+    });
+
+    test('resource_card content decodes XML entities to raw JSON', () {
+      final xml = '<_bondmessage id="1" thread_id="t" type="resource_card" role="assistant" is_error="false">'
+          '{&quot;title&quot;: &quot;A &amp; B &lt;draft&gt;&quot;}'
+          '</_bondmessage>';
+
+      final messages = BondMessageParser.parseAllBondMessages(xml);
+      expect(messages.length, 1);
+      expect(messages[0].content, '{"title": "A & B <draft>"}');
+    });
+
     test('handles XML parse error with parsingHadError', () {
       final xml = '<_bondmessage id="1" role="assistant">content with < unescaped';
 

--- a/packages/bond_chat_ui/test/utils/bond_message_parser_test.dart
+++ b/packages/bond_chat_ui/test/utils/bond_message_parser_test.dart
@@ -128,12 +128,43 @@ void main() {
 
     test('keeps empty non-text and non-assistant messages', () {
       final xml = '<_bondmessage id="1" thread_id="t" type="text" role="user"></_bondmessage>'
-          '<_bondmessage id="2" thread_id="t" type="error" role="assistant" is_error="true"></_bondmessage>';
+          '<_bondmessage id="2" thread_id="t" type="error" role="assistant" is_error="true"></_bondmessage>'
+          '<_bondmessage id="3" thread_id="t" role="assistant"></_bondmessage>';
+
+      final messages = BondMessageParser.parseAllBondMessages(xml);
+      expect(messages.length, 3);
+      expect(messages[0].role, 'user');
+      expect(messages[1].isErrorAttribute, true);
+      // Typeless empty assistant message is kept: the skip is deliberately
+      // narrow (the server always sets type="text" on the empty pairs).
+      expect(messages[2].type, '');
+    });
+
+    test('skips whitespace-only assistant text message', () {
+      final xml = '<_bondmessage id="1" thread_id="t" type="text" role="assistant" is_error="false">   \n  </_bondmessage>'
+          '<_bondmessage id="2" thread_id="t" type="text" role="assistant" is_error="false">real reply</_bondmessage>';
+
+      final messages = BondMessageParser.parseAllBondMessages(xml);
+      expect(messages.length, 1);
+      expect(messages[0].content, 'real reply');
+    });
+
+    test('image flow keeps image and trailing system message with thread_id', () {
+      // Real server shape for an image-only turn: empty text pair around the
+      // image, then the router-guaranteed system "Done." carrying thread_id.
+      final xml = '<_bondmessage id="1" thread_id="t1" type="text" role="assistant" is_error="false"></_bondmessage>'
+          '<_bondmessage id="2" thread_id="t1" type="image_file" role="assistant" is_error="false">data:image/png;base64,iVBORw0KGgo=</_bondmessage>'
+          '<_bondmessage id="3" thread_id="t1" type="text" role="assistant" is_error="false"></_bondmessage>'
+          '<_bondmessage id="4" thread_id="t1" type="text" role="system" is_error="false" is_done="true">Done.</_bondmessage>';
 
       final messages = BondMessageParser.parseAllBondMessages(xml);
       expect(messages.length, 2);
-      expect(messages[0].role, 'user');
-      expect(messages[1].isErrorAttribute, true);
+      expect(messages[0].type, 'image_file');
+      expect(messages[0].imageData, 'iVBORw0KGgo=');
+      // The last message stays the system one, so thread_id extraction from
+      // `allMessages.last` is unaffected by the skip.
+      expect(messages.last.role, 'system');
+      expect(messages.last.threadId, 't1');
     });
 
     test('resource_card content decodes XML entities to raw JSON', () {

--- a/tests/test_bedrock_tool_depth.py
+++ b/tests/test_bedrock_tool_depth.py
@@ -180,19 +180,26 @@ class TestDepthLimitConfig:
             side_effect=_chunk_stream
         )
 
-        list(agent._handle_continuation_response(
-            return_control=return_control,
-            session_id="test-session",
-            thread_id="test-thread",
-            seen_file_hashes=set(),
-            depth=5
-        ))
+        # Patch tool execution so a cap that fails to fire cannot mimic this
+        # shape via the per-invocation error safety net (which also produces
+        # one result per input with matching apiPaths, but with "error" bodies).
+        with patch.object(agent, "_handle_return_control") as mock_hrc:
+            list(agent._handle_continuation_response(
+                return_control=return_control,
+                session_id="test-session",
+                thread_id="test-thread",
+                seen_file_hashes=set(),
+                depth=5
+            ))
 
+        mock_hrc.assert_not_called()  # the cap actually fired
         sent = agent.bond_provider.bedrock_agent_runtime_client.invoke_agent \
             .call_args.kwargs["sessionState"]["returnControlInvocationResults"]
         assert len(sent) == 2
         assert [r["apiResult"]["apiPath"] for r in sent] == \
             ["/b.abc123.jira_search", "/b.abc123.jira_get"]
+        for result in sent:
+            assert "paused" in _body_of(result)["system_notice"]
 
     def test_below_limit_proceeds(self, monkeypatch):
         monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)

--- a/tests/test_bedrock_tool_depth.py
+++ b/tests/test_bedrock_tool_depth.py
@@ -152,13 +152,47 @@ class TestDepthLimitConfig:
         mock_hrc.assert_not_called()  # tools at the cap must not execute
         assert mock_invoke.call_count == 1  # single wrap-up invoke, no recursion
         kwargs = mock_invoke.call_args.kwargs
+        # Routing must be pinned: a wrong session/agent id fails with a
+        # validationException in production that the fallback would swallow.
+        assert kwargs["sessionId"] == "test-session"
+        assert kwargs["agentId"] == "test-agent-id"
+        assert kwargs["agentAliasId"] == "test-alias-id"
         assert kwargs["sessionState"]["invocationId"] == "inv-123"  # same pending invocation
         sent = kwargs["sessionState"]["returnControlInvocationResults"]
         assert len(sent) == 1  # one response per invocation input (INVARIANT)
+        assert "apiResult" in sent[0]  # apiInvocationInput must be wrapped
         body = _body_of(sent[0])
-        assert "paused" in body["error"]
+        assert "paused" in body["system_notice"]  # not the 'error' key - models narrate errors
         # The model's own wrap-up text streams through
         assert any("Done." in i for i in items if isinstance(i, str))
+
+    def test_cap_answers_every_invocation_input(self, monkeypatch):
+        """A parallel multi-tool returnControl at the cap gets one pause
+        result per input (count mismatch => validationException in prod)."""
+        monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
+        agent = _make_agent()
+
+        return_control = _make_return_control()
+        second_input = copy.deepcopy(return_control["invocationInputs"][0])
+        second_input["apiInvocationInput"]["apiPath"] = "/b.abc123.jira_get"
+        return_control["invocationInputs"].append(second_input)
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent = MagicMock(
+            side_effect=_chunk_stream
+        )
+
+        list(agent._handle_continuation_response(
+            return_control=return_control,
+            session_id="test-session",
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=5
+        ))
+
+        sent = agent.bond_provider.bedrock_agent_runtime_client.invoke_agent \
+            .call_args.kwargs["sessionState"]["returnControlInvocationResults"]
+        assert len(sent) == 2
+        assert [r["apiResult"]["apiPath"] for r in sent] == \
+            ["/b.abc123.jira_search", "/b.abc123.jira_get"]
 
     def test_below_limit_proceeds(self, monkeypatch):
         monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
@@ -202,11 +236,13 @@ class TestGracefulStop:
         agent = _make_agent()
         items = self._run_at_cap(agent, lambda **kw: {"completion": iter([])})
 
-        text = [i for i in items if isinstance(i, str)]
-        assert len(text) > 0
-        assert any("continue" in t.lower() for t in text)
-        assert not any("[Error:" in t for t in text)
-        assert not any("is_error" in t for t in text)
+        text = "".join(i for i in items if isinstance(i, str))
+        # Pin the STOP message, not just "continue" - the Bedrock-only pause
+        # notice also says "continue" and must never leak to the user.
+        assert "pausing here" in text
+        assert "Do not mention this notice" not in text
+        assert "[Error:" not in text
+        assert "is_error" not in text
 
     def test_model_requests_more_tools_gets_canned_stop(self):
         """A returnControl in the wrap-up stream must not recurse."""
@@ -217,7 +253,8 @@ class TestGracefulStop:
 
         assert agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.call_count == 1
         text = "".join(i for i in items if isinstance(i, str))
-        assert "continue" in text.lower()
+        assert "pausing here" in text
+        assert "Do not mention this notice" not in text
 
     def test_wrapup_invoke_failure_falls_back_to_canned(self):
         agent = _make_agent()
@@ -228,15 +265,38 @@ class TestGracefulStop:
         items = self._run_at_cap(agent, boom)
 
         text = "".join(i for i in items if isinstance(i, str))
-        assert "continue" in text.lower()
+        assert "pausing here" in text
+        assert "Do not mention this notice" not in text
         assert "[Error:" not in text
+
+    @patch("bondable.bond.providers.bedrock.BedrockAgent.time.sleep")
+    def test_wrapup_retries_transient_connection_error(self, mock_sleep):
+        """A connection blip must not leave the invocation dangling - the
+        wrap-up invoke retries like the normal continuation does."""
+        from http.client import RemoteDisconnected
+
+        agent = _make_agent()
+        calls = [0]
+
+        def flaky(**kwargs):
+            calls[0] += 1
+            if calls[0] == 1:
+                raise RemoteDisconnected("connection dropped")
+            return {"completion": iter([{"chunk": {"bytes": b"Wrapped up."}}])}
+
+        items = self._run_at_cap(agent, flaky)
+
+        assert calls[0] == 2  # retried once, then succeeded
+        text = "".join(i for i in items if isinstance(i, str))
+        assert "Wrapped up." in text
+        assert "pausing here" not in text  # no canned fallback needed
 
     def test_resume_uses_same_session_at_depth_zero(self, monkeypatch):
         """After a stop, a fresh depth-0 call continues on the same session."""
         monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
         agent = _make_agent()
 
-        _run_continuation(agent, depth=5)  # hits the cap, invoke_agent unused
+        _run_continuation(agent, depth=5)  # hits the cap; wrap-up invoke fires once
 
         # Fresh top-level call, as _process_bedrock_invocation would make it
         items, _, mock_invoke = _run_continuation(agent, depth=0, session_id="test-session")
@@ -404,4 +464,4 @@ class TestWarnBandInjection:
         mock_hrc.assert_not_called()  # cap still fires with margin 0
         assert mock_invoke.call_count == 1  # wrap-up invoke only
         body = _body_of(mock_invoke.call_args.kwargs["sessionState"]["returnControlInvocationResults"][0])
-        assert "paused" in body["error"]
+        assert "paused" in body["system_notice"]

--- a/tests/test_bedrock_tool_depth.py
+++ b/tests/test_bedrock_tool_depth.py
@@ -18,10 +18,22 @@ itself is exercised by manual smoke testing, not unit tests.
 
 import copy
 import json
+import os
 import pytest
 from unittest.mock import MagicMock, patch
 
 from bondable.bond.providers.bedrock import BedrockAgent as bedrock_agent_module
+
+# Tests asserting the shipped defaults are meaningless (and would fail
+# spuriously) when a developer has the env overrides exported.
+_env_override_active = bool(
+    os.environ.get('BEDROCK_MAX_TOOL_CALL_DEPTH')
+    or os.environ.get('BEDROCK_TOOL_DEPTH_WARN_MARGIN')
+)
+skip_if_env_override = pytest.mark.skipif(
+    _env_override_active,
+    reason="BEDROCK_MAX_TOOL_CALL_DEPTH / BEDROCK_TOOL_DEPTH_WARN_MARGIN set in env"
+)
 
 
 def _make_agent():
@@ -123,6 +135,7 @@ def _body_of(result):
 
 class TestDepthLimitConfig:
 
+    @skip_if_env_override
     def test_default_limit_is_25_and_margin_3(self):
         """Guard the chosen production defaults (CI has no env override)."""
         assert bedrock_agent_module.MAX_TOOL_CALL_DEPTH == 25
@@ -237,6 +250,7 @@ class TestWarnBandInjection:
             baseline[1]["apiResult"]["responseBody"]["application/json"]["body"]
         assert json.dumps(stripped, sort_keys=True) == json.dumps(baseline[1], sort_keys=True)
 
+    @skip_if_env_override
     def test_below_band_byte_identical_at_defaults(self):
         """Short flows (depth 0 at default 25/3) send tool results unmodified."""
         agent = _make_agent()
@@ -245,6 +259,73 @@ class TestWarnBandInjection:
         sent = _sent_results(mock_invoke)
         assert json.dumps(sent, sort_keys=True) == \
             json.dumps(_make_tool_results(), sort_keys=True)
+
+    def test_warn_band_with_real_return_control(self, monkeypatch):
+        """The notice survives the REAL _handle_return_control response shape.
+
+        The other warn-band tests use hand-built fixtures; if the real
+        _make_tool_response shape drifted, _inject_depth_warning's blanket
+        except would swallow the mismatch silently. This composes the real
+        pair, mocking only the external tool executor.
+        """
+        monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
+        monkeypatch.setattr(bedrock_agent_module, "TOOL_DEPTH_WARN_MARGIN", 2)
+        agent = _make_agent()
+        agent.agent_id = "test-agent-record-id"
+        agent.mcp_tools = []
+        agent.mcp_resources = []
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent = MagicMock(
+            side_effect=_chunk_stream
+        )
+
+        mcp_return_control = {
+            "invocationId": "inv-123",
+            "invocationInputs": [
+                {
+                    "apiInvocationInput": {
+                        "actionGroupName": "mcp-action-group",
+                        "apiPath": "/b.aaa000.jira_search",
+                        "httpMethod": "POST",
+                        "parameters": [{"name": "jql", "value": "project = TEST"}]
+                    }
+                }
+            ]
+        }
+        with patch("bondable.bond.providers.bedrock.BedrockAgent.Config") as mock_config, \
+             patch("bondable.bond.providers.bedrock.BedrockAgent.execute_mcp_tool_sync") as mock_execute, \
+             patch("bondable.bond.providers.bedrock.BedrockAgent._resolve_server_from_hash") as mock_resolve:
+            mock_config.config.return_value.get_mcp_config.return_value = {"mcpServers": {"atlassian": {}}}
+            mock_resolve.return_value = "atlassian"
+            mock_execute.return_value = {"success": True, "result": "tool output"}
+
+            list(agent._handle_continuation_response(
+                return_control=mcp_return_control,
+                session_id="test-session",
+                thread_id="test-thread",
+                seen_file_hashes=set(),
+                depth=3
+            ))
+
+        sent = _sent_results(agent.bond_provider.bedrock_agent_runtime_client.invoke_agent)
+        assert len(sent) == 1
+        body = _body_of(sent[-1])
+        assert "ask the user whether they would like" in body["system_notice"]
+        assert "tool output" in body["result"]
+
+    def test_malformed_last_result_degrades_to_no_notice(self, monkeypatch):
+        """A last result without responseBody must not break the continuation."""
+        monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
+        monkeypatch.setattr(bedrock_agent_module, "TOOL_DEPTH_WARN_MARGIN", 2)
+        agent = _make_agent()
+
+        malformed = [{"apiResult": {"actionGroup": "x", "apiPath": "/y", "httpStatusCode": 200}}]
+        items, _, mock_invoke = _run_continuation(
+            agent, depth=3, tool_results=copy.deepcopy(malformed))
+
+        # No exception; the continuation proceeded with the results unmodified
+        assert any("Done." in i for i in items if isinstance(i, str))
+        sent = _sent_results(mock_invoke)
+        assert json.dumps(sent, sort_keys=True) == json.dumps(malformed, sort_keys=True)
 
     def test_empty_results_fallback_gets_notice(self, monkeypatch):
         """The fallback error result built for empty tool_results carries the nudge."""

--- a/tests/test_bedrock_tool_depth.py
+++ b/tests/test_bedrock_tool_depth.py
@@ -1,0 +1,274 @@
+"""
+Unit tests for tool-call depth handling in BedrockAgent (CRM-22).
+
+Covers the env-configurable depth limit, the graceful resumable stop at the
+limit, and the near-limit warn-band nudge injected into the last tool result.
+
+NOTE on overriding the tunables: BEDROCK_MAX_TOOL_CALL_DEPTH and
+BEDROCK_TOOL_DEPTH_WARN_MARGIN are read from the environment once at module
+import, so monkeypatch.setenv after import is a no-op. Tests must override the
+module constants directly, e.g.:
+
+    monkeypatch.setattr(bedrock_agent_module, 'MAX_TOOL_CALL_DEPTH', 5)
+
+The guard and injection code read the module globals at call time, so this
+works and monkeypatch restores the values automatically. The env-var pathway
+itself is exercised by manual smoke testing, not unit tests.
+"""
+
+import copy
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+
+from bondable.bond.providers.bedrock import BedrockAgent as bedrock_agent_module
+
+
+def _make_agent():
+    """Create a minimal BedrockAgent instance with mocked dependencies."""
+    from bondable.bond.providers.bedrock.BedrockAgent import BedrockAgent
+
+    agent = object.__new__(BedrockAgent)
+    agent.bedrock_agent_id = "test-agent-id"
+    agent.bedrock_agent_alias_id = "test-alias-id"
+    agent.bond_provider = MagicMock()
+    agent._current_user = None
+    agent._jwt_token = None
+    return agent
+
+
+def _make_return_control(invocation_id="inv-123"):
+    """Create a minimal returnControl event."""
+    return {
+        "invocationId": invocation_id,
+        "invocationInputs": [
+            {
+                "apiInvocationInput": {
+                    "actionGroupName": "test-action-group",
+                    "apiPath": "/b.abc123.jira_search",
+                    "httpMethod": "POST",
+                    "parameters": [
+                        {"name": "jql", "value": "project = TEST"}
+                    ]
+                }
+            }
+        ]
+    }
+
+
+def _make_tool_results():
+    """Create tool results as _handle_return_control would return."""
+    return [
+        {
+            "apiResult": {
+                "actionGroup": "test-action-group",
+                "apiPath": "/b.abc123.jira_search",
+                "httpMethod": "POST",
+                "httpStatusCode": 200,
+                "responseBody": {
+                    "application/json": {
+                        "body": json.dumps({"result": "some data"})
+                    }
+                }
+            }
+        }
+    ]
+
+
+def _make_two_tool_results():
+    """Two real tool results, to verify the nudge only touches the last one."""
+    results = _make_tool_results()
+    second = copy.deepcopy(results[0])
+    second["apiResult"]["apiPath"] = "/b.abc123.jira_get"
+    second["apiResult"]["responseBody"]["application/json"]["body"] = json.dumps(
+        {"result": "other data"}
+    )
+    return results + [second]
+
+
+def _chunk_stream(**_kwargs):
+    """Fresh single-chunk completion stream per invoke_agent call."""
+    return {"completion": iter([{"chunk": {"bytes": b"Done."}}])}
+
+
+def _run_continuation(agent, depth, tool_results=None, session_id="test-session"):
+    """Run _handle_continuation_response with mocked tool exec + Bedrock stream."""
+    agent.bond_provider.bedrock_agent_runtime_client.invoke_agent = MagicMock(
+        side_effect=_chunk_stream
+    )
+    with patch.object(
+        agent, "_handle_return_control",
+        return_value=tool_results if tool_results is not None else _make_tool_results()
+    ) as mock_hrc:
+        items = list(agent._handle_continuation_response(
+            return_control=_make_return_control(),
+            session_id=session_id,
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=depth
+        ))
+    return items, mock_hrc, agent.bond_provider.bedrock_agent_runtime_client.invoke_agent
+
+
+def _sent_results(mock_invoke):
+    """Extract the returnControlInvocationResults sent to Bedrock."""
+    kwargs = mock_invoke.call_args.kwargs
+    return kwargs["sessionState"]["returnControlInvocationResults"]
+
+
+def _body_of(result):
+    inner = result.get("apiResult", result)
+    return json.loads(inner["responseBody"]["application/json"]["body"])
+
+
+class TestDepthLimitConfig:
+
+    def test_default_limit_is_25_and_margin_3(self):
+        """Guard the chosen production defaults (CI has no env override)."""
+        assert bedrock_agent_module.MAX_TOOL_CALL_DEPTH == 25
+        assert bedrock_agent_module.TOOL_DEPTH_WARN_MARGIN == 3
+
+    def test_limit_configurable_stops_at_5(self, monkeypatch):
+        monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
+        agent = _make_agent()
+
+        items, mock_hrc, mock_invoke = _run_continuation(agent, depth=5)
+
+        text = [i for i in items if isinstance(i, str)]
+        assert any("continue" in t.lower() for t in text)
+        mock_invoke.assert_not_called()
+        mock_hrc.assert_not_called()  # tools at the cap must not execute
+
+    def test_below_limit_proceeds(self, monkeypatch):
+        monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
+        agent = _make_agent()
+
+        items, mock_hrc, mock_invoke = _run_continuation(agent, depth=4)
+
+        assert mock_invoke.call_count == 1
+        mock_hrc.assert_called_once()
+        assert any("Done." in i for i in items if isinstance(i, str))
+
+
+class TestGracefulStop:
+
+    def test_graceful_stop_text(self):
+        agent = _make_agent()
+        items = list(agent._handle_continuation_response(
+            return_control=_make_return_control(),
+            session_id="test-session",
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=bedrock_agent_module.MAX_TOOL_CALL_DEPTH
+        ))
+
+        text = [i for i in items if isinstance(i, str)]
+        assert len(text) > 0
+        assert any("continue" in t.lower() for t in text)
+        assert not any("[Error:" in t for t in text)
+        assert not any("is_error" in t for t in text)
+
+    def test_resume_uses_same_session_at_depth_zero(self, monkeypatch):
+        """After a stop, a fresh depth-0 call continues on the same session."""
+        monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
+        agent = _make_agent()
+
+        _run_continuation(agent, depth=5)  # hits the cap, invoke_agent unused
+
+        # Fresh top-level call, as _process_bedrock_invocation would make it
+        items, _, mock_invoke = _run_continuation(agent, depth=0, session_id="test-session")
+
+        kwargs = mock_invoke.call_args.kwargs
+        assert kwargs["sessionId"] == "test-session"
+        assert "returnControlInvocationResults" in kwargs["sessionState"]
+
+
+class TestWarnBandInjection:
+
+    def test_warn_band_injection_fires_at_band(self, monkeypatch):
+        monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
+        monkeypatch.setattr(bedrock_agent_module, "TOOL_DEPTH_WARN_MARGIN", 2)
+        agent = _make_agent()
+
+        _, _, mock_invoke = _run_continuation(agent, depth=3)
+
+        sent = _sent_results(mock_invoke)
+        assert len(sent) == 1  # count-preserving: no synthetic entry
+        body = _body_of(sent[-1])
+        assert "ask the user whether they would like" in body["system_notice"]
+
+    @pytest.mark.parametrize("depth", [0, 1, 2, 4])
+    def test_warn_band_not_fired_outside_band(self, monkeypatch, depth):
+        monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
+        monkeypatch.setattr(bedrock_agent_module, "TOOL_DEPTH_WARN_MARGIN", 2)
+        agent = _make_agent()
+
+        _, _, mock_invoke = _run_continuation(agent, depth=depth)
+
+        for result in _sent_results(mock_invoke):
+            assert "system_notice" not in _body_of(result)
+
+    def test_warn_band_preserves_real_responses(self, monkeypatch):
+        """The nudge only adds a key to the last result; nothing dropped/reordered."""
+        monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
+        monkeypatch.setattr(bedrock_agent_module, "TOOL_DEPTH_WARN_MARGIN", 2)
+
+        agent = _make_agent()
+        _, _, mock_invoke = _run_continuation(
+            agent, depth=0, tool_results=_make_two_tool_results())
+        baseline = _sent_results(mock_invoke)
+
+        agent = _make_agent()
+        _, _, mock_invoke = _run_continuation(
+            agent, depth=3, tool_results=_make_two_tool_results())
+        warned = _sent_results(mock_invoke)
+
+        assert len(warned) == len(baseline) == 2
+        # First result untouched, byte-identical
+        assert json.dumps(warned[0], sort_keys=True) == json.dumps(baseline[0], sort_keys=True)
+        # Last result differs ONLY by the added system_notice key in its body
+        warned_body = _body_of(warned[1])
+        baseline_body = _body_of(baseline[1])
+        assert warned_body.pop("system_notice")
+        assert warned_body == baseline_body
+        # All non-body fields identical
+        stripped = copy.deepcopy(warned[1])
+        stripped["apiResult"]["responseBody"]["application/json"]["body"] = \
+            baseline[1]["apiResult"]["responseBody"]["application/json"]["body"]
+        assert json.dumps(stripped, sort_keys=True) == json.dumps(baseline[1], sort_keys=True)
+
+    def test_below_band_byte_identical_at_defaults(self):
+        """Short flows (depth 0 at default 25/3) send tool results unmodified."""
+        agent = _make_agent()
+        _, _, mock_invoke = _run_continuation(agent, depth=0)
+
+        sent = _sent_results(mock_invoke)
+        assert json.dumps(sent, sort_keys=True) == \
+            json.dumps(_make_tool_results(), sort_keys=True)
+
+    def test_empty_results_fallback_gets_notice(self, monkeypatch):
+        """The fallback error result built for empty tool_results carries the nudge."""
+        monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
+        monkeypatch.setattr(bedrock_agent_module, "TOOL_DEPTH_WARN_MARGIN", 2)
+        agent = _make_agent()
+
+        _, _, mock_invoke = _run_continuation(agent, depth=3, tool_results=[])
+
+        sent = _sent_results(mock_invoke)
+        assert len(sent) == 1
+        body = _body_of(sent[0])
+        assert "error" in body  # still the fallback error payload
+        assert "system_notice" in body
+
+    def test_margin_zero_disables_warning(self, monkeypatch):
+        monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
+        monkeypatch.setattr(bedrock_agent_module, "TOOL_DEPTH_WARN_MARGIN", 0)
+        agent = _make_agent()
+
+        _, _, mock_invoke = _run_continuation(agent, depth=4)
+        for result in _sent_results(mock_invoke):
+            assert "system_notice" not in _body_of(result)
+
+        items, _, mock_invoke = _run_continuation(agent, depth=5)
+        assert any("continue" in i.lower() for i in items if isinstance(i, str))
+        mock_invoke.assert_not_called()

--- a/tests/test_bedrock_tool_depth.py
+++ b/tests/test_bedrock_tool_depth.py
@@ -142,15 +142,23 @@ class TestDepthLimitConfig:
         assert bedrock_agent_module.TOOL_DEPTH_WARN_MARGIN == 3
 
     def test_limit_configurable_stops_at_5(self, monkeypatch):
+        """At the cap: tools are NOT executed, but the pending returnControl is
+        answered with synthetic pause results and the model's wrap-up streams."""
         monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
         agent = _make_agent()
 
         items, mock_hrc, mock_invoke = _run_continuation(agent, depth=5)
 
-        text = [i for i in items if isinstance(i, str)]
-        assert any("continue" in t.lower() for t in text)
-        mock_invoke.assert_not_called()
         mock_hrc.assert_not_called()  # tools at the cap must not execute
+        assert mock_invoke.call_count == 1  # single wrap-up invoke, no recursion
+        kwargs = mock_invoke.call_args.kwargs
+        assert kwargs["sessionState"]["invocationId"] == "inv-123"  # same pending invocation
+        sent = kwargs["sessionState"]["returnControlInvocationResults"]
+        assert len(sent) == 1  # one response per invocation input (INVARIANT)
+        body = _body_of(sent[0])
+        assert "paused" in body["error"]
+        # The model's own wrap-up text streams through
+        assert any("Done." in i for i in items if isinstance(i, str))
 
     def test_below_limit_proceeds(self, monkeypatch):
         monkeypatch.setattr(bedrock_agent_module, "MAX_TOOL_CALL_DEPTH", 5)
@@ -165,9 +173,12 @@ class TestDepthLimitConfig:
 
 class TestGracefulStop:
 
-    def test_graceful_stop_text(self):
-        agent = _make_agent()
-        items = list(agent._handle_continuation_response(
+    def _run_at_cap(self, agent, invoke_response):
+        """Run at the cap with a controlled wrap-up invoke response."""
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent = MagicMock(
+            side_effect=invoke_response
+        )
+        return list(agent._handle_continuation_response(
             return_control=_make_return_control(),
             session_id="test-session",
             thread_id="test-thread",
@@ -175,11 +186,50 @@ class TestGracefulStop:
             depth=bedrock_agent_module.MAX_TOOL_CALL_DEPTH
         ))
 
+    def test_model_wrapup_streams_no_canned_message(self):
+        """When the model produces its own wrap-up, the canned text is not appended."""
+        agent = _make_agent()
+        items = self._run_at_cap(agent, lambda **kw: {
+            "completion": iter([{"chunk": {"bytes": b"I finished steps 1-3. Want me to continue?"}}])
+        })
+
+        text = "".join(i for i in items if isinstance(i, str))
+        assert "Want me to continue?" in text
+        assert "pausing here" not in text  # canned fallback not appended
+        assert "[Error:" not in text
+
+    def test_empty_wrapup_stream_falls_back_to_canned(self):
+        agent = _make_agent()
+        items = self._run_at_cap(agent, lambda **kw: {"completion": iter([])})
+
         text = [i for i in items if isinstance(i, str)]
         assert len(text) > 0
         assert any("continue" in t.lower() for t in text)
         assert not any("[Error:" in t for t in text)
         assert not any("is_error" in t for t in text)
+
+    def test_model_requests_more_tools_gets_canned_stop(self):
+        """A returnControl in the wrap-up stream must not recurse."""
+        agent = _make_agent()
+        items = self._run_at_cap(agent, lambda **kw: {
+            "completion": iter([{"returnControl": _make_return_control("inv-nested")}])
+        })
+
+        assert agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.call_count == 1
+        text = "".join(i for i in items if isinstance(i, str))
+        assert "continue" in text.lower()
+
+    def test_wrapup_invoke_failure_falls_back_to_canned(self):
+        agent = _make_agent()
+
+        def boom(**kwargs):
+            raise RuntimeError("bedrock unavailable")
+
+        items = self._run_at_cap(agent, boom)
+
+        text = "".join(i for i in items if isinstance(i, str))
+        assert "continue" in text.lower()
+        assert "[Error:" not in text
 
     def test_resume_uses_same_session_at_depth_zero(self, monkeypatch):
         """After a stop, a fresh depth-0 call continues on the same session."""
@@ -350,6 +400,8 @@ class TestWarnBandInjection:
         for result in _sent_results(mock_invoke):
             assert "system_notice" not in _body_of(result)
 
-        items, _, mock_invoke = _run_continuation(agent, depth=5)
-        assert any("continue" in i.lower() for i in items if isinstance(i, str))
-        mock_invoke.assert_not_called()
+        items, mock_hrc, mock_invoke = _run_continuation(agent, depth=5)
+        mock_hrc.assert_not_called()  # cap still fires with margin 0
+        assert mock_invoke.call_count == 1  # wrap-up invoke only
+        body = _body_of(mock_invoke.call_args.kwargs["sessionState"]["returnControlInvocationResults"][0])
+        assert "paused" in body["error"]

--- a/tests/test_context_compaction.py
+++ b/tests/test_context_compaction.py
@@ -191,12 +191,15 @@ class TestCompactContext:
         agent = _make_agent()
         agent.bond_provider.threads.get_thread_session_id.return_value = 'old-session-id'
 
-        # Mock messages
+        # Mock messages (real .type values so the type filter is exercised -
+        # a MagicMock auto-attribute would never match a filter tuple)
         msg1 = MagicMock()
         msg1.role = 'user'
+        msg1.type = 'text'
         msg1.clob.get_content.return_value = 'Hello, can you help me?'
         msg2 = MagicMock()
         msg2.role = 'assistant'
+        msg2.type = 'text'
         msg2.clob.get_content.return_value = 'Of course! How can I assist you?'
         agent.bond_provider.threads.get_messages.return_value = OrderedDict([
             ('msg-1', msg1), ('msg-2', msg2)

--- a/tests/test_context_compaction.py
+++ b/tests/test_context_compaction.py
@@ -212,6 +212,29 @@ class TestCompactContext:
         }
         return agent
 
+    def test_skips_image_and_card_content(self):
+        """image_file base64 and resource_card JSON must not reach the summarizer."""
+        agent = self._setup_agent()
+        img = MagicMock()
+        img.role = 'assistant'
+        img.type = 'image_file'
+        img.clob.get_content.return_value = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg'
+        card = MagicMock()
+        card.role = 'assistant'
+        card.type = 'resource_card'
+        card.clob.get_content.return_value = '{"type": "proposal", "proposal_id": "p-1"}'
+        messages = agent.bond_provider.threads.get_messages.return_value
+        messages['msg-3'] = img
+        messages['msg-4'] = card
+        session_state = {'context_usage': {'estimated_tokens': 130_000, 'compaction_count': 0}}
+
+        agent._compact_context('thread-1', 'user-1', session_state)
+
+        converse_input = str(agent.bond_provider.bedrock_runtime_client.converse.call_args)
+        assert 'iVBORw0KGgo' not in converse_input
+        assert 'proposal_id' not in converse_input
+        assert 'Hello, can you help me?' in converse_input
+
     def test_calls_converse_api(self):
         """Verifies that Converse API is called for summary generation."""
         agent = self._setup_agent()

--- a/tests/test_continuation_error_handling.py
+++ b/tests/test_continuation_error_handling.py
@@ -755,7 +755,10 @@ class TestContinuationNestedReturnControl:
 
         text_results = [r for r in results if isinstance(r, str)]
         assert len(text_results) > 0
-        assert any("continue" in r.lower() for r in text_results)
+        # Pin the STOP message, not just "continue" - the Bedrock-only pause
+        # notice also contains "continue" and must never leak to the user.
+        assert any("pausing here" in r for r in text_results)
+        assert not any("Do not mention this notice" in r for r in text_results)
         assert not any("[Error:" in r for r in text_results)
         # The pending invocation was answered, not left dangling
         kwargs = agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.call_args.kwargs

--- a/tests/test_continuation_error_handling.py
+++ b/tests/test_continuation_error_handling.py
@@ -734,10 +734,15 @@ class TestContinuationNestedReturnControl:
             f"Expected 3 invoke_agent calls (depth=0 + depth=1 with retry), got: {call_count[0]}"
 
     def test_depth_limit_yields_graceful_stop(self):
-        """Reaching MAX_TOOL_CALL_DEPTH should yield a resumable message, not an error."""
+        """Reaching MAX_TOOL_CALL_DEPTH answers the pending returnControl with
+        pause results and yields a resumable message, not an error."""
         from bondable.bond.providers.bedrock import BedrockAgent as bedrock_agent_module
 
         agent = _make_agent()
+        # Wrap-up invoke returns an empty stream -> canned resumable fallback
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent = MagicMock(
+            side_effect=lambda **kwargs: {"completion": iter([])}
+        )
 
         return_control = _make_return_control()
         results = list(agent._handle_continuation_response(
@@ -752,3 +757,6 @@ class TestContinuationNestedReturnControl:
         assert len(text_results) > 0
         assert any("continue" in r.lower() for r in text_results)
         assert not any("[Error:" in r for r in text_results)
+        # The pending invocation was answered, not left dangling
+        kwargs = agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.call_args.kwargs
+        assert kwargs["sessionState"]["invocationId"] == "inv-123"

--- a/tests/test_continuation_error_handling.py
+++ b/tests/test_continuation_error_handling.py
@@ -733,8 +733,10 @@ class TestContinuationNestedReturnControl:
         assert call_count[0] == 3, \
             f"Expected 3 invoke_agent calls (depth=0 + depth=1 with retry), got: {call_count[0]}"
 
-    def test_depth_limit_exceeded_yields_error(self):
-        """Exceeding MAX_TOOL_CALL_DEPTH should yield error, not recurse infinitely."""
+    def test_depth_limit_yields_graceful_stop(self):
+        """Reaching MAX_TOOL_CALL_DEPTH should yield a resumable message, not an error."""
+        from bondable.bond.providers.bedrock import BedrockAgent as bedrock_agent_module
+
         agent = _make_agent()
 
         return_control = _make_return_control()
@@ -743,9 +745,10 @@ class TestContinuationNestedReturnControl:
             session_id="test-session",
             thread_id="test-thread",
             seen_file_hashes=set(),
-            depth=agent.MAX_TOOL_CALL_DEPTH  # At the limit
+            depth=bedrock_agent_module.MAX_TOOL_CALL_DEPTH  # At the limit
         ))
 
         text_results = [r for r in results if isinstance(r, str)]
         assert len(text_results) > 0
-        assert any("maximum tool call depth" in r.lower() for r in text_results)
+        assert any("continue" in r.lower() for r in text_results)
+        assert not any("[Error:" in r for r in text_results)

--- a/tests/test_cross_agent_context.py
+++ b/tests/test_cross_agent_context.py
@@ -208,7 +208,7 @@ class TestGetCrossAgentConversationHistory:
         assert truncated.endswith("...")
 
     def test_skips_system_error_file_messages(self, threads_provider):
-        """Should skip system, error, file_link, and image_file type messages."""
+        """Should skip system, error, file_link, image_file, and resource_card type messages."""
         messages = [
             make_message(0, "user", "text", [{"text": "Hello"}], agent_id="agent_A"),
             make_message(1, "assistant", "text", [{"text": "Hi"}], agent_id="agent_A"),
@@ -216,7 +216,8 @@ class TestGetCrossAgentConversationHistory:
             make_message(3, "assistant", "error", [{"text": "Error msg"}], agent_id="agent_A"),
             make_message(4, "assistant", "file_link", [{"text": "file.pdf"}], agent_id="agent_A"),
             make_message(5, "assistant", "image_file", [{"text": "data:image/png;base64,abc"}], agent_id="agent_A"),
-            make_message(6, "user", "text", [{"text": "Next question"}], agent_id="agent_B"),
+            make_message(6, "assistant", "resource_card", [{"text": '{"type": "proposal", "proposal_id": "p-1"}'}], agent_id="agent_A"),
+            make_message(7, "user", "text", [{"text": "Next question"}], agent_id="agent_B"),
         ]
         setup_mock_session(threads_provider, messages)
         result = threads_provider.get_cross_agent_conversation_history(

--- a/tests/test_mcp_card_passthrough.py
+++ b/tests/test_mcp_card_passthrough.py
@@ -11,10 +11,16 @@ Results without an envelope must behave byte-identically to today.
 import json
 import pytest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, Mock, patch
 from xml.sax.saxutils import escape as xml_escape
 
-from bondable.bond.providers.bedrock.BedrockMCP import _extract_bond_card
+from botocore.exceptions import EventStreamError
+
+from bondable.bond.providers.bedrock.BedrockMCP import (
+    _extract_bond_card,
+    _strip_bond_card_text,
+    execute_mcp_tool,
+)
 
 
 SAMPLE_CARD = {
@@ -102,6 +108,96 @@ class TestExtractBondCard:
 
     def test_no_structured_content_attr(self):
         assert _extract_bond_card(object(), "") is None
+
+
+class TestStripBondCardText:
+    """The envelope is stripped from the model-facing text; other keys survive."""
+
+    def test_strips_envelope_preserves_other_keys(self):
+        text = json.dumps({"proposal_id": "p-1", "status": "draft", "_bond_card": SAMPLE_CARD})
+        stripped = json.loads(_strip_bond_card_text(text))
+        assert "_bond_card" not in stripped
+        assert stripped == {"proposal_id": "p-1", "status": "draft"}
+
+    def test_non_json_text_unchanged(self):
+        assert _strip_bond_card_text("_bond_card mentioned in prose") == "_bond_card mentioned in prose"
+
+    def test_text_without_key_unchanged(self):
+        text = json.dumps({"proposal_id": "p-1"})
+        assert _strip_bond_card_text(text) == text
+        assert _strip_bond_card_text("") == ""
+
+
+MCP_CONFIG = {
+    "mcpServers": {
+        "crm": {
+            "url": "http://localhost:18004/mcp",
+            "transport": "streamable-http",
+        }
+    }
+}
+
+
+def _fake_call_tool_result(payload: dict, structured: bool):
+    """Fake fastmcp CallToolResult: text content always mirrors the payload;
+    structured_content carries it only when structured=True."""
+    result_obj = Mock()
+    result_obj.content = [Mock(text=json.dumps(payload))]
+    result_obj.structured_content = payload if structured else None
+    return result_obj
+
+
+async def _run_execute_mcp_tool(result_obj):
+    """Drive the real execute_mcp_tool with a fake fastmcp client."""
+    tool = Mock()
+    tool.name = "render_proposal"
+    tool.inputSchema = {}
+    with patch("bondable.bond.providers.bedrock.BedrockMCP.StreamableHttpTransport"), \
+         patch("bondable.bond.providers.bedrock.BedrockMCP.Client") as client_cls:
+        client = AsyncMock()
+        client.list_tools = AsyncMock(return_value=[tool])
+        client.call_tool = AsyncMock(return_value=result_obj)
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock(return_value=None)
+        client_cls.return_value = client
+        return await execute_mcp_tool(
+            MCP_CONFIG, "render_proposal", {"data_id": "d-1"}, target_server="crm"
+        )
+
+
+class TestExecuteMcpToolCardAttachment:
+    """The real execute_mcp_tool attaches the card and strips it from the text.
+
+    This is the only place the feature can silently die with every downstream
+    test green (they all mock execute_mcp_tool_sync), so it must be covered.
+    """
+
+    @pytest.mark.asyncio
+    async def test_structured_content_card_attached_and_text_stripped(self):
+        payload = {"proposal_id": "p-1", "status": "draft", "_bond_card": SAMPLE_CARD}
+        out = await _run_execute_mcp_tool(_fake_call_tool_result(payload, structured=True))
+
+        assert out["success"] is True
+        assert out["card"] == SAMPLE_CARD
+        result_json = json.loads(out["result"])
+        assert "_bond_card" not in result_json
+        assert result_json["proposal_id"] == "p-1"
+        assert result_json["status"] == "draft"
+
+    @pytest.mark.asyncio
+    async def test_text_fallback_card_attached(self):
+        payload = {"proposal_id": "p-1", "_bond_card": SAMPLE_CARD}
+        out = await _run_execute_mcp_tool(_fake_call_tool_result(payload, structured=False))
+
+        assert out["card"] == SAMPLE_CARD
+        assert "_bond_card" not in out["result"]
+
+    @pytest.mark.asyncio
+    async def test_no_envelope_no_card_key_text_untouched(self):
+        payload = {"proposal_id": "p-1", "status": "draft"}
+        out = await _run_execute_mcp_tool(_fake_call_tool_result(payload, structured=True))
+
+        assert out == {"success": True, "result": json.dumps(payload)}
 
 
 @patch("bondable.bond.providers.bedrock.BedrockAgent._resolve_server_from_hash")
@@ -262,6 +358,85 @@ class TestNestedCardForwarding:
         assert "done" in text
 
 
+@patch("bondable.bond.providers.bedrock.BedrockAgent._resolve_server_from_hash")
+@patch("bondable.bond.providers.bedrock.BedrockAgent.execute_mcp_tool_sync")
+@patch("bondable.bond.providers.bedrock.BedrockAgent.Config")
+class TestMultiCardRound:
+    """A round with parallel tool invocations can emit multiple cards."""
+
+    def test_two_cards_from_one_round(self, mock_config, mock_execute, mock_resolve):
+        mock_config.config.return_value.get_mcp_config.return_value = {"mcpServers": {"atlassian": {}}}
+        mock_resolve.return_value = "atlassian"
+        card_b = dict(SAMPLE_CARD, proposal_id="p-2", title="Second")
+        mock_execute.side_effect = [
+            {"success": True, "result": "{}", "card": SAMPLE_CARD},
+            {"success": True, "result": "{}", "card": card_b},
+        ]
+        agent = _make_agent()
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent = MagicMock(
+            side_effect=lambda **kwargs: {"completion": iter([{"chunk": {"bytes": b"Done."}}])}
+        )
+
+        return_control = _make_return_control_for_mcp()
+        second_input = json.loads(json.dumps(return_control["invocationInputs"][0]))
+        second_input["apiInvocationInput"]["apiPath"] = "/b.aaa000.jira_get"
+        return_control["invocationInputs"].append(second_input)
+
+        items = list(agent._handle_continuation_response(
+            return_control=return_control,
+            session_id="test-session",
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=0
+        ))
+
+        card_events = [i for i in items if isinstance(i, dict) and 'card_event' in i]
+        assert card_events == [{'card_event': SAMPLE_CARD}, {'card_event': card_b}]
+
+
+@patch("bondable.bond.providers.bedrock.BedrockAgent._resolve_server_from_hash")
+@patch("bondable.bond.providers.bedrock.BedrockAgent.execute_mcp_tool_sync")
+@patch("bondable.bond.providers.bedrock.BedrockAgent.Config")
+class TestCardNotDuplicatedByStreamRetry:
+    """Cards are emitted before the continuation invoke, so a stream retry
+    (EventStreamError on the first attempt) must not re-emit them."""
+
+    @patch("bondable.bond.providers.bedrock.BedrockAgent.time.sleep")
+    def test_stream_retry_emits_card_once(self, mock_sleep, mock_config, mock_execute, mock_resolve):
+        mock_config.config.return_value.get_mcp_config.return_value = {"mcpServers": {"atlassian": {}}}
+        mock_resolve.return_value = "atlassian"
+        mock_execute.return_value = {"success": True, "result": "{}", "card": SAMPLE_CARD}
+        agent = _make_agent()
+
+        failing_stream = MagicMock()
+        failing_stream.__iter__ = MagicMock(side_effect=EventStreamError(
+            {"Error": {"Code": "dependencyFailedException", "Message": "boom"}},
+            "InvokeAgent"
+        ))
+        invoke_calls = [0]
+
+        def mock_invoke_agent(**kwargs):
+            invoke_calls[0] += 1
+            if invoke_calls[0] == 1:
+                return {"completion": failing_stream}
+            return {"completion": iter([{"chunk": {"bytes": b"Done."}}])}
+
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.side_effect = mock_invoke_agent
+
+        items = list(agent._handle_continuation_response(
+            return_control=_make_return_control_for_mcp(),
+            session_id="test-session",
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=0
+        ))
+
+        assert invoke_calls[0] == 2  # retry happened
+        card_events = [i for i in items if isinstance(i, dict) and 'card_event' in i]
+        assert card_events == [{'card_event': SAMPLE_CARD}]
+        assert any("Done." in i for i in items if isinstance(i, str))
+
+
 class TestTopLevelCardWiring:
     """_process_bedrock_invocation routes card_event dicts to the card helper.
 
@@ -286,7 +461,10 @@ class TestTopLevelCardWiring:
             return_value={"completion": iter([{"returnControl": _make_return_control_for_mcp()}])}
         )
 
-        def fake_continuation(**kwargs):
+        # Keyword-only signature pinned to the call site in
+        # _process_bedrock_invocation: a renamed/removed kwarg there fails here.
+        def fake_continuation(*, return_control, session_id, thread_id,
+                              seen_file_hashes, attachments):
             yield {'card_event': SAMPLE_CARD}
             yield "after card"
 
@@ -314,6 +492,49 @@ class TestTopLevelCardWiring:
         ]
         assert len(card_calls) == 1
         assert card_calls[0].kwargs["content"] == json.dumps(SAMPLE_CARD)
+
+    def test_two_card_events_stream_two_cards(self):
+        """Consecutive cards chain response_id/full_content correctly."""
+        agent = self._make_full_agent()
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent = MagicMock(
+            return_value={"completion": iter([{"returnControl": _make_return_control_for_mcp()}])}
+        )
+        card_b = dict(SAMPLE_CARD, proposal_id="p-2", title="Second")
+
+        def fake_continuation(*, return_control, session_id, thread_id,
+                              seen_file_hashes, attachments):
+            yield {'card_event': SAMPLE_CARD}
+            yield "between cards"
+            yield {'card_event': card_b}
+
+        with patch.object(agent, "_handle_continuation_response", side_effect=fake_continuation):
+            stream = "".join(
+                item for item in agent._process_bedrock_invocation(
+                    prompt="Hello",
+                    thread_id="test-thread",
+                    session_id="test-session",
+                    session_state={},
+                    files=None,
+                    attachments=None,
+                    hidden=False,
+                    user_id="user-1",
+                )
+                if isinstance(item, str)
+            )
+
+        assert xml_escape(json.dumps(SAMPLE_CARD)) in stream
+        assert xml_escape(json.dumps(card_b)) in stream
+        card_calls = [
+            c for c in agent.bond_provider.threads.add_message.call_args_list
+            if c.kwargs.get("message_type") == "resource_card"
+        ]
+        assert [json.loads(c.kwargs["content"]) for c in card_calls] == [SAMPLE_CARD, card_b]
+        # The text between the cards was persisted under the post-first-card id
+        text_calls = [
+            c for c in agent.bond_provider.threads.add_message.call_args_list
+            if c.kwargs.get("message_type") == "text" and "between cards" in c.kwargs.get("content", "")
+        ]
+        assert len(text_calls) == 1
 
 
 class TestCardEventStreamingHelper:
@@ -360,7 +581,7 @@ class TestCardEventStreamingHelper:
             thread_id="test-thread",
             user_id="user-1",
             current_response_id="resp-1",
-            full_content="accumulated text"
+            full_content="A &amp; B"  # stream-escaped, as accumulated text is
         )
         _drain(gen)
 
@@ -369,5 +590,5 @@ class TestCardEventStreamingHelper:
         first_kwargs = calls[0].kwargs
         assert first_kwargs["message_type"] == "text"
         assert first_kwargs["message_id"] == "resp-1"
-        assert first_kwargs["content"] == "accumulated text"
+        assert first_kwargs["content"] == "A & B"  # persisted unescaped
         assert calls[1].kwargs["message_type"] == "resource_card"

--- a/tests/test_mcp_card_passthrough.py
+++ b/tests/test_mcp_card_passthrough.py
@@ -1,0 +1,319 @@
+"""
+Unit tests for the structured card passthrough from MCP tool results (CRM-33).
+
+An MCP tool can surface an in-chat card by including a "_bond_card" object in
+its result — primary transport is MCP structuredContent, fallback is a
+top-level key in the text JSON. bond-ai returns the text to the model exactly
+as before and additionally emits a client-facing resource_card <_bondmessage>.
+Results without an envelope must behave byte-identically to today.
+"""
+
+import json
+import pytest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+from xml.sax.saxutils import escape as xml_escape
+
+from bondable.bond.providers.bedrock.BedrockMCP import _extract_bond_card
+
+
+SAMPLE_CARD = {
+    "type": "proposal",
+    "proposal_id": "p-1",
+    "contact_id": "c-1",
+    "title": "Proposal",
+    "preview": "Hi & <b>there</b>",
+}
+
+
+def _make_agent():
+    """Create a minimal BedrockAgent instance with mocked dependencies."""
+    from bondable.bond.providers.bedrock.BedrockAgent import BedrockAgent
+
+    agent = object.__new__(BedrockAgent)
+    agent.bedrock_agent_id = "test-agent-id"
+    agent.bedrock_agent_alias_id = "test-alias-id"
+    agent.agent_id = "test-agent-record-id"
+    agent.model = "test-model"
+    agent.bond_provider = MagicMock()
+    agent._current_user = None
+    agent._jwt_token = None
+    agent.mcp_tools = []
+    agent.mcp_resources = []
+    return agent
+
+
+def _make_return_control_for_mcp(api_path="/b.aaa000.jira_search"):
+    """Create a returnControl event for an MCP tool invocation."""
+    return {
+        "invocationId": "inv-123",
+        "invocationInputs": [
+            {
+                "apiInvocationInput": {
+                    "actionGroupName": "mcp-action-group",
+                    "apiPath": api_path,
+                    "httpMethod": "POST",
+                    "parameters": [
+                        {"name": "jql", "value": "project = TEST"}
+                    ]
+                }
+            }
+        ]
+    }
+
+
+def _drain(gen):
+    """Exhaust a generator, returning (yielded_items, return_value)."""
+    items = []
+    while True:
+        try:
+            items.append(next(gen))
+        except StopIteration as stop:
+            return items, stop.value
+
+
+class TestExtractBondCard:
+    """Pure unit tests for the envelope extraction helper."""
+
+    def test_structured_content_top_level(self):
+        result = SimpleNamespace(structured_content={"_bond_card": SAMPLE_CARD, "proposal_id": "p-1"})
+        assert _extract_bond_card(result, "") == SAMPLE_CARD
+
+    def test_structured_content_wrapped_under_result(self):
+        result = SimpleNamespace(structured_content={"result": {"_bond_card": SAMPLE_CARD}})
+        assert _extract_bond_card(result, "") == SAMPLE_CARD
+
+    def test_text_json_fallback(self):
+        result = SimpleNamespace(structured_content=None)
+        text = json.dumps({"proposal_id": "p-1", "_bond_card": SAMPLE_CARD})
+        assert _extract_bond_card(result, text) == SAMPLE_CARD
+
+    def test_plain_text_returns_none(self):
+        result = SimpleNamespace(structured_content=None)
+        assert _extract_bond_card(result, "hello") is None
+
+    def test_json_without_key_returns_none(self):
+        result = SimpleNamespace(structured_content=None)
+        assert _extract_bond_card(result, json.dumps({"proposal_id": "p-1"})) is None
+
+    def test_non_dict_card_returns_none(self):
+        result = SimpleNamespace(structured_content={"_bond_card": "not-a-dict"})
+        assert _extract_bond_card(result, json.dumps({"_bond_card": "not-a-dict"})) is None
+
+    def test_no_structured_content_attr(self):
+        assert _extract_bond_card(object(), "") is None
+
+
+@patch("bondable.bond.providers.bedrock.BedrockAgent._resolve_server_from_hash")
+@patch("bondable.bond.providers.bedrock.BedrockAgent.execute_mcp_tool_sync")
+@patch("bondable.bond.providers.bedrock.BedrockAgent.Config")
+class TestReturnControlCardSideChannel:
+    """Cards ride the side channel, never the Bedrock tool results."""
+
+    def _setup(self, mock_config, mock_resolve):
+        mock_config.config.return_value.get_mcp_config.return_value = {"mcpServers": {"atlassian": {}}}
+        mock_resolve.return_value = "atlassian"
+
+    def test_card_captured_and_absent_from_bedrock_results(self, mock_config, mock_execute, mock_resolve):
+        self._setup(mock_config, mock_resolve)
+        mock_execute.return_value = {
+            "success": True,
+            "result": json.dumps({"proposal_id": "p-1"}),
+            "card": SAMPLE_CARD,
+        }
+        agent = _make_agent()
+
+        results = agent._handle_return_control(_make_return_control_for_mcp())
+
+        assert len(results) == 1
+        api_result = results[0]["apiResult"]
+        assert api_result["httpStatusCode"] == 200
+        # Text result still reaches the model
+        body = json.loads(api_result["responseBody"]["application/json"]["body"])
+        assert "p-1" in body["result"]
+        # The card never enters what is sent to Bedrock
+        assert "_bond_card" not in json.dumps(results)
+        assert "card" not in api_result
+        assert agent._pending_tool_cards == [SAMPLE_CARD]
+
+    def test_no_card_key_leaves_results_unchanged(self, mock_config, mock_execute, mock_resolve):
+        self._setup(mock_config, mock_resolve)
+        mock_execute.return_value = {
+            "success": True,
+            "result": json.dumps({"proposal_id": "p-1"}),
+        }
+        agent = _make_agent()
+
+        baseline = agent._handle_return_control(_make_return_control_for_mcp())
+        assert agent._pending_tool_cards == []
+
+        mock_execute.return_value = {
+            "success": True,
+            "result": json.dumps({"proposal_id": "p-1"}),
+            "card": SAMPLE_CARD,
+        }
+        with_card = agent._handle_return_control(_make_return_control_for_mcp())
+
+        # Bedrock-bound results are deep-equal with or without the envelope
+        assert json.dumps(with_card, sort_keys=True) == json.dumps(baseline, sort_keys=True)
+
+    def test_stale_cards_reset_between_invocations(self, mock_config, mock_execute, mock_resolve):
+        self._setup(mock_config, mock_resolve)
+        mock_execute.return_value = {"success": True, "result": "{}", "card": SAMPLE_CARD}
+        agent = _make_agent()
+        agent._handle_return_control(_make_return_control_for_mcp())
+        assert agent._pending_tool_cards == [SAMPLE_CARD]
+
+        mock_execute.return_value = {"success": True, "result": "{}"}
+        agent._handle_return_control(_make_return_control_for_mcp())
+        assert agent._pending_tool_cards == []
+
+
+@patch("bondable.bond.providers.bedrock.BedrockAgent._resolve_server_from_hash")
+@patch("bondable.bond.providers.bedrock.BedrockAgent.execute_mcp_tool_sync")
+@patch("bondable.bond.providers.bedrock.BedrockAgent.Config")
+class TestContinuationCardEmission:
+    """_handle_continuation_response yields card_event dicts for the client."""
+
+    def _setup(self, mock_config, mock_resolve):
+        mock_config.config.return_value.get_mcp_config.return_value = {"mcpServers": {"atlassian": {}}}
+        mock_resolve.return_value = "atlassian"
+
+    def _run(self, agent):
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent = MagicMock(
+            side_effect=lambda **kwargs: {"completion": iter([{"chunk": {"bytes": b"Done."}}])}
+        )
+        return list(agent._handle_continuation_response(
+            return_control=_make_return_control_for_mcp(),
+            session_id="test-session",
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=0
+        ))
+
+    def test_card_event_yielded_before_text(self, mock_config, mock_execute, mock_resolve):
+        self._setup(mock_config, mock_resolve)
+        mock_execute.return_value = {"success": True, "result": "{}", "card": SAMPLE_CARD}
+        agent = _make_agent()
+
+        items = self._run(agent)
+
+        card_events = [i for i in items if isinstance(i, dict) and 'card_event' in i]
+        assert card_events == [{'card_event': SAMPLE_CARD}]
+        card_idx = items.index(card_events[0])
+        text_idx = next(i for i, item in enumerate(items)
+                        if isinstance(item, str) and "Done." in item)
+        assert card_idx < text_idx  # card streams as soon as the tool ran
+
+    def test_no_envelope_yields_identical_sequence(self, mock_config, mock_execute, mock_resolve):
+        self._setup(mock_config, mock_resolve)
+        mock_execute.return_value = {"success": True, "result": "{}"}
+
+        baseline = self._run(_make_agent())
+        repeat = self._run(_make_agent())
+
+        assert baseline == repeat  # deterministic without an envelope
+        assert not any(isinstance(i, dict) and 'card_event' in i for i in baseline)
+
+
+@patch("bondable.bond.providers.bedrock.BedrockAgent._resolve_server_from_hash")
+@patch("bondable.bond.providers.bedrock.BedrockAgent.execute_mcp_tool_sync")
+@patch("bondable.bond.providers.bedrock.BedrockAgent.Config")
+class TestNestedCardForwarding:
+    """card_event dicts from nested tool rounds are forwarded to depth 0."""
+
+    def test_nested_card_reaches_depth_zero_output(self, mock_config, mock_execute, mock_resolve):
+        mock_config.config.return_value.get_mcp_config.return_value = {"mcpServers": {"atlassian": {}}}
+        mock_resolve.return_value = "atlassian"
+        # Outer tool round: no card. Nested round: carries the card.
+        mock_execute.side_effect = [
+            {"success": True, "result": "{}"},
+            {"success": True, "result": "{}", "card": SAMPLE_CARD},
+        ]
+        agent = _make_agent()
+
+        nested_return_control = _make_return_control_for_mcp("/b.aaa000.jira_get")
+        depth0_events = [
+            {"chunk": {"bytes": b"first "}},
+            {"returnControl": nested_return_control},
+        ]
+        invoke_calls = [0]
+
+        def mock_invoke_agent(**kwargs):
+            invoke_calls[0] += 1
+            if invoke_calls[0] == 1:
+                return {"completion": iter(depth0_events)}
+            return {"completion": iter([{"chunk": {"bytes": b"done"}}])}
+
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent.side_effect = mock_invoke_agent
+
+        items = list(agent._handle_continuation_response(
+            return_control=_make_return_control_for_mcp(),
+            session_id="test-session",
+            thread_id="test-thread",
+            seen_file_hashes=set(),
+            depth=0
+        ))
+
+        card_events = [i for i in items if isinstance(i, dict) and 'card_event' in i]
+        assert card_events == [{'card_event': SAMPLE_CARD}]
+        # Text from both rounds still streams
+        text = "".join(i for i in items if isinstance(i, str))
+        assert "done" in text
+
+
+class TestCardEventStreamingHelper:
+    """_handle_card_event_streaming persists and streams the card message."""
+
+    def test_yield_sequence_and_persistence(self):
+        agent = _make_agent()
+        agent.bond_provider.threads.add_message = MagicMock(return_value="card-msg-id")
+
+        gen = agent._handle_card_event_streaming(
+            card=SAMPLE_CARD,
+            thread_id="test-thread",
+            user_id="user-1",
+            current_response_id="resp-1",
+            full_content=""
+        )
+        items, new_response_id = _drain(gen)
+
+        card_json = json.dumps(SAMPLE_CARD)
+        assert items[0] == '</_bondmessage>'
+        assert 'type="resource_card"' in items[1]
+        assert 'id="card-msg-id"' in items[1]
+        assert 'is_error="false"' in items[1]
+        assert items[2] == xml_escape(card_json)
+        assert "&amp;" in items[2]  # preview ampersand escaped on the stream
+        assert items[3] == '</_bondmessage>'
+        assert 'type="text"' in items[4]
+
+        # Persisted unescaped, with the resource_card type
+        agent.bond_provider.threads.add_message.assert_called_once()
+        kwargs = agent.bond_provider.threads.add_message.call_args.kwargs
+        assert kwargs["message_type"] == "resource_card"
+        assert kwargs["content"] == card_json
+
+        assert new_response_id and new_response_id != "resp-1"
+        assert f'id="{new_response_id}"' in items[4]
+
+    def test_accumulated_text_persisted_first(self):
+        agent = _make_agent()
+        agent.bond_provider.threads.add_message = MagicMock(side_effect=["text-msg-id", "card-msg-id"])
+
+        gen = agent._handle_card_event_streaming(
+            card=SAMPLE_CARD,
+            thread_id="test-thread",
+            user_id="user-1",
+            current_response_id="resp-1",
+            full_content="accumulated text"
+        )
+        _drain(gen)
+
+        calls = agent.bond_provider.threads.add_message.call_args_list
+        assert len(calls) == 2
+        first_kwargs = calls[0].kwargs
+        assert first_kwargs["message_type"] == "text"
+        assert first_kwargs["message_id"] == "resp-1"
+        assert first_kwargs["content"] == "accumulated text"
+        assert calls[1].kwargs["message_type"] == "resource_card"

--- a/tests/test_mcp_card_passthrough.py
+++ b/tests/test_mcp_card_passthrough.py
@@ -262,6 +262,60 @@ class TestNestedCardForwarding:
         assert "done" in text
 
 
+class TestTopLevelCardWiring:
+    """_process_bedrock_invocation routes card_event dicts to the card helper.
+
+    Guards the elif ordering at the top-level continuation loop: if the generic
+    dict branch ever precedes the card_event branch, cards vanish silently.
+    """
+
+    def _make_full_agent(self):
+        """Agent with the attrs _process_bedrock_invocation touches (mirrors
+        tests/test_bedrock_connection_resilience.py)."""
+        agent = _make_agent()
+        agent.name = "Test Agent"
+        agent.introduction = "Hi"
+        agent.reminder = ""
+        agent.owner_user_id = "user-1"
+        agent.bond_provider.threads.add_message = MagicMock(return_value="card-msg-id")
+        return agent
+
+    def test_card_event_from_continuation_streams_resource_card(self):
+        agent = self._make_full_agent()
+        agent.bond_provider.bedrock_agent_runtime_client.invoke_agent = MagicMock(
+            return_value={"completion": iter([{"returnControl": _make_return_control_for_mcp()}])}
+        )
+
+        def fake_continuation(**kwargs):
+            yield {'card_event': SAMPLE_CARD}
+            yield "after card"
+
+        with patch.object(agent, "_handle_continuation_response", side_effect=fake_continuation):
+            stream = "".join(
+                item for item in agent._process_bedrock_invocation(
+                    prompt="Hello",
+                    thread_id="test-thread",
+                    session_id="test-session",
+                    session_state={},
+                    files=None,
+                    attachments=None,
+                    hidden=False,
+                    user_id="user-1",
+                )
+                if isinstance(item, str)
+            )
+
+        assert 'type="resource_card"' in stream
+        assert xml_escape(json.dumps(SAMPLE_CARD)) in stream
+        assert "after card" in stream
+        card_calls = [
+            c for c in agent.bond_provider.threads.add_message.call_args_list
+            if c.kwargs.get("message_type") == "resource_card"
+        ]
+        assert len(card_calls) == 1
+        assert card_calls[0].kwargs["content"] == json.dumps(SAMPLE_CARD)
+
+
 class TestCardEventStreamingHelper:
     """_handle_card_event_streaming persists and streams the card message."""
 


### PR DESCRIPTION
This pull request introduces significant enhancements to the Bedrock agent, focusing on tool-call recursion depth management, structured card streaming from MCP tool results, and improved handling of persisted content. The changes add configurable limits and user-facing notices for tool-call depth, enable the streaming and persistence of structured cards, and ensure that only meaningful content is stored. These updates improve system robustness, user experience, and future extensibility.

**Tool-call recursion depth management:**
- Added configurable environment variables (`BEDROCK_MAX_TOOL_CALL_DEPTH`, `BEDROCK_TOOL_DEPTH_WARN_MARGIN`) to control the maximum number of sequential tool calls per user turn and to warn when approaching this limit. User-facing and system notices are injected to guide the agent and inform users when the cap is reached. A new graceful wrap-up mechanism replaces hard errors, ensuring sessions are not left in a dangling state. [[1]](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bR83-R118) [[2]](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bL2197-R2463) [[3]](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bL2217-R2508)

**Structured card streaming and persistence (CRM-33):**
- Added support for capturing, persisting, and streaming structured "resource_card" messages from MCP tool results. Cards are surfaced to the client via a side channel and are excluded from Bedrock tool results and conversation summaries. [[1]](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bR1268-R1271) [[2]](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bR1454-R1458) [[3]](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bR1590-R1668) [[4]](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bR2009-R2021) [[5]](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bR2223-R2228)

**Content persistence improvements:**
- Modified logic to avoid persisting whitespace-only text messages, ensuring consistency between live and reloaded threads and preventing empty turns in the UI. [[1]](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bL1504-R1554) [[2]](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bL1937-R2083)

**Error and synthetic response handling:**
- Enhanced `_make_error_response` to allow non-error synthetic responses (e.g., depth-cap pause notices) to avoid the "error" framing, which improves model narration and user experience. [[1]](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bL1155-R1199) [[2]](diffhunk://#diff-4bf062b50aa5a197b9cecf4b1c337f0ba85b0eae21030115b8766e075d6fbf3bL1169-R1208)

**Conversation summary logic:**
- Updated conversation compaction to exclude non-summarizable message types such as images and resource cards, keeping summaries relevant and concise.